### PR TITLE
Redirect to root if a pathname is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,3 +32,7 @@ expressApp.use(function(err, req, res, next) {
 
 
 var commandRouter = new (require('./app/index.js'))(httpServer);
+
+expressApp.get('/?*', function (req, res) {
+        res.redirect('/');
+});


### PR DESCRIPTION
If the user hit reload/refresh while using volumio, he may get an error in the browser about the non-existent pathname. With this he will be redirected to Volumio main page.

This entry is cosmetic and can be removed at any time if it impacts functionality.