### PR TITLE
Alsa Output Control From the UI

### DIFF
--- a/app/plugins/audio_interfaces/alsa_controller/index.js
+++ b/app/plugins/audio_interfaces/alsa_controller/index.js
@@ -1,30 +1,22 @@
 var io = require('socket.io-client');
-var libQ = require('kew');
-var exec = require('child_process').exec;
 var fs = require('fs-extra');
-var S = require('string');
 
 // Define the ControllerMpd class
 module.exports = ControllerAlsa;
 function ControllerAlsa(context) {
-	// This fixed variable will let us refer to 'this' object at deeper scopes
-	var self = this;
-	self.context = context;
-	self.commandRouter = self.context.coreCommand;
-	self.logger = self.context.logger;
-
+	this.context = context;
+	this.commandRouter = this.context.coreCommand;
+	this.logger = this.context.logger;
 }
 
 ControllerAlsa.prototype.onVolumioStart = function () {
-	var self = this;
 
-	var configFile = self.commandRouter.pluginManager.getConfigurationFile(self.context, 'config.json');
+	var configFile = this.commandRouter.pluginManager.getConfigurationFile(this.context, 'config.json');
 
-	self.config = new (require('v-conf'))();
-	self.config.loadFile(configFile);
+	this.config = new (require('v-conf'))();
+	this.config.loadFile(configFile);
 
-
-	var volume = self.config.get('volumestart');
+	var volume = this.config.get('volumestart');
 
 	var socketURL = 'http://localhost:3000';
 	var options = {
@@ -34,50 +26,42 @@ ControllerAlsa.prototype.onVolumioStart = function () {
 
 	var client1 = io.connect(socketURL, options);
 
+	var self = this;
 	client1.on('connect', function (data) {
 		self.logger.info("Setting volume on startup at " + volume);
 		client1.emit('volume', volume);
 	});
 
-	if (self.config.has('outputdevice') == false)
-		self.config.addConfigValue('outputdevice', 'string', '0');
+	if (this.config.has('outputdevice') == false)
+		this.config.addConfigValue('outputdevice', 'string', '0');
 
-	self.logger.debug("Creating shared var alsa.outputdevice");
-	self.commandRouter.sharedVars.addConfigValue('alsa.outputdevice', 'string', self.config.get('outputdevice'));
-	self.commandRouter.sharedVars.registerCallback('alsa.outputdevice', self.outputDeviceCallback.bind(self));
+	this.logger.debug("Creating shared var alsa.outputdevice");
+	this.commandRouter.sharedVars.addConfigValue('alsa.outputdevice', 'string', this.config.get('outputdevice'));
+	this.commandRouter.sharedVars.registerCallback('alsa.outputdevice', this.outputDeviceCallback.bind(this));
 };
 
 ControllerAlsa.prototype.outputDeviceCallback = function (value) {
-	var self = this;
-
-	self.config.set('outputdevice', value);
+	this.config.set('outputdevice', value);
 };
 
 ControllerAlsa.prototype.getConfigParam = function (key) {
-	var self = this;
-
-	return self.config.get(key);
+	return this.config.get(key);
 };
 
 ControllerAlsa.prototype.setConfigParam = function (data) {
-	var self = this;
-
-	self.config.set(data.key, data.value);
+	this.config.set(data.key, data.value);
 };
 
 
 ControllerAlsa.prototype.getConfigurationFiles = function () {
-	var self = this;
-
 	return ['config.json'];
 };
 
 ControllerAlsa.prototype.getAlsaCards = function () {
-	var self = this;
 	var cards = [];
 
 	var soundCardDir = '/proc/asound/';
-	var infoFile = '/pcm0p/info';
+	var idFile = '/id';
 	var regex = /card(\d+)/;
 
 	var soundFiles = fs.readdirSync(soundCardDir);
@@ -85,19 +69,12 @@ ControllerAlsa.prototype.getAlsaCards = function () {
 	for (var i = 0; i < soundFiles.length; i++) {
 		var fileName = soundFiles[i];
 		var matches = regex.exec(fileName);
-		var infoFileName = soundCardDir + fileName + infoFile;
-		if (matches && fs.existsSync(infoFileName)) {
-			var index = matches[1];
-			var content = fs.readFileSync(infoFileName);
-
-			var splitted = content.toString().split('\n');
-			for (var j = 0; j < splitted.length; j++) {
-				var line = S(splitted[j]);
-				if (line.startsWith('id:')) {
-					cards.push({id: index, name: line.chompLeft('id:').trim().s});
-					break;
-				}
-			}
+		var idFileName = soundCardDir + fileName + idFile;
+		if (matches && fs.existsSync(idFileName)) {
+			var id = matches[1];
+			var content = fs.readFileSync(idFileName);
+			var name = content.toString().trim();
+			cards.push({id: id, name: name});
 		}
 	}
 

--- a/app/plugins/audio_interfaces/alsa_controller/index.js
+++ b/app/plugins/audio_interfaces/alsa_controller/index.js
@@ -7,99 +7,99 @@ var S = require('string');
 // Define the ControllerMpd class
 module.exports = ControllerAlsa;
 function ControllerAlsa(context) {
-    // This fixed variable will let us refer to 'this' object at deeper scopes
-    var self = this;
-    self.context = context;
-    self.commandRouter = self.context.coreCommand;
-    self.logger = self.context.logger;
+	// This fixed variable will let us refer to 'this' object at deeper scopes
+	var self = this;
+	self.context = context;
+	self.commandRouter = self.context.coreCommand;
+	self.logger = self.context.logger;
 
 }
 
 ControllerAlsa.prototype.onVolumioStart = function () {
-    var self = this;
+	var self = this;
 
-    var configFile = self.commandRouter.pluginManager.getConfigurationFile(self.context, 'config.json');
+	var configFile = self.commandRouter.pluginManager.getConfigurationFile(self.context, 'config.json');
 
-    self.config = new (require('v-conf'))();
-    self.config.loadFile(configFile);
+	self.config = new (require('v-conf'))();
+	self.config.loadFile(configFile);
 
 
-    var volume = self.config.get('volumestart');
+	var volume = self.config.get('volumestart');
 
-    var socketURL = 'http://localhost:3000';
-    var options = {
-        transports: ['websocket'],
-        'force new connection': true
-    };
+	var socketURL = 'http://localhost:3000';
+	var options = {
+		transports: ['websocket'],
+		'force new connection': true
+	};
 
-    var client1 = io.connect(socketURL, options);
+	var client1 = io.connect(socketURL, options);
 
-    client1.on('connect', function (data) {
-        self.logger.info("Setting volume on startup at " + volume);
-        client1.emit('volume', volume);
-    });
+	client1.on('connect', function (data) {
+		self.logger.info("Setting volume on startup at " + volume);
+		client1.emit('volume', volume);
+	});
 
-    if (self.config.has('outputdevice') == false)
-        self.config.addConfigValue('outputdevice', 'string', '0');
+	if (self.config.has('outputdevice') == false)
+		self.config.addConfigValue('outputdevice', 'string', '0');
 
-    self.logger.debug("Creating shared var alsa.outputdevice");
-    self.commandRouter.sharedVars.addConfigValue('alsa.outputdevice', 'string', self.config.get('outputdevice'));
-    self.commandRouter.sharedVars.registerCallback('alsa.outputdevice', self.outputDeviceCallback.bind(self));
+	self.logger.debug("Creating shared var alsa.outputdevice");
+	self.commandRouter.sharedVars.addConfigValue('alsa.outputdevice', 'string', self.config.get('outputdevice'));
+	self.commandRouter.sharedVars.registerCallback('alsa.outputdevice', self.outputDeviceCallback.bind(self));
 };
 
 ControllerAlsa.prototype.outputDeviceCallback = function (value) {
-    var self = this;
+	var self = this;
 
-    self.config.set('outputdevice', value);
+	self.config.set('outputdevice', value);
 };
 
 ControllerAlsa.prototype.getConfigParam = function (key) {
-    var self = this;
+	var self = this;
 
-    return self.config.get(key);
+	return self.config.get(key);
 };
 
 ControllerAlsa.prototype.setConfigParam = function (data) {
-    var self = this;
+	var self = this;
 
-    self.config.set(data.key, data.value);
+	self.config.set(data.key, data.value);
 };
 
 
 ControllerAlsa.prototype.getConfigurationFiles = function () {
-    var self = this;
+	var self = this;
 
-    return ['config.json'];
+	return ['config.json'];
 };
 
 ControllerAlsa.prototype.getAlsaCards = function () {
-    var self = this;
-    var cards = [];
+	var self = this;
+	var cards = [];
 
-    var soundCardDir = '/proc/asound/';
-    var infoFile = '/pcm0p/info';
-    var regex = /card(\d+)/;
+	var soundCardDir = '/proc/asound/';
+	var infoFile = '/pcm0p/info';
+	var regex = /card(\d+)/;
 
-    var soundFiles = fs.readdirSync(soundCardDir);
+	var soundFiles = fs.readdirSync(soundCardDir);
 
-    for (var i = 0; i < soundFiles.length; i++) {
-        var fileName = soundFiles[i];
-        var matches = regex.exec(fileName);
-        var infoFileName = soundCardDir + fileName + infoFile;
-        if (matches && fs.existsSync(infoFileName)) {
-            var index = matches[1];
-            var content = fs.readFileSync(infoFileName);
+	for (var i = 0; i < soundFiles.length; i++) {
+		var fileName = soundFiles[i];
+		var matches = regex.exec(fileName);
+		var infoFileName = soundCardDir + fileName + infoFile;
+		if (matches && fs.existsSync(infoFileName)) {
+			var index = matches[1];
+			var content = fs.readFileSync(infoFileName);
 
-            var splitted = content.toString().split('\n');
-            for (var j = 0; j < splitted.length; j++) {
-                var line = S(splitted[j]);
-                if (line.startsWith('id:')) {
-                    cards.push({id: index, name: line.chompLeft('id:').trim().s});
-                    break;
-                }
-            }
-        }
-    }
+			var splitted = content.toString().split('\n');
+			for (var j = 0; j < splitted.length; j++) {
+				var line = S(splitted[j]);
+				if (line.startsWith('id:')) {
+					cards.push({id: index, name: line.chompLeft('id:').trim().s});
+					break;
+				}
+			}
+		}
+	}
 
-    return cards;
+	return cards;
 };

--- a/app/plugins/audio_interfaces/alsa_controller/index.js
+++ b/app/plugins/audio_interfaces/alsa_controller/index.js
@@ -1,105 +1,105 @@
-var io 	= require('socket.io-client');
+var io = require('socket.io-client');
 var libQ = require('kew');
 var exec = require('child_process').exec;
 var fs = require('fs-extra');
-var S=require('string');
+var S = require('string');
 
 // Define the ControllerMpd class
 module.exports = ControllerAlsa;
 function ControllerAlsa(context) {
-	// This fixed variable will let us refer to 'this' object at deeper scopes
-	var self = this;
-	self.context=context;
-	self.commandRouter = self.context.coreCommand;
-	self.logger=self.context.logger;
+    // This fixed variable will let us refer to 'this' object at deeper scopes
+    var self = this;
+    self.context = context;
+    self.commandRouter = self.context.coreCommand;
+    self.logger = self.context.logger;
 
 }
 
-ControllerAlsa.prototype.onVolumioStart = function() {
-	var self=this;
+ControllerAlsa.prototype.onVolumioStart = function () {
+    var self = this;
 
-	var configFile=self.commandRouter.pluginManager.getConfigurationFile(self.context,'config.json');
+    var configFile = self.commandRouter.pluginManager.getConfigurationFile(self.context, 'config.json');
 
-	self.config= new (require('v-conf'))();
-	self.config.loadFile(configFile);
-
-
-	var volume=self.config.get('volumestart');
-
-	var socketURL = 'http://localhost:3000';
-	var options = {
-		transports: ['websocket'],
-		'force new connection': true
-	};
-
-	var client1 = io.connect(socketURL, options);
-
-	client1.on('connect', function(data){
-		self.logger.info("Setting volume on startup at "+volume);
-		client1.emit('volume', volume);
-	});
-
-	if(self.config.has('outputdevice')==false)
-		self.config.addConfigValue('outputdevice','string','0');
-
-	self.logger.debug("Creating shared var alsa.outputdevice");
-	self.commandRouter.sharedVars.addConfigValue('alsa.outputdevice','string',self.config.get('outputdevice'));
-	self.commandRouter.sharedVars.registerCallback('alsa.outputdevice',self.outputDeviceCallback.bind(self));
-}
-
-ControllerAlsa.prototype.outputDeviceCallback = function(value) {
-	var self=this;
-
-	self.config.set('outputdevice',value);
-}
-
-ControllerAlsa.prototype.getConfigParam = function(key) {
-	var self=this;
-
-	return self.config.get(key);
-}
-
-ControllerAlsa.prototype.setConfigParam = function(data) {
-	var self=this;
-
-	self.config.set(data.key,data.value);
-}
+    self.config = new (require('v-conf'))();
+    self.config.loadFile(configFile);
 
 
-ControllerAlsa.prototype.getConfigurationFiles = function()
-{
-	var self = this;
+    var volume = self.config.get('volumestart');
 
-	return ['config.json'];
-}
+    var socketURL = 'http://localhost:3000';
+    var options = {
+        transports: ['websocket'],
+        'force new connection': true
+    };
 
-ControllerAlsa.prototype.getAlsaCards = function()
-{
-	var self = this;
-	var cards=[];
-	var index=0;
+    var client1 = io.connect(socketURL, options);
 
-	while(fs.existsSync('/proc/asound/card'+index+'/pcm0p/info'))
-	{
-		var content=fs.readFileSync('/proc/asound/card'+index+'/pcm0p/info');
+    client1.on('connect', function (data) {
+        self.logger.info("Setting volume on startup at " + volume);
+        client1.emit('volume', volume);
+    });
 
-		var splitted=content.toString().split('\n');
-		for(var i in splitted)
-		{
-			var line=S(splitted[i]);
-			if(line.startsWith('id:'))
-			{
-				cards.push({id:index, name:line.chompLeft('id:').trim().s});
-				break;
-			}
+    if (self.config.has('outputdevice') == false)
+        self.config.addConfigValue('outputdevice', 'string', '0');
 
-		}
+    self.logger.debug("Creating shared var alsa.outputdevice");
+    self.commandRouter.sharedVars.addConfigValue('alsa.outputdevice', 'string', self.config.get('outputdevice'));
+    self.commandRouter.sharedVars.registerCallback('alsa.outputdevice', self.outputDeviceCallback.bind(self));
+};
 
-		index++;
+ControllerAlsa.prototype.outputDeviceCallback = function (value) {
+    var self = this;
 
-	}
+    self.config.set('outputdevice', value);
+};
 
-	return cards;
+ControllerAlsa.prototype.getConfigParam = function (key) {
+    var self = this;
+
+    return self.config.get(key);
+};
+
+ControllerAlsa.prototype.setConfigParam = function (data) {
+    var self = this;
+
+    self.config.set(data.key, data.value);
+};
 
 
-}
+ControllerAlsa.prototype.getConfigurationFiles = function () {
+    var self = this;
+
+    return ['config.json'];
+};
+
+ControllerAlsa.prototype.getAlsaCards = function () {
+    var self = this;
+    var cards = [];
+
+    var soundCardDir = '/proc/asound/';
+    var infoFile = '/pcm0p/info';
+    var regex = /card(\d+)/;
+
+    var soundFiles = fs.readdirSync(soundCardDir);
+
+    for (var i = 0; i < soundFiles.length; i++) {
+        var fileName = soundFiles[i];
+        var matches = regex.exec(fileName);
+        var infoFileName = soundCardDir + fileName + infoFile;
+        if (matches && fs.existsSync(infoFileName)) {
+            var index = matches[1];
+            var content = fs.readFileSync(infoFileName);
+
+            var splitted = content.toString().split('\n');
+            for (var j = 0; j < splitted.length; j++) {
+                var line = S(splitted[j]);
+                if (line.startsWith('id:')) {
+                    cards.push({id: index, name: line.chompLeft('id:').trim().s});
+                    break;
+                }
+            }
+        }
+    }
+
+    return cards;
+};

--- a/app/plugins/music_services/mpd/index.js
+++ b/app/plugins/music_services/mpd/index.js
@@ -5,13 +5,13 @@ var libUtil = require('util');
 var libFsExtra = require('fs-extra');
 var libChokidar = require('chokidar');
 var exec = require('child_process').exec;
-var s=require('string');
+var s = require('string');
 var ifconfig = require('wireless-tools/ifconfig');
 var ip = require('ip');
-var nodetools=require('nodetools');
+var nodetools = require('nodetools');
 var convert = require('convert-seconds');
 var pidof = require('pidof');
-var S=require('string');
+var S = require('string');
 var parser = require('cue-parser');
 
 // Define the ControllerMpd class
@@ -19,55 +19,55 @@ module.exports = ControllerMpd;
 function ControllerMpd(context) {
 	// This fixed variable will let us refer to 'this' object at deeper scopes
 	var self = this;
-	self.context=context;
+	self.context = context;
 	self.commandRouter = self.context.coreCommand;
-	self.logger=self.context.logger;
+	self.logger = self.context.logger;
 }
 
 // Public Methods ---------------------------------------------------------------------------------------
 // These are 'this' aware, and return a promise
 
 // Define a method to clear, add, and play an array of tracks
-ControllerMpd.prototype.clearAddPlayTracks = function(arrayTrackUris) {
+ControllerMpd.prototype.clearAddPlayTracks = function (arrayTrackUris) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::clearAddPlayTracks');
 
 	// Clear the queue, add the first track, and start playback
 	return self.sendMpdCommandArray([
-		{command: 'clear', parameters: []},
-		{command: 'add', parameters: [arrayTrackUris.shift()]},
-		{command: 'play', parameters: []}
-	])
-	.then(function() {
-		// If there are more tracks in the array, add those also
-		if (arrayTrackUris.length > 0) {
-			return self.sendMpdCommandArray(
-				libFast.map(arrayTrackUris, function(currentTrack) {
-					return {command: 'add',		parameters: [currentTrack]};
-				})
-			);
-		} else {
-			return libQ.resolve();
-		}
-	});
+			{command: 'clear', parameters: []},
+			{command: 'add', parameters: [arrayTrackUris.shift()]},
+			{command: 'play', parameters: []}
+		])
+		.then(function () {
+			// If there are more tracks in the array, add those also
+			if (arrayTrackUris.length > 0) {
+				return self.sendMpdCommandArray(
+					libFast.map(arrayTrackUris, function (currentTrack) {
+						return {command: 'add', parameters: [currentTrack]};
+					})
+				);
+			} else {
+				return libQ.resolve();
+			}
+		});
 };
 //MPD Play
-ControllerMpd.prototype.play = function(N) {
+ControllerMpd.prototype.play = function (N) {
 	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::play ' +N);
+	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::play ' + N);
 
 	return self.sendMpdCommand('play', [N]);
 };
 
 //MPD Add
-ControllerMpd.prototype.add = function(data) {
+ControllerMpd.prototype.add = function (data) {
 	var self = this;
-	self.commandRouter.pushToastMessage('Success','',str + ' Added');
+	self.commandRouter.pushToastMessage('Success', '', str + ' Added');
 
 	return self.sendMpdCommand('add', [data]);
 };
 //MPD Remove
-ControllerMpd.prototype.remove = function(position) {
+ControllerMpd.prototype.remove = function (position) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::remove ' + position);
 
@@ -75,7 +75,7 @@ ControllerMpd.prototype.remove = function(position) {
 };
 
 // MPD stop
-ControllerMpd.prototype.stop = function() {
+ControllerMpd.prototype.stop = function () {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::stop');
 
@@ -83,7 +83,7 @@ ControllerMpd.prototype.stop = function() {
 };
 
 // MPD pause
-ControllerMpd.prototype.pause = function() {
+ControllerMpd.prototype.pause = function () {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::pause');
 
@@ -91,7 +91,7 @@ ControllerMpd.prototype.pause = function() {
 };
 
 //MPD Next
-ControllerMpd.prototype.next = function() {
+ControllerMpd.prototype.next = function () {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::next');
 
@@ -99,7 +99,7 @@ ControllerMpd.prototype.next = function() {
 };
 
 //MPD Previous
-ControllerMpd.prototype.previous = function() {
+ControllerMpd.prototype.previous = function () {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::previous');
 
@@ -107,43 +107,41 @@ ControllerMpd.prototype.previous = function() {
 };
 
 //MPD Seek
-ControllerMpd.prototype.seek = function(timepos) {
+ControllerMpd.prototype.seek = function (timepos) {
 	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::seek to ' +timepos);
+	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::seek to ' + timepos);
 
 	return self.sendMpdCommand('seekcur', [timepos]);
 };
 
 //MPD Random
-ControllerMpd.prototype.random = function(randomcmd) {
+ControllerMpd.prototype.random = function (randomcmd) {
 	var self = this;
 	var string = randomcmd ? 1 : 0;
 	if (string === 1) {
-		self.commandRouter.pushToastMessage('success',"Random", 'ON');
+		self.commandRouter.pushToastMessage('success', "Random", 'ON');
 	} else if (string === 0) {
-		self.commandRouter.pushToastMessage('success',"Random", 'OFF');
+		self.commandRouter.pushToastMessage('success', "Random", 'OFF');
 	}
-
-
 
 	return self.sendMpdCommand('random', [string])
 };
 
 //MPD Repeat
-ControllerMpd.prototype.repeat = function(repeatcmd) {
+ControllerMpd.prototype.repeat = function (repeatcmd) {
 	var self = this;
 	var string = repeatcmd ? 1 : 0;
 	if (string === 1) {
-		self.commandRouter.pushToastMessage('success',"Repeat", 'ON');
+		self.commandRouter.pushToastMessage('success', "Repeat", 'ON');
 	} else if (string === 0) {
-		self.commandRouter.pushToastMessage('success',"Repeat", 'OFF');
+		self.commandRouter.pushToastMessage('success', "Repeat", 'OFF');
 	}
 	return self.sendMpdCommand('repeat', [string]);
 };
 
 
 // MPD resume
-ControllerMpd.prototype.resume = function() {
+ControllerMpd.prototype.resume = function () {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::resume');
 
@@ -151,7 +149,7 @@ ControllerMpd.prototype.resume = function() {
 };
 
 // MPD clear
-ControllerMpd.prototype.clear = function() {
+ControllerMpd.prototype.clear = function () {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::clear');
 
@@ -159,23 +157,23 @@ ControllerMpd.prototype.clear = function() {
 };
 
 // MPD enable output
-ControllerMpd.prototype.enableOutput = function(output) {
+ControllerMpd.prototype.enableOutput = function (output) {
 	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Enable Output ' +output);
+	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Enable Output ' + output);
 
 	return self.sendMpdCommand('enableoutput', [output]);
 };
 
 // MPD disable output
-ControllerMpd.prototype.disableOutput = function(output) {
+ControllerMpd.prototype.disableOutput = function (output) {
 	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Disable Output ' +output);
+	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Disable Output ' + output);
 
 	return self.sendMpdCommand('disableoutput', [output]);
 };
 
 //UpdateDB
-ControllerMpd.prototype.updateMpdDB = function() {
+ControllerMpd.prototype.updateMpdDB = function () {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Update mpd DB');
 
@@ -183,60 +181,59 @@ ControllerMpd.prototype.updateMpdDB = function() {
 };
 
 
-ControllerMpd.prototype.addPlay = function(data) {
+ControllerMpd.prototype.addPlay = function (data) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::addPlay');
-	self.commandRouter.pushToastMessage('Success','',str + ' Added');
-	var fileName=S(data);
+	self.commandRouter.pushToastMessage('Success', '', str + ' Added');
+	var fileName = S(data);
 
 	//Add playlists and cue with load command
-if (fileName.endsWith('.cue') || fileName.endsWith('.pls') || fileName.endsWith('.m3u')) {
-	self.logger.info('Adding Playlist: '+data)
-	return self.sendMpdCommandArray([
-		{command: 'clear', parameters: []},
-		{command: 'load', parameters: [data]},
-		{command: 'play', parameters: []}
-	])
-} else {
-	return self.sendMpdCommandArray([
-		{command: 'clear', parameters: []},
-		{command: 'add', parameters: [data]},
-		{command: 'play', parameters: []}
-	])
-}
+	if (fileName.endsWith('.cue') || fileName.endsWith('.pls') || fileName.endsWith('.m3u')) {
+		self.logger.info('Adding Playlist: ' + data)
+		return self.sendMpdCommandArray([
+			{command: 'clear', parameters: []},
+			{command: 'load', parameters: [data]},
+			{command: 'play', parameters: []}
+		])
+	} else {
+		return self.sendMpdCommandArray([
+			{command: 'clear', parameters: []},
+			{command: 'add', parameters: [data]},
+			{command: 'play', parameters: []}
+		])
+	}
 	/*.then(function() {
-		self.commandRouter.volumioPlay();
+	 self.commandRouter.volumioPlay();
 
-	});*/
+	 });*/
 };
 
-ControllerMpd.prototype.addPlayCue = function(data) {
+ControllerMpd.prototype.addPlayCue = function (data) {
 	var self = this;
-	self.commandRouter.pushToastMessage('Success','',str + ' Added');
-	var fileName=S(data.uri);
+	self.commandRouter.pushToastMessage('Success', '', str + ' Added');
+	var fileName = S(data.uri);
 
 	//Add playlists and cue with load command
-	self.logger.info('Adding CUE individual entry: '+data.number+' '+data.uri)
+	self.logger.info('Adding CUE individual entry: ' + data.number + ' ' + data.uri)
 	return self.sendMpdCommandArray([
 		{command: 'clear', parameters: []},
 		{command: 'load', parameters: [data.uri]},
 		{command: 'play', parameters: [data.number]}
 	])
-}
-
+};
 
 
 // MPD music library
-ControllerMpd.prototype.getTracklist = function() {
+ControllerMpd.prototype.getTracklist = function () {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::getTracklist');
 
 	return self.mpdReady
-		.then(function() {
+		.then(function () {
 			return libQ.nfcall(libFast.bind(self.clientMpd.sendCommand, self.clientMpd), libMpd.cmd('listallinfo', []));
 		})
 		.then(libFast.bind(self.parseListAllInfoResult, self))
-		.then(function(objResult) {
+		.then(function (objResult) {
 			return objResult.tracks;
 		});
 };
@@ -246,18 +243,18 @@ ControllerMpd.prototype.getTracklist = function() {
 
 // Parses the info out of the 'listallinfo' MPD command
 // Metadata fields to roughly conform to Ogg Vorbis standards (http://xiph.org/vorbis/doc/v-comment.html)
-ControllerMpd.prototype.parseListAllInfoResult = function(sInput) {
+ControllerMpd.prototype.parseListAllInfoResult = function (sInput) {
 	var self = this;
 
 	var arrayLines = sInput.split('\n');
 	var objReturn = {};
-	var curEntry = {}
+	var curEntry = {};
 
 	objReturn.tracks = [];
 	objReturn.playlists = [];
 
 	for (var i = 0; i < arrayLines.length; i++) {
-		var arrayLineParts = libFast.map(arrayLines[i].split(':'), function(sPart) {
+		var arrayLineParts = libFast.map(arrayLines[i].split(':'), function (sPart) {
 			return sPart.trim();
 		});
 
@@ -283,12 +280,12 @@ ControllerMpd.prototype.parseListAllInfoResult = function(sInput) {
 		} else if (arrayLineParts[0] === 'Title') {
 			curEntry.name = arrayLineParts[1];
 		} else if (arrayLineParts[0] === 'Artist') {
-			curEntry.artists = libFast.map(arrayLineParts[1].split(','), function(sArtist) {
+			curEntry.artists = libFast.map(arrayLineParts[1].split(','), function (sArtist) {
 				// TODO - parse other options in artist string, such as "feat."
 				return sArtist.trim();
 			});
 		} else if (arrayLineParts[0] === 'AlbumArtist') {
-			curEntry.performers = libFast.map(arrayLineParts[1].split(','), function(sPerformer) {
+			curEntry.performers = libFast.map(arrayLineParts[1].split(','), function (sPerformer) {
 				return sPerformer.trim();
 			});
 		} else if (arrayLineParts[0] === 'Album') {
@@ -302,10 +299,10 @@ ControllerMpd.prototype.parseListAllInfoResult = function(sInput) {
 	}
 
 	return objReturn;
-}
+};
 
 // Define a method to get the MPD state
-ControllerMpd.prototype.getState = function() {
+ControllerMpd.prototype.getState = function () {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::getState');
 
@@ -314,42 +311,42 @@ ControllerMpd.prototype.getState = function() {
 	self.timeLatestUpdate = timeCurrentUpdate;
 
 	return self.sendMpdCommand('status', [])
-	/*.then(function(data) {
-		return self.haltIfNewerUpdateRunning(data, timeCurrentUpdate);
-	})*/
-	.then(libFast.bind(self.parseState, self))
-	.then(function(state) {
-		collectedState = state;
+		/*.then(function(data) {
+		 return self.haltIfNewerUpdateRunning(data, timeCurrentUpdate);
+		 })*/
+		.then(libFast.bind(self.parseState, self))
+		.then(function (state) {
+			collectedState = state;
 
-		// If there is a track listed as currently playing, get the track info
-		if (collectedState.position !== null) {
-			return self.sendMpdCommand('playlistinfo', [collectedState.position])
-			/*.then(function(data) {
-				return self.haltIfNewerUpdateRunning(data, timeCurrentUpdate);
-			})*/
-			.then(libFast.bind(self.parseTrackInfo, self))
-			.then(function(trackinfo) {
-				collectedState.isStreaming=trackinfo.isStreaming!=undefined?trackinfo.isStreaming:false;
-				collectedState.title = trackinfo.title;
-				collectedState.artist = trackinfo.artist;
-				collectedState.album = trackinfo.album;
-				collectedState.albumart = trackinfo.albumart;
+			// If there is a track listed as currently playing, get the track info
+			if (collectedState.position !== null) {
+				return self.sendMpdCommand('playlistinfo', [collectedState.position])
+					/*.then(function(data) {
+					 return self.haltIfNewerUpdateRunning(data, timeCurrentUpdate);
+					 })*/
+					.then(libFast.bind(self.parseTrackInfo, self))
+					.then(function (trackinfo) {
+						collectedState.isStreaming = trackinfo.isStreaming != undefined ? trackinfo.isStreaming : false;
+						collectedState.title = trackinfo.title;
+						collectedState.artist = trackinfo.artist;
+						collectedState.album = trackinfo.album;
+						collectedState.albumart = trackinfo.albumart;
+						return libQ.resolve(collectedState);
+					});
+				// Else return null track info
+			} else {
+				collectedState.isStreaming = false;
+				collectedState.title = null;
+				collectedState.artist = null;
+				collectedState.album = null;
+				collectedState.albumart = null;
 				return libQ.resolve(collectedState);
-			});
-			// Else return null track info
-		} else {
-			collectedState.isStreaming=false;
-			collectedState.title = null;
-			collectedState.artist = null;
-			collectedState.album = null;
-			collectedState.albumart = null;
-			return libQ.resolve(collectedState);
-		}
-	});
+			}
+		});
 };
 
 // Stop the current status update thread if a newer one exists
-ControllerMpd.prototype.haltIfNewerUpdateRunning = function(data, timeCurrentThread) {
+ControllerMpd.prototype.haltIfNewerUpdateRunning = function (data, timeCurrentThread) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::haltIfNewerUpdateRunning');
 
@@ -361,7 +358,7 @@ ControllerMpd.prototype.haltIfNewerUpdateRunning = function(data, timeCurrentThr
 };
 
 // Announce updated MPD state
-ControllerMpd.prototype.pushState = function(state) {
+ControllerMpd.prototype.pushState = function (state) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::pushState');
 
@@ -369,7 +366,7 @@ ControllerMpd.prototype.pushState = function(state) {
 };
 
 // Pass the error if we don't want to handle it
-ControllerMpd.prototype.pushError = function(sReason) {
+ControllerMpd.prototype.pushError = function (sReason) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::pushError');
 	self.commandRouter.pushConsoleMessage(sReason);
@@ -379,102 +376,99 @@ ControllerMpd.prototype.pushError = function(sReason) {
 };
 
 // Define a general method for sending an MPD command, and return a promise for its execution
-ControllerMpd.prototype.sendMpdCommand = function(sCommand, arrayParameters) {
+ControllerMpd.prototype.sendMpdCommand = function (sCommand, arrayParameters) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::sendMpdCommand');
 
 	return self.mpdReady
-	.then(function() {
-		self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'sending command...');
-		return libQ.nfcall(libFast.bind(self.clientMpd.sendCommand, self.clientMpd), libMpd.cmd(sCommand, arrayParameters));
-	})
-	.then(function(response) {
-		self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'parsing response...');
-		return libQ.resolve(libMpd.parseKeyValueMessage.call(libMpd, response));
-	});
+		.then(function () {
+			self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'sending command...');
+			return libQ.nfcall(libFast.bind(self.clientMpd.sendCommand, self.clientMpd), libMpd.cmd(sCommand, arrayParameters));
+		})
+		.then(function (response) {
+			self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'parsing response...');
+			return libQ.resolve(libMpd.parseKeyValueMessage.call(libMpd, response));
+		});
 };
 
 // Define a general method for sending an array of MPD commands, and return a promise for its execution
 // Command array takes the form [{command: sCommand, parameters: arrayParameters}, ...]
-ControllerMpd.prototype.sendMpdCommandArray = function(arrayCommands) {
+ControllerMpd.prototype.sendMpdCommandArray = function (arrayCommands) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::sendMpdCommandArray');
 
 	return self.mpdReady
-	.then(function() {
-		return libQ.nfcall(libFast.bind(self.clientMpd.sendCommands, self.clientMpd),
-			libFast.map(arrayCommands, function(currentCommand) {
-				return libMpd.cmd(currentCommand.command, currentCommand.parameters);
-			})
-		);
-	})
-	.then(libFast.bind(libMpd.parseKeyValueMessage, libMpd));
+		.then(function () {
+			return libQ.nfcall(libFast.bind(self.clientMpd.sendCommands, self.clientMpd),
+				libFast.map(arrayCommands, function (currentCommand) {
+					return libMpd.cmd(currentCommand.command, currentCommand.parameters);
+				})
+			);
+		})
+		.then(libFast.bind(libMpd.parseKeyValueMessage, libMpd));
 };
 
 // Parse MPD's track info text into Volumio recognizable object
-ControllerMpd.prototype.parseTrackInfo = function(objTrackInfo) {
+ControllerMpd.prototype.parseTrackInfo = function (objTrackInfo) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::parseTrackInfo');
 
-	var defer=libQ.defer();
+	var defer = libQ.defer();
 
 	//console.log(JSON.stringify("OBJTRACKINFO "+JSON.stringify(objTrackInfo)));
-	var resp={};
+	var resp = {};
 
-	var file=s(objTrackInfo.file);
+	var file = s(objTrackInfo.file);
 
-	resp.isStreaming=file.startsWith('http://');
+	resp.isStreaming = file.startsWith('http://');
 
-	if (objTrackInfo.Title!=undefined) {
-		resp.title=objTrackInfo.Title;
+	if (objTrackInfo.Title != undefined) {
+		resp.title = objTrackInfo.Title;
 	} else {
-		resp.title=objTrackInfo.null;
+		resp.title = objTrackInfo.null;
 	}
 
-	if (objTrackInfo.Artist!=undefined) {
-		resp.artist=objTrackInfo.Artist;
+	if (objTrackInfo.Artist != undefined) {
+		resp.artist = objTrackInfo.Artist;
 	} else {
-		resp.artist=null;
+		resp.artist = null;
 	}
 
-	if (objTrackInfo.Album!=undefined) {
-		resp.album=objTrackInfo.Album;
+	if (objTrackInfo.Album != undefined) {
+		resp.album = objTrackInfo.Album;
 	} else {
-		resp.album=null;
+		resp.album = null;
 	}
 
 	var promise;
-	var foundFileCover=false;
+	var foundFileCover = false;
 	var web;
 
-	var coverFolder='/mnt';
+	var coverFolder = '/mnt';
 
-	var splitted=objTrackInfo.file.split('/');
+	var splitted = objTrackInfo.file.split('/');
 
-	for(var k=0;k<splitted.length-1;k++)
-	{
-		coverFolder=coverFolder+'/'+splitted[k];
+	for (var k = 0; k < splitted.length - 1; k++) {
+		coverFolder = coverFolder + '/' + splitted[k];
 	}
 
-	if(objTrackInfo.Artist!=undefined)
-	{
-		if (objTrackInfo.Album!=undefined) {
-			web={artist:objTrackInfo.Artist,album:objTrackInfo.Album};
+	if (objTrackInfo.Artist != undefined) {
+		if (objTrackInfo.Album != undefined) {
+			web = {artist: objTrackInfo.Artist, album: objTrackInfo.Album};
 		} else {
-			web={artist:objTrackInfo.Artist};
+			web = {artist: objTrackInfo.Artist};
 		}
 	}
 
-	promise=self.getAlbumArt(web,coverFolder);
+	promise = self.getAlbumArt(web, coverFolder);
 
-	if(promise!=undefined)
-	{
-		promise.then(function(value){
-			//console.log("ALBUMART: "+value);
-			resp.albumart=value;
-			defer.resolve(resp);
-		})
-			.fail(function(){
+	if (promise != undefined) {
+		promise.then(function (value) {
+				//console.log("ALBUMART: "+value);
+				resp.albumart = value;
+				defer.resolve(resp);
+			})
+			.fail(function () {
 				defer.resolve(resp);
 			});
 
@@ -485,19 +479,19 @@ ControllerMpd.prototype.parseTrackInfo = function(objTrackInfo) {
 };
 
 // Parse MPD's text playlist into a Volumio recognizable playlist object
-ControllerMpd.prototype.parsePlaylist = function(objQueue) {
+ControllerMpd.prototype.parsePlaylist = function (objQueue) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::parsePlaylist');
 
 	// objQueue is in form {'0': 'file: http://uk4.internet-radio.com:15938/', '1': 'file: http://2363.live.streamtheworld.com:80/KUSCMP128_SC'}
 	// We want to convert to a straight array of trackIds
-	return libQ.fcall(libFast.map, Object.keys(objQueue), function(currentKey) {
+	return libQ.fcall(libFast.map, Object.keys(objQueue), function (currentKey) {
 		return convertUriToTrackId(objQueue[currentKey]);
 	});
 };
 
 // Parse MPD's text status into a Volumio recognizable status object
-ControllerMpd.prototype.parseState = function(objState) {
+ControllerMpd.prototype.parseState = function (objState) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::parseState');
 
@@ -567,13 +561,13 @@ ControllerMpd.prototype.parseState = function(objState) {
 	});
 };
 
-ControllerMpd.prototype.logDone = function(timeStart) {
+ControllerMpd.prototype.logDone = function (timeStart) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + '------------------------------ ' + (Date.now() - timeStart) + 'ms');
 	return libQ.resolve();
 };
 
-ControllerMpd.prototype.logStart = function(sCommand) {
+ControllerMpd.prototype.logStart = function (sCommand) {
 	var self = this;
 	self.commandRouter.pushConsoleMessage('\n' + '[' + Date.now() + '] ' + '---------------------------- ' + sCommand);
 	return libQ.resolve();
@@ -583,30 +577,30 @@ ControllerMpd.prototype.logStart = function(sCommand) {
  * This method can be defined by every plugin which needs to be informed of the startup of Volumio.
  * The Core controller checks if the method is defined and executes it on startup if it exists.
  */
-ControllerMpd.prototype.onVolumioStart = function() {
-	var self=this;
+ControllerMpd.prototype.onVolumioStart = function () {
+	var self = this;
 
 	// Connect to MPD only if process MPD is running
 	pidof('mpd', function (err, pid) {
-    if (err) {
-      self.logger.info('Cannot initialize  MPD Connection: MPD is not running');
-    } else {
-        if (pid) {
-          self.logger.info('MPD running with PID' +pid+' ,establishing connection');
-					self.mpdEstablish();
+		if (err) {
+			self.logger.info('Cannot initialize  MPD Connection: MPD is not running');
+		} else {
+			if (pid) {
+				self.logger.info('MPD running with PID' + pid + ' ,establishing connection');
+				self.mpdEstablish();
 
-        } else {
-          self.logger.info('Cannot initialize  MPD Connection: MPD is not running');
-        }
-    }
-});
-}
+			} else {
+				self.logger.info('Cannot initialize  MPD Connection: MPD is not running');
+			}
+		}
+	});
+};
 
-ControllerMpd.prototype.mpdEstablish = function() {
+ControllerMpd.prototype.mpdEstablish = function () {
 	var self = this;
-	var configFile=self.commandRouter.pluginManager.getConfigurationFile(self.context,'config.json');
+	var configFile = self.commandRouter.pluginManager.getConfigurationFile(self.context, 'config.json');
 
-	self.config= new (require('v-conf'))();
+	self.config = new (require('v-conf'))();
 	self.config.loadFile(configFile);
 
 	// TODO use names from the package.json instead
@@ -624,13 +618,13 @@ ControllerMpd.prototype.mpdEstablish = function() {
 	// Make a promise for when the MPD connection is ready to receive events
 	self.mpdReady = libQ.nfcall(libFast.bind(self.clientMpd.on, self.clientMpd), 'ready');
 	// Catch and log errors
-	self.clientMpd.on('error', function(err) {
+	self.clientMpd.on('error', function (err) {
 		console.error('MPD error: ' + err);
 		if (err = "{ [Error: This socket has been ended by the other party] code: 'EPIPE' }") {
 			// Wait 5 seconds before trying to reconnect
-			setTimeout(function(){
-			self.mpdEstablish();
-			},5000);
+			setTimeout(function () {
+				self.mpdEstablish();
+			}, 5000);
 		}
 	});
 
@@ -640,197 +634,185 @@ ControllerMpd.prototype.mpdEstablish = function() {
 	// TODO remove pertaining function when properly found out we don't need em
 	//self.fswatch();
 	// When playback status changes
-	self.clientMpd.on('system', function() {
+	self.clientMpd.on('system', function () {
 		var timeStart = Date.now();
 
 		self.logStart('MPD announces state update')
 			.then(libFast.bind(self.getState, self))
 			.then(libFast.bind(self.pushState, self))
 			.fail(libFast.bind(self.pushError, self))
-			.done(function() {
+			.done(function () {
 				return self.logDone(timeStart);
 			});
 	});
 
 
-
-	self.clientMpd.on('system-playlist', function() {
+	self.clientMpd.on('system-playlist', function () {
 		var timeStart = Date.now();
 
 		self.logStart('MPD announces sysyrm state update')
 			.then(libFast.bind(self.updateQueue, self))
 			.fail(libFast.bind(self.pushError, self))
-			.done(function() {
+			.done(function () {
 				return self.logDone(timeStart);
 			});
 	});
 
 	//Notify that The mpd DB has changed
-	self.clientMpd.on('system-database', function() {
+	self.clientMpd.on('system-database', function () {
 
 		return self.reportUpdatedLibrary();
 	});
-}
+};
 
-ControllerMpd.prototype.mpdConnect = function() {
+ControllerMpd.prototype.mpdConnect = function () {
 
 	var self = this;
 
-	var configFile=self.commandRouter.pluginManager.getConfigurationFile(self.context,'config.json');
+	var configFile = self.commandRouter.pluginManager.getConfigurationFile(self.context, 'config.json');
 
-	self.config= new (require('v-conf'))();
+	self.config = new (require('v-conf'))();
 	self.config.loadFile(configFile);
 
-	var nHost=self.config.get('nHost');
-	var nPort=self.config.get('nPort');
+	var nHost = self.config.get('nHost');
+	var nPort = self.config.get('nPort');
 	self.clientMpd = libMpd.connect({port: nPort, host: nHost});
-}
+};
 /*
  * This method shall be defined by every plugin which needs to be configured.
  */
 /*ControllerMpd.prototype.getConfiguration = function(mainConfig) {
 
-	var language=__dirname+"/i18n/"+mainConfig.locale+".json";
-	if(!libFsExtra.existsSync(language))
-	{
-		language=__dirname+"/i18n/EN.json";
-	}
+ var language=__dirname+"/i18n/"+mainConfig.locale+".json";
+ if(!libFsExtra.existsSync(language))
+ {
+ language=__dirname+"/i18n/EN.json";
+ }
 
-	var languageJSON=libFsExtra.readJsonSync(language);
+ var languageJSON=libFsExtra.readJsonSync(language);
 
-	var config=libFsExtra.readJsonSync(__dirname+'/config.json');
-	var uiConfig={};
+ var config=libFsExtra.readJsonSync(__dirname+'/config.json');
+ var uiConfig={};
 
-	for(var key in config)
-	{
-		if(config[key].modifiable==true)
-		{
-			uiConfig[key]={
-				"value":config[key].value,
-				"type":config[key].type,
-				"label":languageJSON[config[key].ui_label_key]
-			};
+ for(var key in config)
+ {
+ if(config[key].modifiable==true)
+ {
+ uiConfig[key]={
+ "value":config[key].value,
+ "type":config[key].type,
+ "label":languageJSON[config[key].ui_label_key]
+ };
 
-			if(config[key].enabled_by!=undefined)
-				uiConfig[key].enabled_by=config[key].enabled_by;
-		}
-	}
+ if(config[key].enabled_by!=undefined)
+ uiConfig[key].enabled_by=config[key].enabled_by;
+ }
+ }
 
-	return uiConfig;
-}*/
+ return uiConfig;
+ }*/
 
-ControllerMpd.prototype.getUIConfig = function()
-{
+ControllerMpd.prototype.getUIConfig = function () {
 	var self = this;
 
-	var uiconf=libFsExtra.readJsonSync(__dirname+'/UIConfig.json');
+	var uiconf = libFsExtra.readJsonSync(__dirname + '/UIConfig.json');
 	var value;
 
 
-	value=self.config.get('gapless_mp3_playback');
-	uiconf.sections[0].content[0].value.value=value;
-	uiconf.sections[0].content[0].value.label=self.getLabelForSelect(uiconf.sections[0].content[0].options,value);
+	value = self.config.get('gapless_mp3_playback');
+	uiconf.sections[0].content[0].value.value = value;
+	uiconf.sections[0].content[0].value.label = self.getLabelForSelect(uiconf.sections[0].content[0].options, value);
 
-	value=self.config.get('volume_normalization');
-	uiconf.sections[0].content[1].value.value=value;
-	uiconf.sections[0].content[1].value.label=self.getLabelForSelect(uiconf.sections[0].content[1].options,value);
+	value = self.config.get('volume_normalization');
+	uiconf.sections[0].content[1].value.value = value;
+	uiconf.sections[0].content[1].value.label = self.getLabelForSelect(uiconf.sections[0].content[1].options, value);
 
-	value=self.config.get('audio_buffer_size');
-	uiconf.sections[0].content[2].value.value=value;
-	uiconf.sections[0].content[2].value.label=self.getLabelForSelect(uiconf.sections[0].content[2].options,value);
+	value = self.config.get('audio_buffer_size');
+	uiconf.sections[0].content[2].value.value = value;
+	uiconf.sections[0].content[2].value.label = self.getLabelForSelect(uiconf.sections[0].content[2].options, value);
 
-	value=self.config.get('buffer_before_play');
-	uiconf.sections[0].content[3].value.value=value;
-	uiconf.sections[0].content[3].value.label=self.getLabelForSelect(uiconf.sections[0].content[3].options,value);
+	value = self.config.get('buffer_before_play');
+	uiconf.sections[0].content[3].value.value = value;
+	uiconf.sections[0].content[3].value.label = self.getLabelForSelect(uiconf.sections[0].content[3].options, value);
 
-	value=self.config.get('auto_update');
-	uiconf.sections[0].content[4].value.value=value;
-	uiconf.sections[0].content[4].value.label=self.getLabelForSelect(uiconf.sections[0].content[4].options,value);
+	value = self.config.get('auto_update');
+	uiconf.sections[0].content[4].value.value = value;
+	uiconf.sections[0].content[4].value.label = self.getLabelForSelect(uiconf.sections[0].content[4].options, value);
 
-	value=self.getAdditionalConf('audio_interface','alsa_controller','volumestart');
-	uiconf.sections[1].content[0].value.value=value;
-	uiconf.sections[1].content[0].value.label=self.getLabelForSelect(uiconf.sections[1].content[0].options,value);
+	value = self.getAdditionalConf('audio_interface', 'alsa_controller', 'volumestart');
+	uiconf.sections[1].content[0].value.value = value;
+	uiconf.sections[1].content[0].value.label = self.getLabelForSelect(uiconf.sections[1].content[0].options, value);
 
-	value=self.getAdditionalConf('audio_interface','alsa_controller','volumemax');
-	uiconf.sections[1].content[1].value.value=value;
-	uiconf.sections[1].content[1].value.label=self.getLabelForSelect(uiconf.sections[1].content[1].options,value);
+	value = self.getAdditionalConf('audio_interface', 'alsa_controller', 'volumemax');
+	uiconf.sections[1].content[1].value.value = value;
+	uiconf.sections[1].content[1].value.label = self.getLabelForSelect(uiconf.sections[1].content[1].options, value);
 
-	value=self.getAdditionalConf('audio_interface','alsa_controller','volumecurvemode')
-	uiconf.sections[1].content[2].value.value=value;
-	uiconf.sections[1].content[2].value.label=self.getLabelForSelect(uiconf.sections[1].content[2].options,value);
+	value = self.getAdditionalConf('audio_interface', 'alsa_controller', 'volumecurvemode')
+	uiconf.sections[1].content[2].value.value = value;
+	uiconf.sections[1].content[2].value.label = self.getLabelForSelect(uiconf.sections[1].content[2].options, value);
 
 
-	var cards=self.commandRouter.executeOnPlugin('audio_interface','alsa_controller','getAlsaCards');
+	var cards = self.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getAlsaCards');
 
-	value=self.getAdditionalConf('audio_interface','alsa_controller','outputdevice');
-	if(value==undefined)
-		value=0;
+	value = self.getAdditionalConf('audio_interface', 'alsa_controller', 'outputdevice');
+	if (value == undefined)
+		value = 0;
 
-	uiconf.sections[2].content[0].value.value=value;
-	uiconf.sections[2].content[0].value.label=self.getLabelForSelectedCard(cards,value);
+	uiconf.sections[2].content[0].value.value = value;
+	uiconf.sections[2].content[0].value.label = self.getLabelForSelectedCard(cards, value);
 
-	for(var i in cards)
-	{
-		uiconf.sections[2].content[0].options.push({value:cards[i].id,label:cards[i].name});
+	for (var i in cards) {
+		uiconf.sections[2].content[0].options.push({value: cards[i].id, label: cards[i].name});
 	}
 
 
 	return uiconf;
-}
+};
 
-ControllerMpd.prototype.getLabelForSelectedCard = function(cards,key)
-{
-	for(var i in cards)
-	{
-		if(cards[i].id==key)
+ControllerMpd.prototype.getLabelForSelectedCard = function (cards, key) {
+	for (var i in cards) {
+		if (cards[i].id == key)
 			return cards[i].name;
 	}
 
 	return 'VALUE NOT FOUND BETWEEN SELECT OPTIONS!';
-}
+};
 
-ControllerMpd.prototype.getLabelForSelect = function(options,key)
-{
-	for(var i in options)
-	{
-		if(options[i].value==key)
+ControllerMpd.prototype.getLabelForSelect = function (options, key) {
+	for (var i in options) {
+		if (options[i].value == key)
 			return options[i].label;
 	}
 
 	return 'VALUE NOT FOUND BETWEEN SELECT OPTIONS!';
-}
+};
 
 
-ControllerMpd.prototype.savePlaybackOptions = function(data)
-{
+ControllerMpd.prototype.savePlaybackOptions = function (data) {
 	var self = this;
 
 	var defer = libQ.defer();
 
-	self.config.set('gapless_mp3_playback',data['gapless_mp3_playback'].value);
-	self.config.set('volume_normalization',data['volume_normalization'].value);
-	self.config.set('audio_buffer_size',data['audio_buffer_size'].value);
-	self.config.set('buffer_before_play',data['buffer_before_play'].value);
-	self.config.set('auto_update',data['auto_update'].value);
+	self.config.set('gapless_mp3_playback', data['gapless_mp3_playback'].value);
+	self.config.set('volume_normalization', data['volume_normalization'].value);
+	self.config.set('audio_buffer_size', data['audio_buffer_size'].value);
+	self.config.set('buffer_before_play', data['buffer_before_play'].value);
+	self.config.set('auto_update', data['auto_update'].value);
 
-
-	self.createMPDFile(function(error)
-	{
+	self.createMPDFile(function (error) {
 		if (error !== undefined && error !== null) {
-			self.commandRouter.pushToastMessage('error',"Configuration update",'Error while Applying new configuration');
+			self.commandRouter.pushToastMessage('error', "Configuration update", 'Error while Applying new configuration');
 			defer.resolve({});
 		}
-		else
-		{
-			self.commandRouter.pushToastMessage('success',"Configuration update",'The playback configuration has been successfully updated');
+		else {
+			self.commandRouter.pushToastMessage('success', "Configuration update", 'The playback configuration has been successfully updated');
 
-			self.restartMpd(function(error)
-			{
-				if (error !== null && error !=undefined) {
-					self.logger.info('Cannot restart MPD: '+error);
-					self.commandRouter.pushToastMessage('error',"Player restart",'Error while restarting player');
+			self.restartMpd(function (error) {
+				if (error !== null && error != undefined) {
+					self.logger.info('Cannot restart MPD: ' + error);
+					self.commandRouter.pushToastMessage('error', "Player restart", 'Error while restarting player');
 				}
-				else self.commandRouter.pushToastMessage('success',"Player restart",'Player successfully restarted');
+				else self.commandRouter.pushToastMessage('success', "Player restart", 'Player successfully restarted');
 
 				defer.resolve({});
 			});
@@ -839,48 +821,43 @@ ControllerMpd.prototype.savePlaybackOptions = function(data)
 
 	return defer.promise;
 
-}
+};
 
-ControllerMpd.prototype.saveVolumeOptions = function(data)
-{
+ControllerMpd.prototype.saveVolumeOptions = function (data) {
 	var self = this;
 
 	var defer = libQ.defer();
 
-	self.setAdditionalConf('audio_interface','alsa_controller',{key:'volumestart',value:data.volumestart.value});
-	self.setAdditionalConf('audio_interface','alsa_controller',{key:'volumemax',value:data.volumemax.value});
-	self.setAdditionalConf('audio_interface','alsa_controller',{key:'volumecurvemode',value:data.volumecurvemode.value});
+	self.setAdditionalConf('audio_interface', 'alsa_controller', {key: 'volumestart', value: data.volumestart.value});
+	self.setAdditionalConf('audio_interface', 'alsa_controller', {key: 'volumemax', value: data.volumemax.value});
+	self.setAdditionalConf('audio_interface', 'alsa_controller', {key: 'volumecurvemode', value:data.volumecurvemode.value});
 
 	self.logger.info('Volume configurations have been set');
 
 
-	self.commandRouter.pushToastMessage('success',"Configuration update",'The volume configuration has been successfully updated');
+	self.commandRouter.pushToastMessage('success', "Configuration update", 'The volume configuration has been successfully updated');
 
 	defer.resolve({});
 
 	return defer.promise;
 
-}
+};
 
-ControllerMpd.prototype.restartMpd = function(callback)
-{
+ControllerMpd.prototype.restartMpd = function (callback) {
 	var self = this;
-
 
 	exec('/bin/systemctl restart mpd.service ',
 		function (error, stdout, stderr) {
 			callback(error);
-	});
+		});
 
-}
+};
 
-ControllerMpd.prototype.createMPDFile = function(callback)
-{
+ControllerMpd.prototype.createMPDFile = function (callback) {
 	var self = this;
 
-	try
-	{
-		libFsExtra.copySync('/etc/mpd.conf','/etc/mpd.conf.old');
+	try {
+		libFsExtra.copySync('/etc/mpd.conf', '/tmp/mpd.conf.old');
 
 		var ws = libFsExtra.createOutputStream('/etc/mpd.conf');
 
@@ -902,10 +879,10 @@ ControllerMpd.prototype.createMPDFile = function(callback)
 		ws.write('bind_to_address		"any"\n');
 		ws.write('#port				"6600"\n');
 		ws.write('#log_level			"default"\n');
-		ws.write('gapless_mp3_playback			"'+self.config.get('gapless_mp3_playback')+'"\n');
+		ws.write('gapless_mp3_playback			"' + self.config.get('gapless_mp3_playback') + '"\n');
 		ws.write('#save_absolute_paths_in_playlists	"no"\n');
 		ws.write('#metadata_to_use	"artist,album,title,track,name,genre,date,composer,performer,disc"\n');
-		ws.write('auto_update    "'+self.config.get('auto_update')+'"\n');
+		ws.write('auto_update    "' + self.config.get('auto_update') + '"\n');
 		ws.write('#auto_update_depth "3"\n');
 		ws.write('###############################################################################\n');
 		ws.write('# Symbolic link behavior ######################################################\n');
@@ -926,17 +903,17 @@ ControllerMpd.prototype.createMPDFile = function(callback)
 		ws.write('audio_output {\n');
 		ws.write('		type		"alsa"\n');
 		ws.write('		name		"alsa"\n');
-		ws.write('		device		"hw:0,0"\n');
+		ws.write('		device		"hw:' + self.getAdditionalConf('audio_interface', 'alsa_controller', 'outputdevice') + ',0"\n');
 		ws.write('}\n');
 		ws.write('samplerate_converter "soxr very high"\n');
 		ws.write('#replaygain			"album"\n');
 		ws.write('#replaygain_preamp		"0"\n');
-		ws.write('volume_normalization		"'+self.config.get('volume_normalization')+'"\n');
+		ws.write('volume_normalization		"' + self.config.get('volume_normalization') + '"\n');
 		ws.write('###############################################################################\n');
 		ws.write('\n');
 		ws.write('# MPD Internal Buffering ######################################################\n');
-		ws.write('audio_buffer_size		"'+self.config.get('audio_buffer_size')+'"\n');
-		ws.write('buffer_before_play		"'+self.config.get('buffer_before_play')+'"\n');
+		ws.write('audio_buffer_size		"' + self.config.get('audio_buffer_size') + '"\n');
+		ws.write('buffer_before_play		"' + self.config.get('buffer_before_play') + '"\n');
 		ws.write('###############################################################################\n');
 		ws.write('\n');
 		ws.write('\n');
@@ -956,25 +933,24 @@ ControllerMpd.prototype.createMPDFile = function(callback)
 
 		callback();
 	}
-	catch(err)
-	{
+	catch (err) {
 
-		if(libFsExtra.existsSync('/etc/mpd.conf.old')) {
-			libFsExtra.copySync('/etc/mpd.conf.old', '/etc/mpd.conf');
+		if (libFsExtra.existsSync('/tmp/mpd.conf.old')) {
+			libFsExtra.copySync('/tmp/mpd.conf.old', '/etc/mpd.conf');
 		}
 
 		callback(err);
 	}
 
-}
+};
 
 
 /*
  * This method shall be defined by every plugin which needs to be configured.
  */
-ControllerMpd.prototype.setConfiguration = function(configuration) {
+ControllerMpd.prototype.setConfiguration = function (configuration) {
 	//DO something intelligent
-}
+};
 
 ControllerMpd.prototype.fswatch = function () {
 	var self = this;
@@ -987,7 +963,7 @@ ControllerMpd.prototype.fswatch = function () {
 			watcher.close();
 			return self.waitupdate();
 		})
-		.on('addDir', function(path) {
+		.on('addDir', function (path) {
 			self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::UpdateMusicDatabase');
 			self.sendMpdCommand('update', []);
 			watcher.close();
@@ -1002,21 +978,21 @@ ControllerMpd.prototype.fswatch = function () {
 		.on('error', function (error) {
 			self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::UpdateMusicDatabase ERROR');
 		})
-}
+};
 
 ControllerMpd.prototype.waitupdate = function () {
 	var self = this;
 
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::WaitUpdatetoFinish');
 	//Delay to ensure any media is properly mounted and accessible
-	setTimeout(function() {
+	setTimeout(function () {
 		return self.sendMpdCommand('update', []);
 	}, 500);
 
-	setTimeout(function() {
+	setTimeout(function () {
 		return self.fswatch()
 	}, 5000);
-}
+};
 
 
 ControllerMpd.prototype.listFavourites = function (uri) {
@@ -1025,36 +1001,41 @@ ControllerMpd.prototype.listFavourites = function (uri) {
 
 	var defer = libQ.defer();
 
-	var promise=self.commandRouter.playListManager.getFavouritesContent();
-	promise.then(function(data)
-	{
-		var response={
-			navigation: {
-				prev: {
-					uri: '/'
-				},
-				list:[]
+	var promise = self.commandRouter.playListManager.getFavouritesContent();
+	promise.then(function (data) {
+			var response = {
+				navigation: {
+					prev: {
+						uri: '/'
+					},
+					list: []
+				}
+			};
+
+			for (var i in data) {
+				var ithdata = data[i];
+				var song = {
+					service: ithdata.service,
+					type: 'song',
+					title: ithdata.title,
+					artist: ithdata.artist,
+					album: ithdata.album,
+					icon: ithdata.albumart,
+					uri: ithdata.uri
+				};
+
+				response.navigation.list.push(song);
 			}
-		};
 
-		for(var i in data)
-		{
-			var ithdata=data[i];
-			var song={service: ithdata.service, type: 'song',  title: ithdata.title, artist: ithdata.artist, album: ithdata.album, icon: ithdata.albumart, uri: ithdata.uri};
+			defer.resolve(response);
 
-			response.navigation.list.push(song);
-		}
-
-		defer.resolve(response);
-
-	})
-	.fail(function()
-	{
-		defer.reject(new Error("Cannot list Favourites"));
-	});
+		})
+		.fail(function () {
+			defer.reject(new Error("Cannot list Favourites"));
+		});
 
 	return defer.promise;
-}
+};
 
 ControllerMpd.prototype.listPlaylists = function (uri) {
 	var self = this;
@@ -1062,22 +1043,19 @@ ControllerMpd.prototype.listPlaylists = function (uri) {
 
 	var defer = libQ.defer();
 
-	var response={
+	var response = {
 		navigation: {
 			prev: {
 				uri: '/'
 			},
-			list: [
-			]
+			list: []
 		}
 	};
-	var promise=self.commandRouter.playListManager.listPlaylist();
-	promise.then(function(data)
-	{
-		for(var i in data)
-		{
-			var ithdata=data[i];
-			var song={type: 'playlist',  title: ithdata, icon: 'bars', uri: 'playlists/'+ithdata};
+	var promise = self.commandRouter.playListManager.listPlaylist();
+	promise.then(function (data) {
+		for (var i in data) {
+			var ithdata = data[i];
+			var song = {type: 'playlist', title: ithdata, icon: 'bars', uri: 'playlists/' + ithdata};
 
 			response.navigation.list.push(song);
 		}
@@ -1087,7 +1065,7 @@ ControllerMpd.prototype.listPlaylists = function (uri) {
 
 
 	return defer.promise;
-}
+};
 
 ControllerMpd.prototype.browsePlaylist = function (uri) {
 	var self = this;
@@ -1095,26 +1073,31 @@ ControllerMpd.prototype.browsePlaylist = function (uri) {
 
 	var defer = libQ.defer();
 
-	var response={
+	var response = {
 		navigation: {
 			prev: {
 				uri: 'playlists'
 			},
-			list: [
-			]
+			list: []
 		}
 	};
 
-	var name=uri.split('/')[1];
+	var name = uri.split('/')[1];
 
-	var promise=self.commandRouter.playListManager.getPlaylistContent(name);
-	promise.then(function(data)
-	{
+	var promise = self.commandRouter.playListManager.getPlaylistContent(name);
+	promise.then(function (data) {
 		//console.log("CONTENT: "+JSON.stringify(data));
-		for(var i in data)
-		{
-			var ithdata=data[i];
-			var song={service: ithdata.service, type: 'song',  title: ithdata.title, artist: ithdata.artist, album: ithdata.album, icon: ithdata.albumart, uri: ithdata.uri};
+		for (var i in data) {
+			var ithdata = data[i];
+			var song = {
+				service: ithdata.service,
+				type: 'song',
+				title: ithdata.title,
+				artist: ithdata.artist,
+				album: ithdata.album,
+				icon: ithdata.albumart,
+				uri: ithdata.uri
+			};
 
 			response.navigation.list.push(song);
 		}
@@ -1125,39 +1108,38 @@ ControllerMpd.prototype.browsePlaylist = function (uri) {
 
 
 	return defer.promise;
-}
+};
 
 ControllerMpd.prototype.lsInfo = function (uri) {
 	var self = this;
 
 	var defer = libQ.defer();
 
-	var sections=uri.split('/');
-	var folder=sections[1];
-	var prev='';
-	var folderToList='';
-	var command='lsinfo';
-	var list=[];
+	var sections = uri.split('/');
+	var folder = sections[1];
+	var prev = '';
+	var folderToList = '';
+	var command = 'lsinfo';
+	var list = [];
 
-	if(sections.length>1)
-	{
-		for(var i=0;i<sections.length-1;i++)
-			prev+=sections[i]+'/';
+	if (sections.length > 1) {
+		for (var i = 0; i < sections.length - 1; i++)
+			prev += sections[i] + '/';
 
-		prev=s(prev).chompRight('/');
+		prev = s(prev).chompRight('/');
 
-		for(var j=1;j<sections.length;j++)
-			folderToList+=sections[j]+'/';
+		for (var j = 1; j < sections.length; j++)
+			folderToList += sections[j] + '/';
 
-		folderToList=s(folderToList).chompRight('/');
+		folderToList = s(folderToList).chompRight('/');
 
-		command+=' "'+folderToList+'"';
+		command += ' "' + folderToList + '"';
 
 	}
 
 	var cmd = libMpd.cmd;
 
-	self.mpdReady.then(function() {
+	self.mpdReady.then(function () {
 		self.clientMpd.sendCommand(cmd(command, []), function (err, msg) {
 			if (msg) {
 				var lines = s(msg).lines();
@@ -1172,7 +1154,7 @@ ControllerMpd.prototype.lsInfo = function (uri) {
 							type: 'folder',
 							title: name[count - 1],
 							icon: 'fa fa-folder-open-o',
-							uri: sections[0]+'/' + path
+							uri: sections[0] + '/' + path
 						});
 					}
 					else if (line.startsWith('playlist:')) {
@@ -1180,43 +1162,43 @@ ControllerMpd.prototype.lsInfo = function (uri) {
 						var path = line.chompLeft('playlist:').trimLeft().s;
 						var name = path.split('/');
 						var count = name.length;
-						var playlistName=S(path);
-						if (playlistName.endsWith('.cue')){
+						var playlistName = S(path);
+						if (playlistName.endsWith('.cue')) {
 							try {
-							var cuesheet = parser.parse('/mnt/'+path);
+								var cuesheet = parser.parse('/mnt/' + path);
 
+								list.push({
+									service: 'mpd',
+									type: 'song',
+									title: name[count - 1],
+									icon: 'fa fa-list-ol',
+									uri: sections[0] + '/' + path
+								});
+								for (var i in cuesheet.files[0].tracks) {
+
+									list.push({
+										service: 'mpd',
+										type: 'cuesong',
+										title: cuesheet.files[0].tracks[i].title,
+										artist: cuesheet.files[0].tracks[i].performer,
+										album: path.substring(path.lastIndexOf("/") + 1),
+										number: cuesheet.files[0].tracks[i].number - 1,
+										icon: 'fa fa-music',
+										uri: sections[0] + '/' + path
+									});
+								}
+							} catch (err) {
+								self.logger.info('Cue Parser - Cannot parse ' + path);
+							}
+						} else {
 							list.push({
 								service: 'mpd',
 								type: 'song',
 								title: name[count - 1],
 								icon: 'fa fa-list-ol',
-								uri: sections[0]+'/' + path
-							});
-							for (var i in cuesheet.files[0].tracks){
-
-							list.push({
-								service: 'mpd',
-								type: 'cuesong',
-								title: cuesheet.files[0].tracks[i].title,
-								artist: cuesheet.files[0].tracks[i].performer,
-								album: path.substring(path.lastIndexOf("/")+1),
-								number: cuesheet.files[0].tracks[i].number-1,
-								icon: 'fa fa-music',
-								uri: sections[0]+'/' + path
+								uri: sections[0] + '/' + path
 							});
 						}
-					} catch(err) {
-self.logger.info('Cue Parser - Cannot parse '+path);
-};
-						} else {
-						list.push({
-							service: 'mpd',
-							type: 'song',
-							title: name[count - 1],
-							icon: 'fa fa-list-ol',
-							uri: sections[0]+'/' + path
-						});
-					}
 					}
 					else if (line.startsWith('file:')) {
 						var path = line.chompLeft('file:').trimLeft().s;
@@ -1237,7 +1219,7 @@ self.logger.info('Cue Parser - Cannot parse '+path);
 							artist: artist,
 							album: album,
 							icon: 'fa fa-music',
-							uri:sections[0]+'/' + path
+							uri: sections[0] + '/' + path
 						});
 					}
 
@@ -1256,18 +1238,18 @@ self.logger.info('Cue Parser - Cannot parse '+path);
 		});
 	});
 	return defer.promise;
-}
+};
 
 ControllerMpd.prototype.search = function (query) {
 	var self = this;
 
 	var defer = libQ.defer();
-	var command='search any';
-	command+=' "'+query+'"';
+	var command = 'search any';
+	command += ' "' + query + '"';
 	var cmd = libMpd.cmd;
-	var list=[];
+	var list = [];
 
-	self.mpdReady.then(function() {
+	self.mpdReady.then(function () {
 		self.clientMpd.sendCommand(cmd(command, []), function (err, msg) {
 			if (msg) {
 				var lines = s(msg).lines();
@@ -1293,7 +1275,7 @@ ControllerMpd.prototype.search = function (query) {
 							artist: artist,
 							album: album,
 							icon: 'fa fa-music',
-							uri:'music-library/' + path
+							uri: 'music-library/' + path
 						});
 					}
 
@@ -1312,42 +1294,41 @@ ControllerMpd.prototype.search = function (query) {
 		});
 	});
 	return defer.promise;
-}
+};
 
-ControllerMpd.prototype.searchFor = function (lines,startFrom,beginning) {
-	var self=this;
+ControllerMpd.prototype.searchFor = function (lines, startFrom, beginning) {
+	var self = this;
 
-	var count=lines.length;
-	var i=0;
+	var count = lines.length;
+	var i = 0;
 
-	while(startFrom+i<count)
-	{
-		var line=s(lines[startFrom+i]);
+	while (startFrom + i < count) {
+		var line = s(lines[startFrom + i]);
 
-		if(line.startsWith(beginning))
+		if (line.startsWith(beginning))
 			return line.chompLeft(beginning).trimLeft().s;
-		else if(line.startsWith('file:'))
+		else if (line.startsWith('file:'))
 			return '';
-		else if(line.startsWith('directory:'))
+		else if (line.startsWith('directory:'))
 			return '';
 
 		i++;
 	}
-}
+};
 
 ControllerMpd.prototype.updateQueue = function () {
 	var self = this;
 
 	var defer = libQ.defer();
 
-	var prev='';
-	var folderToList='';
-	var command='playlistinfo';
-	var list=[];
+	var prev = '';
+	var folderToList = '';
+	var command = 'playlistinfo';
+	var list = [];
 
 	var cmd = libMpd.cmd;
-	self.mpdReady.then(function(){
-		self.clientMpd.sendCommand(cmd(command, []), function(err, msg) {
+	self.mpdReady.then(function () {
+		self.clientMpd.sendCommand(cmd(command, []), function (err, msg) {
 			if (msg) {
 				var lines = s(msg).lines();
 
@@ -1355,25 +1336,32 @@ ControllerMpd.prototype.updateQueue = function () {
 
 				var promises = [];
 
-				var queue=[];
+				var queue = [];
 				for (var i = 0; i < lines.length; i++) {
 					var line = s(lines[i]);
 					if (line.startsWith('file:')) {
-						var path=line.chompLeft('file:').trimLeft().s;
-						var name=path.split('/');
-						var count=name.length;
+						var path = line.chompLeft('file:').trimLeft().s;
+						var name = path.split('/');
+						var count = name.length;
 
-						var artist=self.searchFor(lines,i+1,'Artist:');
-						var album=self.searchFor(lines,i+1,'Album:');
-						var title=self.searchFor(lines,i+1,'Title:');
-						var tracknumber=self.searchFor(lines,i+1,'Pos:');
-						if( title == undefined)
-						{
-							title=name[count-1];
+						var artist = self.searchFor(lines, i + 1, 'Artist:');
+						var album = self.searchFor(lines, i + 1, 'Album:');
+						var title = self.searchFor(lines, i + 1, 'Title:');
+						var tracknumber = self.searchFor(lines, i + 1, 'Pos:');
+						if (title == undefined) {
+							title = name[count - 1];
 						}
 
-						var queueItem={uri: path, service:'mpd', name: title, artist: artist, album: album, type:'track', tracknumber: tracknumber };
-						queueItem.promise=self.getAlbumArt({artist:artist,album:album});
+						var queueItem = {
+							uri: path,
+							service: 'mpd',
+							name: title,
+							artist: artist,
+							album: album,
+							type: 'track',
+							tracknumber: tracknumber
+						};
+						queueItem.promise = self.getAlbumArt({artist: artist, album: album});
 						promises.push(queueItem.promise);
 						queue.push(queueItem);
 
@@ -1382,10 +1370,9 @@ ControllerMpd.prototype.updateQueue = function () {
 				}
 
 				libQ.all(promises)
-					.then(function(data){
-						for(var i in queue)
-						{
-							queue[i].albumart=data[i];
+					.then(function (data) {
+						for (var i in queue) {
+							queue[i].albumart = data[i];
 							delete queue[i].promise;
 						}
 
@@ -1412,134 +1399,113 @@ ControllerMpd.prototype.updateQueue = function () {
 	});
 
 
-
 	return defer.promise;
-}
+};
 
 
-ControllerMpd.prototype.getAlbumArt=function(data,path)
-{
-	var self=this;
+ControllerMpd.prototype.getAlbumArt = function (data, path) {
+	var self = this;
 
-	var defer=libQ.defer();
+	var defer = libQ.defer();
 
-	ifconfig.status('wlan0', function(err, status) {
+	ifconfig.status('wlan0', function (err, status) {
 		var address;
 
 		var url;
-		var artist,album;
-
+		var artist, album;
 
 
 		var web;
 
-		if(data!= undefined && data.artist!=undefined)
-		{
-			artist=data.artist;
-			if(data.album!=undefined)
-				album=data.album;
-			else album=data.artist;
+		if (data != undefined && data.artist != undefined) {
+			artist = data.artist;
+			if (data.album != undefined)
+				album = data.album;
+			else album = data.artist;
 
-			web='?web='+nodetools.urlEncode(artist)+'/'+nodetools.urlEncode(album)+'/extralarge'
+			web = '?web=' + nodetools.urlEncode(artist) + '/' + nodetools.urlEncode(album) + '/extralarge'
 		}
 
-		var url='/albumart';
+		var url = '/albumart';
 
-		if(web!=undefined)
-			url=url+web;
+		if (web != undefined)
+			url = url + web;
 
-		if(web!=undefined && path != undefined)
-			url=url+'&';
-		else if(path != undefined)
-			url=url+'?';
+		if (web != undefined && path != undefined)
+			url = url + '&';
+		else if (path != undefined)
+			url = url + '?';
 
-		if(path!=undefined)
-			url=url+'path='+nodetools.urlEncode(path);
+		if (path != undefined)
+			url = url + 'path=' + nodetools.urlEncode(path);
 
 		defer.resolve(url);
 	});
 
 
 	return defer.promise;
-}
-
-
-
-
-
-
-
-
-
-
+};
 
 
 ControllerMpd.prototype.reportUpdatedLibrary = function () {
-	var self=this;
+	var self = this;
 	// TODO PUSH THIS MESSAGE TO ALL CONNECTED CLIENTS
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerMpd::DB Update Finished');
-	return self.commandRouter.pushToastMessage('Success','ASF',' Added');
-}
+	return self.commandRouter.pushToastMessage('Success', 'ASF', ' Added');
+};
 
-ControllerMpd.prototype.getConfigurationFiles = function()
-{
+ControllerMpd.prototype.getConfigurationFiles = function () {
 	var self = this;
 
 	return ['config.json'];
-}
+};
 
-ControllerMpd.prototype.getAdditionalConf = function(type,controller,data)
-{
-	var self=this;
-	return self.commandRouter.executeOnPlugin(type,controller,'getConfigParam',data);
-}
+ControllerMpd.prototype.getAdditionalConf = function (type, controller, data) {
+	var self = this;
+	return self.commandRouter.executeOnPlugin(type, controller, 'getConfigParam', data);
+};
 
-ControllerMpd.prototype.setAdditionalConf = function(type,controller,data)
-{
-	var self=this;
-	return self.commandRouter.executeOnPlugin(type,controller,'setConfigParam',data);
-}
+ControllerMpd.prototype.setAdditionalConf = function (type, controller, data) {
+	var self = this;
+	return self.commandRouter.executeOnPlugin(type, controller, 'setConfigParam', data);
+};
 
-ControllerMpd.prototype.getMyCollectionStats=function()
-{
-	var self=this;
+ControllerMpd.prototype.getMyCollectionStats = function () {
+	var self = this;
 
-	var defer=libQ.defer();
+	var defer = libQ.defer();
 
 	var cmd = libMpd.cmd;
-	self.clientMpd.sendCommand(cmd("count", ["group","artist"]), function(err, msg) {
+	self.clientMpd.sendCommand(cmd("count", ["group", "artist"]), function (err, msg) {
 		if (err) defer.resolve({
-			artists:0,
-			albums:0,
-			songs:0,
-			playtime:'00:00:00'
+			artists: 0,
+			albums: 0,
+			songs: 0,
+			playtime: '00:00:00'
 		});
-		else{
-			var artistsCount=0;
-			var songsCount=0;
-			var playtimesCount=0;
+		else {
+			var artistsCount = 0;
+			var songsCount = 0;
+			var playtimesCount = 0;
 
-			var splitted=msg.split('\n');
-			for(var i=0;i< splitted.length-1;i=i+3)
-			{
+			var splitted = msg.split('\n');
+			for (var i = 0; i < splitted.length - 1; i = i + 3) {
 				artistsCount++;
-				songsCount=songsCount+parseInt(splitted[i+1].substring(7));
-				playtimesCount=playtimesCount+parseInt(splitted[i+2].substring(10));
+				songsCount = songsCount + parseInt(splitted[i + 1].substring(7));
+				playtimesCount = playtimesCount + parseInt(splitted[i + 2].substring(10));
 			}
 
-			var convertedSecs=convert(playtimesCount);
+			var convertedSecs = convert(playtimesCount);
 
 
-
-			self.clientMpd.sendCommand(cmd("count", ["group","album"]), function(err, msg) {
-				if (!err)
-				{
-					var splittedAlbum=msg.split('\n').length;
-					var response={
-						artists:artistsCount,
-						albums:(splittedAlbum-1)/3,
-						songs:songsCount,
-						playtime:convertedSecs.hours+':'+convertedSecs.minutes+':'+convertedSecs.seconds
+			self.clientMpd.sendCommand(cmd("count", ["group", "album"]), function (err, msg) {
+				if (!err) {
+					var splittedAlbum = msg.split('\n').length;
+					var response = {
+						artists: artistsCount,
+						albums: (splittedAlbum - 1) / 3,
+						songs: songsCount,
+						playtime: convertedSecs.hours + ':' + convertedSecs.minutes + ':' + convertedSecs.seconds
 					};
 				}
 
@@ -1553,29 +1519,43 @@ ControllerMpd.prototype.getMyCollectionStats=function()
 	});
 	return defer.promise;
 
-}
+};
 
 
-ControllerMpd.prototype.rescanDb=function()
-{
-	var self=this;
+ControllerMpd.prototype.rescanDb = function () {
+	var self = this;
 
 	return self.sendMpdCommand('rescan', []);
-}
+};
 
-ControllerMpd.prototype.saveAlsaOptions = function(data) {
+ControllerMpd.prototype.saveAlsaOptions = function (data) {
 
 	var self = this;
 
 	var defer = libQ.defer();
 
-	self.commandRouter.sharedVars.set('alsa.outputdevice',data.output_device.value);
-	self.config.set('outputdevice',data.output_device.value);
+	self.commandRouter.sharedVars.set('alsa.outputdevice', data.output_device.value);
 
-	self.commandRouter.pushToastMessage('success',"Configuration update",'The configuration has been successfully updated');
+	self.createMPDFile(function (error) {
+		if (error !== undefined && error !== null) {
+			self.commandRouter.pushToastMessage('error', "Configuration update", 'Error while Applying new configuration');
+			defer.resolve({});
+		}
+		else {
+			self.commandRouter.pushToastMessage('success', "Configuration update", 'The output device has been successfully updated');
 
-	defer.resolve({});
+			self.restartMpd(function (error) {
+				if (error !== null && error != undefined) {
+					self.logger.info('Cannot restart MPD: ' + error);
+					self.commandRouter.pushToastMessage('error', "Player restart", 'Error while restarting player');
+				}
+				else self.commandRouter.pushToastMessage('success', "Player restart", 'Player successfully restarted');
+
+				defer.resolve({});
+			});
+		}
+	});
 
 	return defer.promise;
 
-}
+};


### PR DESCRIPTION
**Functionality**
When searching through the sound card directory (/proc/asound/) the sound card numbers no longer need to be sequential. All cards with directories of the form card(\d+) and id files inside will be made available as Alsa cards.

The Audio device names are shown in a human readable form - coming from the card<>/id file instead of the card<>/pcm0p/infor file. this means instead of multiple 'USB Audio' entries in the UI you can actually see what USB audio device is being referred to.

After saving the new output device in the UI the mpd.conf file is updated.

After saving the new mpd.conf file an attempt is made to restart mpd and use the new config.

**File Permissions**
In the current distribution of volumio the mpd.conf file is read-write for user:mpd and read-only for group:audio. This means that user:volumio cannot update the mpd.conf file unless you change the permissions for the mpd.conf file by adding group write permissions

sudo chmod g+w /etc/mpd.conf

I do not know if thias is what is wanted, nor how to update it in the distribution so that it works out of the box.

Additionally the /etc directory does not allow anybody to write new things to it and so the /tmp directory is now used for the mpd.conf.old backup - which is actually the correct directory for such things anyway.

**Access Permissions**
The attempt to restart mpd does not work for the volumio user as they do not seem to have permission to do it. Again this is not a source code issue and so I am sending you this pull request. I am going to look into allowing user:volumio to restart mpd, and let you know if I find  way.

**this and self**
There seems to be some confusion in the volumio source code about the usage of self (apologies if there are not).

A 'self' reference to 'this' only needs to be created in an outer scope when it is to be passed into a callback function with an inner scope that will be resolved later. 

IMHO It is actually quite confusing to read all the 'self' references when 'this' would be correct.
IMHO Only using 'self' when it is needed makes the code easier to understand.

In the spirit of this I have change the alsa contrroller index.js to only use 'self' where it is actually needed. I think the code is cleaner, simpler and easier to understand (with less lines :-) )

What are your thoughts?


