### PR TITLE
Play Queue Simplification?

### DIFF
--- a/app/playqueue.js
+++ b/app/playqueue.js
@@ -1,56 +1,41 @@
+'use strict';
+
 var libQ = require('kew');
 var libFast = require('fast.js');
 
 // Define the CorePlayQueue class
 module.exports = CorePlayQueue;
 function CorePlayQueue(commandRouter, stateMachine) {
-	var self = this;
-
-	self.commandRouter = commandRouter;
-	self.stateMachine = stateMachine;
-
-	self.queueReadyDeferred = libQ.defer();
-	self.queueReady = self.queueReadyDeferred.promise;
-
-	self.arrayQueue = [];
-
-	self.queueReadyDeferred.resolve();
-
-
+	this.commandRouter = commandRouter;
+	this.stateMachine = stateMachine;
+	this.arrayQueue = [];
 }
 
 // Public Methods ---------------------------------------------------------------------------------------
 // These are 'this' aware, and return a promise
 
 // Get a promise for contents of play queue
-CorePlayQueue.prototype.getQueue = function() {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::getQueue');
-
-	return self.queueReady
-		.then(function() {
-			//self.commandRouter.pushConsoleMessage(self.arrayQueue);
-			return self.arrayQueue;
-		});
+CorePlayQueue.prototype.getQueue = function () {
+	this.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::getQueue');
+	return this.arrayQueue;
 };
 
 // Get a array of contiguous trackIds which share the same service, starting at nStartIndex
-CorePlayQueue.prototype.getTrackBlock = function(nStartIndex) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::getTrackBlock');
+CorePlayQueue.prototype.getTrackBlock = function (nStartIndex) {
+	this.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::getTrackBlock');
 
-	var sTargetService = self.arrayQueue[nStartIndex].service;
+	var sTargetService = this.arrayQueue[nStartIndex].service;
 	var nEndIndex = nStartIndex;
+	var nToCheck = this.arrayQueue.length - 1;
 
-	while (nEndIndex < self.arrayQueue.length - 1) {
-		if (self.arrayQueue[nEndIndex + 1].service !== sTargetService) {
+	while (nEndIndex < nToCheck) {
+		if (this.arrayQueue[nEndIndex + 1].service !== sTargetService) {
 			break;
 		}
-
 		nEndIndex++;
 	}
 
-	var arrayUris = libFast.map(self.arrayQueue.slice(nStartIndex, nEndIndex + 1), function(curTrack) {
+	var arrayUris = libFast.map(this.arrayQueue.slice(nStartIndex, nEndIndex + 1), function (curTrack) {
 		return curTrack.uri;
 	});
 
@@ -58,39 +43,24 @@ CorePlayQueue.prototype.getTrackBlock = function(nStartIndex) {
 };
 
 // Removes one item from the queue
-CorePlayQueue.prototype.removeQueueItem = function(nIndex) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::removeQueueItem');
-
-	return self.queueReady
-		.then(function() {
-			self.arrayQueue.splice(nIndex, 1);
-			return self.commandRouter.volumioPushQueue(self.arrayQueue);
-		});
+CorePlayQueue.prototype.removeQueueItem = function (nIndex) {
+	this.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::removeQueueItem');
+	this.arrayQueue.splice(nIndex, 1);
+	return this.commandRouter.volumioPushQueue(this.arrayQueue);
 };
 
 // Add one item to the queue
-CorePlayQueue.prototype.addQueueItems = function(arrayItems) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::addQueueItems');
-
-	return self.queueReady
-		.then(function() {
-			self.arrayQueue = self.arrayQueue.concat(arrayItems);
-			return self.commandRouter.volumioPushQueue(self.arrayQueue);
-		});
+CorePlayQueue.prototype.addQueueItems = function (arrayItems) {
+	this.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::addQueueItems');
+	this.arrayQueue = this.arrayQueue.concat(arrayItems);
+	return this.commandRouter.volumioPushQueue(this.arrayQueue);
 };
 
-CorePlayQueue.prototype.clearPlayQueue = function() {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::clearPlayQueue');
+CorePlayQueue.prototype.clearPlayQueue = function () {
+	this.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'CorePlayQueue::clearPlayQueue');
+	return this.arrayQueue = [];
+};
 
-	return self.arrayQueue = [];
-}
-
-CorePlayQueue.prototype.clearMpdQueue = function() {
-
-	var self = this;
-	return self.commandRouter.executeOnPlugin('music_service', 'mpd', 'clear');
-
-}
+CorePlayQueue.prototype.clearMpdQueue = function () {
+	return this.commandRouter.executeOnPlugin('music_service', 'mpd', 'clear');
+};

--- a/app/plugins/user_interfaces/websocket/index.js
+++ b/app/plugins/user_interfaces/websocket/index.js
@@ -64,11 +64,9 @@ function InterfaceWebUI(context) {
 				var selfConnWebSocket = this;
 
 				var timeStart = Date.now();
+				var queue = self.commandRouter.volumioGetQueue();
 				self.logStart('Client requests Volumio queue')
-					.then(self.commandRouter.volumioGetQueue.bind(self.commandRouter))
-					.then(function (queue) {
-						return self.pushQueue.call(self, queue, selfConnWebSocket);
-					})
+					.then(self.pushQueue.bind(self, queue, selfConnWebSocket))
 					.fail(self.pushError.bind(self))
 					.done(function () {
 						return self.logDone(timeStart);


### PR DESCRIPTION
I noticed that in CorePlayQueue constructor there was a promise created for the play queue which is immediately resolved. 

```
       var self = this;

	self.commandRouter = commandRouter;
	self.stateMachine = stateMachine;

	self.queueReadyDeferred = libQ.defer();
	self.queueReady = self.queueReadyDeferred.promise;

	self.arrayQueue = [];

	self.queueReadyDeferred.resolve();

```
This promise was then returned every time that the play queue was accessed (adding, removing items and retrieving).

The add and remove items in particular wrapped another promise in this pre-resolved promise

```
return self.queueReady
		.then(function() {
			self.arrayQueue.splice(nIndex, 1);
			return self.commandRouter.volumioPushQueue(self.arrayQueue);
		});
```

This seems entirely unnecessary.

I have removed this pre-resolved promise and made the getQueue method syncronous. I also return the volumioPushQueue promises directly.

This all works and has had the side effect of fixing an issue where albums being added to the queue would show up multiple time (but I don't know how).


Now, it is possible that the pre-resolved promise is there for some future reason that I am unaware of, and so you may not want to do this. I think it is better and simpler now, and it has a side effect of fixing the issue mentioned.

Let me know