### PR TITLE
capital letters are preserved, using serviceName when possible

### DIFF
--- a/app/plugins/system_controllers/volumiodiscovery/index.js
+++ b/app/plugins/system_controllers/volumiodiscovery/index.js
@@ -121,12 +121,14 @@ ControllerVolumioDiscovery.prototype.startAdvertisement=function()
 		console.log("Discovery: Started advertising... " + name + " - "  + forceRename);
 
 		self.ad = mdns.createAdvertisement(mdns.tcp(serviceName), servicePort, {txtRecord: txt_record}, function (error, service) {
-			if ((service.name != name) && (!forceRename)) {
+			var lowerServer = serviceName.toLowerCase()
+			var theName = service.name.replace(lowerServer,serviceName)
+			if ((theName != name) && (!forceRename)) {
 				console.log("Discovery: Changing my name to " + service.name + " CINGHIALE is " + forceRename);
-				systemController.setConf('playerName', service.name);
+				systemController.setConf('playerName', theName);
 
 				self.ad.stop();
-				txt_record.volumioName = service.name;
+				txt_record.volumioName = theName;
 				setTimeout(
 					function () {
 						self.ad = mdns.createAdvertisement(mdns.tcp(serviceName), servicePort, {txtRecord: txt_record}, function (error, service) {


### PR DESCRIPTION
Please not the config.json value "service" (AKA serviceName in the volumiodiscovery plugin) is used as a template for name capitalisation. so if "service" is "vOlumio" you'll have device names "vOlumio", "vOlumio-2", "vOlumio-3" and so on. If the name is changed by user, no capitalisation is done (unless the name give by the user contain the serviceName. For example if the user call it aGoodvolumio, it may be changed to aGoodvOlumio during subsequent reboots.