### PR TITLE
Display leading 0 for single digit minutes and seconds of Playtime

### DIFF
--- a/app/plugins/music_services/mpd/index.js
+++ b/app/plugins/music_services/mpd/index.js
@@ -1398,7 +1398,7 @@ ControllerMpd.prototype.getMyCollectionStats = function () {
 						artists: artistsCount,
 						albums: (splittedAlbum - 1) / 3,
 						songs: songsCount,
-						playtime: convertedSecs.hours + ':' + convertedSecs.minutes + ':' + convertedSecs.seconds
+						playtime: convertedSecs.hours + ':' + ('0' + convertedSecs.minutes).slice(-2) + ':' + ('0' + convertedSecs.seconds).slice(-2)
 					};
 				}
 


### PR DESCRIPTION
i.e. Display 125:04:08 instead of 125:4:8