### PR TITLE
add ST400 DAC - Amp board

### DIFF
--- a/app/plugins/system_controllers/i2s_dacs/dacs.json
+++ b/app/plugins/system_controllers/i2s_dacs/dacs.json
@@ -6,6 +6,7 @@
     {"id":"hifiberry-amp","name":"Hifiberry Amp","overlay":"hifiberry-amp","alsanum":"1","mixer":"Digital","modules":"","script":""},
     {"id":"hifiberry-digi","name":"Hifiberry DIGI","overlay":"hifiberry-digi","alsanum":"1","mixer":"","modules":"","script":""},
     {"id":"iqaudio-dacplus","name":"IQaudIO DAC Plus","overlay":"iqaudio-dacplus","alsanum":"1","mixer":"Digital","modules":"","script":""},
+    {"id":"st400-dac-amp","name":"ST400 Dac (PCM5122) - Amp","overlay":"iqaudio-dacplus","alsanum":"1","mixer":"Digital","modules":"","script":""},
     {"id":"mamboberry-dac","name":"Mamboberry HiFi DAC+","overlay":"hifiberry-dac","alsanum":"1","mixer":"Digital","modules":"","script":""}
   ]},
   {"name":"Raspberry PI","data":[


### PR DESCRIPTION
add ST400 dac (pcm5122) - amp : http://www.audiophonics.fr/en/raspberry-pi/st-400-hat-module-class-d-amp-headphone-amp-dac-pcm5122-24bit192khz-p-10248.html