### PR TITLE
Fix syntax in hostapd*.conf if hotspot is disabled in volumio settings.

### DIFF
--- a/app/plugins/system_controller/network/index.js
+++ b/app/plugins/system_controller/network/index.js
@@ -461,7 +461,7 @@ ControllerNetwork.prototype.rebuildHotspotConfig = function () {
 						}
 					}
 					else {
-						ws.write(' ');
+						ws.write('# hotspot disabled\n');
 					}
 
 					ws.end();
@@ -500,7 +500,7 @@ ControllerNetwork.prototype.rebuildHotspotConfig = function () {
 					}
 				}
 				else {
-					hs.write(' ');
+					hs.write('# hotspot disabled\n');
 				}
 
 				hs.end();


### PR DESCRIPTION
Hostapd will ignore 'empty' lines or those beginning with '#'.
A line with a single space is not treated as 'empty', hostapd tries to
interpret it and gives an error. So replace it with a comment line that
explains the situation.