### PR TITLE
Added missing Shebang line

### DIFF
--- a/app/plugins/system_controller/volumio_command_line_client/commands/playback.js
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/playback.js
@@ -1,3 +1,4 @@
+#!/bin/node
 var io=require('socket.io-client');
 var socket= io.connect('http://localhost:3000');
 var command = process.argv.slice(2);


### PR DESCRIPTION
I added the missing header line in [playback.js](https://github.com/volumio/Volumio2/blob/master/app/plugins/system_controller/volumio_command_line_client/commands/playback.js), wich prevented commands like `volumio next` from working.