### PR TITLE
Handle undefined or 'blank' share alias

### DIFF
--- a/app/i18n/strings_ca.json
+++ b/app/i18n/strings_ca.json
@@ -40,6 +40,9 @@
     "WIRELESS_RESTART_ERROR":"Error en reiniciar la xarxa:",
     "WIRELESS_RESTART_SUCCESS":"Adaptador WiFi reiniciat amb èxit"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Triar un àlies que es mostrarà en muntar NAS"
+  },
   "PLAYLIST":{
     "ADDED_TITLE":"Afegit",
     "ADDED_TO_PLAYLIST":" a la llista de reproducció",

--- a/app/i18n/strings_da.json
+++ b/app/i18n/strings_da.json
@@ -40,6 +40,9 @@
     "WIRELESS_RESTART_ERROR": "Fejl ved genstart af trådløst netværk: ",
     "WIRELESS_RESTART_SUCCESS": "Genstart af trådløst netværk lykkedes"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Vælg et alias som vil blive vist i menupunktet NAS mounts"
+  },
   "PLAYLIST":{
   "ADDED_TITLE":"Tilføjet",
   "ADDED_TO_PLAYLIST":" til afspilningsliste ",

--- a/app/i18n/strings_de.json
+++ b/app/i18n/strings_de.json
@@ -40,6 +40,9 @@
 	"WIRELESS_RESTART_ERROR": "Fehler beim Neustarten des Funknetzwerks: ",
 	"WIRELESS_RESTART_SUCCESS": "Funknetzwerk erfolgreich neu gestartet"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Name auswählen der in den NAS-Mounts angezeigt wird"
+  },
   "PLAYLIST":{
 	"ADDED_TITLE":"Hinzugefügt",
 	"ADDED_TO_PLAYLIST":" zu Wiedergabeliste ",

--- a/app/i18n/strings_en.json
+++ b/app/i18n/strings_en.json
@@ -52,6 +52,9 @@
     "HOTSPOT_CONF_ERROR":"Hotspot Configuration Error",
     "HOTSPOT_PW_LENGTH":"Hotspot Password must be at least 8 characters long"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Choose an Alias that will be displayed in NAS Mounts"
+  },
   "PLAYLIST":{
     "ADDED_TITLE":"Added",
     "ADDED_TO_PLAYLIST":" to playlist ",

--- a/app/i18n/strings_es.json
+++ b/app/i18n/strings_es.json
@@ -40,6 +40,9 @@
     "WIRELESS_RESTART_ERROR": "Error al reiniciar la red: ",
     "WIRELESS_RESTART_SUCCESS": "Adaptador WiFi reiniciado con éxito"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Elige el alias para esta ruta que se mostrará en la biblioteca"
+  },
   "PLAYLIST":{
   "ADDED_TITLE":"Añadido",
   "ADDED_TO_PLAYLIST":" a la lista de reproducción ",

--- a/app/i18n/strings_fi.json
+++ b/app/i18n/strings_fi.json
@@ -41,6 +41,9 @@
 	"WIRELESS_RESTART_ERROR": "Virhe käynnistettäessä langatonta verkkoa: ",
 	"WIRELESS_RESTART_SUCCESS": "Langattoman uudelleenkäynnistys onnistui"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Valitse käytettävän verkkoaseman alias."
+  },
   "PLAYLIST":{
 	"ADDED_TITLE":"Lisätty",
 	"ADDED_TO_PLAYLIST":" soittolistaan ",

--- a/app/i18n/strings_fr.json
+++ b/app/i18n/strings_fr.json
@@ -52,6 +52,9 @@
     "HOTSPOT_CONF_ERROR":"Erreur de configuration du Hotspot",
     "HOTSPOT_PW_LENGTH":"Le mot de passe du Hotspot doit faire au moins 8 caractètres"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Choisir un le nom qui sera affiché dans les disques NAS montés"
+  },
     "PLAYLIST":{
     "ADDED_TITLE":"Ajouté",
     "ADDED_TO_PLAYLIST":" à la playlist ",

--- a/app/i18n/strings_it.json
+++ b/app/i18n/strings_it.json
@@ -48,6 +48,9 @@
 	"HOTSPOT_CONF_ERROR":"Errore di configurazione dell'Hotspot",
 	"HOTSPOT_PW_LENGTH":"La password dell'hotspot deve contenere almeno 8 caratteri"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Scegli un alias che verrà mostrato alla voce NAS"
+  },
   "PLAYLIST":{
     "ADDED_TITLE":"Aggiunta",
     "ADDED_TO_PLAYLIST":" alla Playlist ",

--- a/app/i18n/strings_ja.json
+++ b/app/i18n/strings_ja.json
@@ -40,6 +40,9 @@
     "WIRELESS_RESTART_ERROR": "無線ネットワーク再起動中にエラー発生: ",
     "WIRELESS_RESTART_SUCCESS": "無線ネットワーク再起動に成功"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"NAS マウントに表示されるエイリアスの選択"
+  },
   "PLAYLIST":{
   "ADDED_TITLE":"追加済み",
   "ADDED_TO_PLAYLIST":" プレイリストに ",

--- a/app/i18n/strings_nl.json
+++ b/app/i18n/strings_nl.json
@@ -40,6 +40,9 @@
     "WIRELESS_RESTART_ERROR": "Error bij herstarten draadloos netwerk: ",
     "WIRELESS_RESTART_SUCCESS": "Draadloos netwerk succesvol herstart"
   },
+  "NETWORK":{
+    "ALIAS_DOC":"Kies een Alias die weergegeven wordt in NAS Mounts"
+  },
   "PLAYLIST":{
   "ADDED_TITLE":"Toegevoegd",
   "ADDED_TO_PLAYLIST":" aan Afspeellijst ",

--- a/app/i18n/strings_pl.json
+++ b/app/i18n/strings_pl.json
@@ -40,6 +40,9 @@
 	"WIRELESS_RESTART_ERROR": "Błąd podczas restartu usług komunikacji bezprzewodowej: ",
 	"WIRELESS_RESTART_SUCCESS": "Usługi komunikacji bezprzewodowej uruchomione poprawnie"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Nadaj nazwę zasobu"
+  },
   "PLAYLIST":{
 	"ADDED_TITLE":"Dodane",
 	"ADDED_TO_PLAYLIST":" do listy odtwarzania ",

--- a/app/i18n/strings_pt.json
+++ b/app/i18n/strings_pt.json
@@ -50,6 +50,9 @@
     "HOTSPOT_CONF_ERROR":"Erro na configuração do Hotspot",
     "HOTSPOT_PW_LENGTH":"Palavra Chave do Hotspot tem de ter pelo menos 8 caracteres"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Escolher um Pseudónimo para mostrar nas NAS montadas"
+  },
   "PLAYLIST":{
     "ADDED_TITLE":"Adicionada",
     "ADDED_TO_PLAYLIST":" á Lista de Reprodução ",

--- a/app/i18n/strings_sv.json
+++ b/app/i18n/strings_sv.json
@@ -41,6 +41,9 @@
     "WIRELESS_RESTART_ERROR": "Ett fel inträffade när det trådlösa nätverket startades om: ",
     "WIRELESS_RESTART_SUCCESS": "Det trådlösa nätverket startades om korrekt"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"Välj ett  Alias som kommer att visas i NAS listan"
+  },
   "PLAYLIST":{
     "ADDED_TITLE":"Lade till",
     "ADDED_TO_PLAYLIST":" till spellistan ",

--- a/app/i18n/strings_zh.json
+++ b/app/i18n/strings_zh.json
@@ -41,6 +41,9 @@
     "WIRELESS_RESTART_ERROR": "重启无线网络发生错误: ",
     "WIRELESS_RESTART_SUCCESS": "成功重启无线网络"
   },
+  "NETWORKFS":{
+    "ALIAS_DOC":"选择一个别名显示在NAS的挂载点中"
+  },
   "PLAYLIST":{
   "ADDED_TITLE":"已添加",
   "ADDED_TO_PLAYLIST":" 到播放列表 ",

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -291,8 +291,20 @@ ControllerNetworkfs.prototype.addShare = function (data) {
 	var defer = libQ.defer();
 
 	var name = data['name'];
-	var nameStr = S(name);
+	/*
+	 * A name is required. In the ui this field is called 'alias'.
+	 */
+	if (name == undefined) name = '';
+	var blankname_regex = /^\s*$/;
+	var matches = blankname_regex.exec(name);
+	if (matches) {
+		self.logger.info("Share alias is blank");
+		self.commandRouter.pushToastMessage('warning', self.commandRouter.getI18nString('COMMON.MY_MUSIC'), self.commandRouter.getI18nString('NETWORKFS.ALIAS_DOC'));
+		defer.reject(new Error('Shares must have an alias'));
+		return defer.promise;
+	}
 
+	var nameStr = S(name);
 
 	/**
 	 * Check special characters


### PR DESCRIPTION
If the user fails to type anything in the 'Alias' field of
network-drives-add-edit-drive.html then addShare fails with the following
somewhat obscure error in the logs:
    Missing error handler on `socket`.
    TypeError: Cannot read property 'indexOf' of undefined
and no indication to the user of what the problem is (particularly if this
is their first attempt to add a network drive).
In addition, the share is not mounted.

Fix by making sure 'name' is always defined and raising a warning in the webui
when 'name' is empty or all-spaces. To get a displayable warning I had to copy NETWORKFS.ALIAS_DOC from the webui into the string list.