### PR TITLE
mount.cifs fails if given '//server//path'; so clean up the input path 

### DIFF
--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -326,6 +326,14 @@ ControllerNetworkfs.prototype.addShare = function (data) {
 	if (password == undefined) password = '';
 	if (options == undefined) options = '';
 
+	if (fstype == 'cifs') {
+		/* when the share is mounted the ip and path are joined with '/'.
+		 * mount.cifs can fail if given '//server//path', so let's avoid that.
+		 */
+		path = path.replace(/\/+/g,'/');
+		path = path.replace(/^\//,'');
+	}
+
 	var uuid = self.getShare(name, ip, path);
 	var response;
 	if (uuid == undefined) {


### PR DESCRIPTION
It seems best to just silently fix the mistake than bother the user with popups (that would have to be translated).