### PR TITLE
Avoid NaN results when NAS path has spaces in it. Fixes #856.

### DIFF
--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -473,7 +473,6 @@ ControllerNetworkfs.prototype.listShares = function (data) {
 
 	var response = [];
 	var size = '';
-	var unity = '';
 	var defer = libQ.defer();
 
 	var shares = config.getKeys('NasMounts');
@@ -501,9 +500,31 @@ ControllerNetworkfs.prototype.listShares = function (data) {
 	return defer.promise;
 };
 
+// Library function based on
+// http://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-by
+// tes-to-kb-mb-gb-in-javascript
+// http://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable
+ControllerNetworkfs.prototype.formatBytes = function (bytes, decimals, SIunits) {
+	if ( isNaN(bytes) ) return 'NaN';
+	var dm = Math.abs(decimals) + 0 || 3;
+	var thresh = SIunits ? 1000 : 1024;
+	if (Math.abs(bytes) < thresh) {
+	    return bytes.toFixed(dm) + ' B';
+	}
+	var units = SIunits
+	    ? ['kB','MB','GB','TB','PB','EB','ZB','YB']
+	    : ['KiB','MiB','GiB','TiB','PiB','EiB','ZiB','YiB'];
+	var u = -1;
+	do {
+	    bytes /= thresh;
+	    ++u;
+	} while(Math.abs(bytes) >= thresh && u < units.length - 1);
+	return bytes.toFixed(dm) + ' ' + units[u];
+};
+
 ControllerNetworkfs.prototype.getMountSize = function (share) {
+	var self = this;
 	return new Promise(function (resolve, reject) {
-		var realsize = '';
 		var key = 'NasMounts.' + share + '.';
 		var name = config.get(key + 'name');
 		var mountpoint = '/mnt/NAS/' + name;
@@ -518,28 +539,18 @@ ControllerNetworkfs.prototype.getMountSize = function (share) {
 			password: config.get(key + 'password'),
 			options: config.get(key + 'options'),
 			mounted: mounted.mounted,
-			size: realsize
+			size: ''
 		};
-		var cmd="df -BM "+mountpoint+" | awk '{print $3}'";
+		// cmd returns size in bytes with no units and no header line
+		var cmd="df -B1 --output=used '"+mountpoint+"' | tail -1";
 		var promise = libQ.ncall(exec,respShare,cmd).then(function (stdout){
 
+			var splitted = stdout.split('\n');
+			var sizeStr = splitted[0];
 
-			var splitted=stdout.split('\n');
-			var sizeStr=splitted[1];
-
-			var size=parseInt(sizeStr.substring(0,sizeStr.length-1));
-
-			var unity = 'MB';
-			if (size > 1024) {
-				size = size / 1024;
-				unity = 'GB';
-				if (size > 1024) {
-					size = size / 1024;
-					unity = 'TB';
-				}
-			}
-			realsize = size.toFixed(2);
-			respShare.size = realsize + " " + unity ;
+			var bytes = parseInt(sizeStr);
+			// format with 2 decimal places and binary units
+			respShare.size = self.formatBytes(bytes, 2, false);
 			resolve(respShare);
 
 		}).fail(function (e){


### PR DESCRIPTION
Add quoting to the mountpoint path and avoid printing the NAS's
export path, so that we reliably get a raw number back from 'df'.
Add formatBytes() function, to give a size string suitable for
display in the UI.

This PR replaces 869, which I will ditch shortly.
This version has been tested and actually works on my system which is at this revision:
```
commit 3aedc4d9179c081941d69f0b05f06d81ea07d2d8
Author: Ghembs <ggambacorta88@gmail.com>
Date:   Wed Nov 23 15:49:21 2016 +0000

    broadcast methods rest api
```
As noted before, the [Numeral](http://numeraljs.com/) module might be a better way to implement formatBytes().