### PR TITLE
Don't allow volume to be stepped below zero. Fixes #857

### DIFF
--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -212,6 +212,9 @@ CoreVolumeController.prototype.alsavolume = function (VolumeInteger) {
 						vol =  currentvolume
 					}
 					VolumeInteger = Number(vol)+Number(volumesteps);
+					if (VolumeInteger < 0){
+						VolumeInteger = 0;
+					}
 					if (VolumeInteger > maxvolume){
 						VolumeInteger = maxvolume;
 					}
@@ -235,6 +238,9 @@ CoreVolumeController.prototype.alsavolume = function (VolumeInteger) {
 					vol =  currentvolume
 				}
 				VolumeInteger = Number(vol)-Number(volumesteps);
+				if (VolumeInteger < 0){
+					VolumeInteger = 0;
+				}
 				if (VolumeInteger > maxvolume){
 					VolumeInteger = maxvolume;
 				}


### PR DESCRIPTION
I was able to reproduce this easily and the obvious fix seems to work. Not tested with a DAC, just onboard analog out.