### PR TITLE
Improve the message logged when albumart lookup fails

### DIFF
--- a/app/plugins/miscellanea/albumart/albumart.js
+++ b/app/plugins/miscellanea/albumart/albumart.js
@@ -92,7 +92,7 @@ var searchOnline = function (defer, web) {
 			if (err) {
 				albumart(artist, function (err, url) {
 					if (err) {
-						console.log("ERRORE: " + err);
+						console.log("ERROR getting albumart: " + err + " for Infopath '" + infoPath + "'");
 						defer.reject(new Error(err));
 						return defer.promise;
 					}


### PR DESCRIPTION
Make it clear the error is related to albumart, and log the infoPath
that caused the problem. This change was triggered by trying to understand
where messages like
  ERRORE: Got error: The artist you supplied could not be found
were coming from.