### PR TITLE
Kernelsource

### DIFF
--- a/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
@@ -57,7 +57,7 @@ fi
 echo volumio | sudo -S make modules_prepare
 echo "Linking Modules"
 echo volumio | sudo -S ln -sv /usr/src/rpi-linux /lib/modules/$(uname -r)/build
-echo Â" "
+echo " "
 echo "Done, you can now build and install out of kernel modules"
 }
 

--- a/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
@@ -51,7 +51,7 @@ echo volumio | sudo -S gunzip -c /proc/config.gz >.config
 echo "Copying modules symverse"
 if [ "$ARCH" = armv7l ]; then
  echo volumio | sudo -S cp /home/volumio/Module7.symvers Module.symvers
- else
+else
  echo volumio | sudo -S cp /home/volumio/Module.symvers Module.symvers
 fi
 echo volumio | sudo -S make modules_prepare

--- a/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
@@ -16,7 +16,7 @@ echo "Checking if build essential is installed"
 if [ $(dpkg-query -W -f='${Status}' make 2>/dev/null | grep -c "ok installed") -eq 0 ];
 then
   echo "Installing build essential"
-  echo volumio | sudo -S apt-get update && apt-get install -y build-essential bc;
+  sudo apt-get update && sudo apt-get install -y build-essential bc;
 fi
 
 cd /home/volumio
@@ -41,7 +41,7 @@ echo "creating /usr/src/rpi-linux folder"
 echo volumio | sudo -S mkdir /usr/src/rpi-linux
 
 echo "Extracting Kernel"
-echo volumio | sudo -S tar --strip-components 1 -xf rpi-linux.tar.gz -C /usr/src/rpi-linux
+sudo tar --strip-components 1 -xf rpi-linux.tar.gz -C /usr/src/rpi-linux
 cd /usr/src/rpi-linux
 
 echo "Cloning current config"

--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -140,18 +140,15 @@ case "$1" in
                 volumeget
             fi
             ;;
-	pull)
+		pull)
             pull
             ;;
-	kernelsource)
-	    kernelsource
+		kernelsource)
+		    kernelsource
             ;;
-        *)
+		*)
             doc
             exit 1
-
+            ;;
 esac
-
-
-
 

--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -140,13 +140,13 @@ case "$1" in
                 volumeget
             fi
             ;;
-		pull)
+        pull)
             pull
             ;;
-		kernelsource)
-		    kernelsource
+        kernelsource)
+            kernelsource
             ;;
-		*)
+        *)
             doc
             exit 1
             ;;

--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -69,26 +69,26 @@ echo $var
 #VOLUMIO SERVICE CONTROLS
 
 function start {
-echo volumio | sudo -S systemctl start volumio.service
+sudo systemctl start volumio.service
 }
 
 function vstop {
-echo volumio | sudo -S systemctl stop volumio.service
+sudo systemctl stop volumio.service
 }
 
 #VOLUMIO DEVELOPMENT
 
 function pull {
 echo "Stopping Volumio"
-echo volumio | sudo -S systemctl stop volumio.service
-echo volumio | sudo -S sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/pull.sh
+sudo systemctl stop volumio.service
+sudo /volumio/app/plugins/system_controller/volumio_command_line_client/commands/pull.sh
 echo "Pull completed, restarting Volumio"
-echo volumio | sudo -S systemctl start volumio.service
+sudo systemctl start volumio.service
 echo "Done"
 }
 
 function kernelsource {
-echo volumio | sudo -S sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
+sudo /volumio/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
 }
 
 


### PR DESCRIPTION
This addresses #904 but I don't know for sure that it works. I don't see anywhere in 2.031 that I can call the 'volumio.sh' script from the UI, and 'which volumio' doesn't find anything.