### PR TITLE
add driver=nl80211 in hostapd.conf

### DIFF
--- a/app/plugins/system_controller/network/index.js
+++ b/app/plugins/system_controller/network/index.js
@@ -622,6 +622,7 @@ ControllerNetwork.prototype.rebuildHotspotConfig = function () {
 					hs.write('interface=wlan0\n');
 					hs.write('ssid=' + hotspotname + '\n');
 					hs.write('channel=' + hotspotchannel + '\n');
+					ws.write('driver=nl80211\n');
 					hs.write('hw_mode=g\n');
 					if (config.get('hotspot_protection') == true || config.get('hotspot_protection') == 'true') {
 						hs.write('auth_algs=1\n');


### PR DESCRIPTION
to be consistent with https://github.com/volumio/Build/pull/114
BTW it very much seems hostapd.tmpl in build  (https://github.com/macmpi/Build/blob/master/scripts/volumioconfig.sh#L419) does not serve much purpose.