### PR TITLE
Adding pisound to dacs.json

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -22,6 +22,7 @@
     {"id":"mamboberry-dac","name":"Mamboberry HiFi DAC+","overlay":"hifiberry-dac","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"phat-dac","name":"pHAT DAC","overlay":"hifiberry-dac","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"picade-hat","name":"Picade HAT","overlay":"hifiberry-dac","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes","eeprom_name":["Picade HAT"]},
+    {"id":"pisound","name":"pisound","overlay":"pisound","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"no"},
     {"id":"raspidacv3","name":"RaspiDACv3","overlay":"raspidac3","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"rpi-dac","name":"R-PI DAC","overlay":"rpi-dac","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"soekris-dac","name":"Soekris dam 1021","overlay":"hifiberry-dac","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"},


### PR DESCRIPTION
Adding pisound (http://blokas.io/pisound) to volumio.

Note that the latest pisound module code is available in 4.4.41 RPI kernel version.

Also I found that if switching from dac with 'needsreboot=yes' to 'needsreboot=no', reboot should still happen, without it, the output doesn't work.