### PR TITLE
Fixes Repeat mode in the State Machine module

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/index.js
+++ b/app/plugins/system_controller/i2s_dacs/index.js
@@ -437,7 +437,7 @@ ControllerI2s.prototype.enableI2SDAC = function (data) {
 ControllerI2s.prototype.writeI2SDAC = function (data) {
 	var self = this;
 
-	var bootstring = 'initramfs volumio.initrd' + os.EOL + 'gpu_mem=16' + os.EOL + 'force_turbo=1' + os.EOL + 'max_usb_current=1' + os.EOL + 'disable_splash=1'+ os.EOL + 'dtparam=audio=on' + os.EOL + 'dtparam=i2c_arm=on' + os.EOL + 'dtoverlay='+data;
+	var bootstring = 'initramfs volumio.initrd' + os.EOL + 'gpu_mem=16' + os.EOL + 'max_usb_current=1' + os.EOL + 'disable_splash=1'+ os.EOL + 'dtparam=audio=on' + os.EOL + 'dtparam=i2c_arm=on' + os.EOL + 'dtoverlay='+data;
 
 	fs.writeFile('/boot/config.txt', bootstring, function (err) {
 		if (err) {
@@ -453,7 +453,7 @@ ControllerI2s.prototype.disableI2SDAC = function () {
 
 	this.config.set("i2s_enabled", false);
 
-	var bootstring = 'initramfs volumio.initrd' + os.EOL + 'gpu_mem=16' + os.EOL + 'force_turbo=1' + os.EOL + 'max_usb_current=1' + os.EOL + 'disable_splash=1'+ os.EOL + 'dtparam=audio=on' + os.EOL + 'dtparam=i2c_arm=on';
+	var bootstring = 'initramfs volumio.initrd' + os.EOL + 'gpu_mem=16' + os.EOL + 'max_usb_current=1' + os.EOL + 'disable_splash=1'+ os.EOL + 'dtparam=audio=on' + os.EOL + 'dtparam=i2c_arm=on';
 
 	fs.writeFile('/boot/config.txt', bootstring, function (err) {
 		if (err) {

--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -299,6 +299,7 @@ CoreStateMachine.prototype.increasePlaybackTimer = function () {
 
 
 		var remainingTime=this.currentSongDuration-this.currentSeek;
+		var isLastTrack=(this.playQueue.arrayQueue.length-1)==this.currentPosition;
 		if(remainingTime<5000 && this.askedForPrefetch==false)
 		{
 			this.askedForPrefetch=true;
@@ -306,8 +307,8 @@ CoreStateMachine.prototype.increasePlaybackTimer = function () {
 			var trackBlock = this.getTrack(this.currentPosition);
 
             var nextIndex=this.currentPosition+1;
-// First check if Repeat mode is on, note that Random and Consume overides Repeat
-						if(this.currentRepeat && ((this.playQueue.arrayQueue.length-1)==this.currentPosition)!== this.currentConsume)
+// Check if Repeat mode is on and last track is played, note that Random and Consume overides Repeat
+						if(this.currentRepeat && isLastTrack !== this.currentConsume)
 							{
 								nextIndex=0;
 							}
@@ -347,8 +348,8 @@ CoreStateMachine.prototype.increasePlaybackTimer = function () {
                 if(this.currentRandom)
                     this.currentPosition=this.nextRandomIndex;
                 else
-								// Handles if repeat mode is on and Consume is not on
-									if(this.currentRepeat && ((this.playQueue.arrayQueue.length-1)==this.currentPosition) !== this.currentConsume)
+						//if repeat mode is on and the last track is playing and Consume is not on
+									if(this.currentRepeat && isLastTrack !== this.currentConsume)
 										{
 											this.currentPosition=0;
 										}


### PR DESCRIPTION
This fix takes care of the case when Repeat mode is on by adding two new conditional statements in the method CoreStateMachine.prototype.increasePlaybackTimer:
1.) It checks if the current track is the last track of the queue then the next track is set to the first track in the prefetch phase, unless Consume mode is on.
2.) At the end of the current track, if that track is the last track it sets the current track to the first track unless Consume mode is on.

If the consume mode also is on the last track has to be consumed. No need for next track.

It has been tested also with the other modes. Remember that Random and Consume override Repeat in MPD.
Repeat + Random = Random;  
Repeat + Consume = Consume; 
Random + Repeat + Consume should be Repeat + Consume, but this combination is still buggy (same bugs as before).