### PR TITLE
Avoid unsuitable characters in mountpoints

### DIFF
--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -149,16 +149,20 @@ ControllerNetworkfs.prototype.mountShare = function (data) {
 		var trial = 0;
 	}
 
-
 	var fstype = config.get('NasMounts.' + shareid + '.fstype');
 	var options = config.get('NasMounts.' + shareid + '.options');
+	var pathraw = config.get('NasMounts.' + shareid + '.path');
+	var mountidraw = config.get('NasMounts.' + shareid + '.name');
+	// Check we have sane data - operating on undefined values will crash us
+	if (fstype === 'undefined' || pathraw === 'undefined') {
+		console.log('Unable to retrieve config for share '  + shareid + ', returning early');
+		return defer.promise;
+	}
 	var pointer;
 	var fsopts;
 	var credentials;
 	var responsemessage = {status:""};
-	var pathraw = config.get('NasMounts.' + shareid + '.path');
 	var path = pathraw.replace(/ /g,"\\ ");
-	var mountidraw = config.get('NasMounts.' + shareid + '.name');
 	// The local mountpoint path must not contain these characters, because
 	// they get specially encoded in /etc/mtab and cause mount/umount failures.
 	// See getmntent(7).

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -150,7 +150,6 @@ ControllerNetworkfs.prototype.mountShare = function (data) {
 	}
 
 
-	var sharename = config.get('NasMounts.' + shareid + '.name');
 	var fstype = config.get('NasMounts.' + shareid + '.fstype');
 	var options = config.get('NasMounts.' + shareid + '.options');
 	var pointer;

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -510,7 +510,9 @@ ControllerNetworkfs.prototype.getMountSize = function (share) {
 		var realsize = '';
 		var key = 'NasMounts.' + share + '.';
 		var name = config.get(key + 'name');
-		var mountpoint = '/mnt/NAS/' + name;
+		var mountidraw = name;
+		var mountid    = mountidraw.replace(/[\s\n\\]/g,"_");
+		var mountpoint = '/mnt/NAS/' + mountid;
 		var mounted = mountutil.isMounted(mountpoint, false);
 		var respShare = {
 			path: config.get(key + 'path'),

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -638,7 +638,7 @@ ControllerNetworkfs.prototype.editShare = function (data) {
 					reason: 'Cannot unmount share'
 				});
 			} else {
-				self.logger.info("Share " + config.get('NasMounts.' + data['id'] + '.name') + " successfully unmounted");
+				self.logger.info("Share " + mountidraw + " successfully unmounted");
 				var key = 'NasMounts.' + data['id'] + '.';
 
 				var oldpath = config.get(key + 'path');


### PR DESCRIPTION
Issue #684 revealed that linux-mountutils, which we use for mounting NAS drives,
does not handle mountpoints with spaces in them very well - it fails to take
into account the octal encoding of some characters in /etc/mtab (details in
getmntent(7)). This can lead to failures to create mountpoints and failures
to detect that a given share is mounted.
Change how the mountpoint path is constructed from the share name - replace any
characters that get encoded with an underscore. Use this method consistently
in all functions that have to mount or unmount a share. 
                                                                                
This has been tested by adding, editing and deleting an NFS share with a        
space in the name/alias. This also will conflict with earlier pull requests;
please pull this first, I will rework the other changes once this is merged.
                                                                                
Fixes: #684.