### PR TITLE
Avoid referencing undefined elements in i18nStrings array

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1320,7 +1320,8 @@ CoreCommandRouter.prototype.getI18nString = function (key) {
         else return this.i18nStringsDefaults[key];
     }
     else {
-        if(this.i18nStrings[splitted[0]][splitted[1]]!==undefined)
+        if(this.i18nStrings[splitted[0]]!==undefined &&
+           this.i18nStrings[splitted[0]][splitted[1]]!==undefined)
             return this.i18nStrings[splitted[0]][splitted[1]];
         else return this.i18nStringsDefaults[splitted[0]][splitted[1]];
     }


### PR DESCRIPTION
Not all translations are complete, so we can't rely on i18nStrings having
even the top level of the language strings. To avoid crashing with a TypeError,
check the first element of a two-element template exists before trying to
check the second element exists.

Fixes: #992