### PR TITLE
More robust mounting

### DIFF
--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -160,10 +160,10 @@ ControllerNetworkfs.prototype.mountShare = function (data) {
 
 	var fstype = config.get('NasMounts.' + shareid + '.fstype');
 	var options = config.get('NasMounts.' + shareid + '.options');
-	var pathraw = config.get('NasMounts.' + shareid + '.path');
+	var path = config.get('NasMounts.' + shareid + '.path');
 	var mountidraw = config.get('NasMounts.' + shareid + '.name');
 	// Check we have sane data - operating on undefined values will crash us
-	if (fstype === 'undefined' || pathraw === 'undefined') {
+	if (fstype === 'undefined' || path === 'undefined') {
 		console.log('Unable to retrieve config for share '  + shareid + ', returning early');
 		return defer.promise;
 	}
@@ -171,14 +171,13 @@ ControllerNetworkfs.prototype.mountShare = function (data) {
 	var fsopts;
 	var credentials;
 	var responsemessage = {status:""};
-	var path = pathraw.replace(/ /g,"\\ ");
 	// The local mountpoint path must not contain these characters, because
 	// they get specially encoded in /etc/mtab and cause mount/umount failures.
 	// See getmntent(7).
 	var mountid = mountidraw.replace(/[\s\n\\]/g,"_");
 
 	if (fstype == "cifs") {
-		pointer = '//' + config.get('NasMounts.' + shareid + '.ip') + '/' + path.replace(' ', '\ ');;
+		pointer = '//' + config.get('NasMounts.' + shareid + '.ip') + '/' + path;
 		//Password-protected mount
 		if (config.get('NasMounts.' + shareid + '.user') !== 'undefined' && config.get('NasMounts.' + shareid + '.user') !== '') {
 			credentials = 'username=' + config.get('NasMounts.' + shareid + '.user') + ',' + 'password=' + config.get('NasMounts.' + shareid + '.password') + ",";
@@ -192,7 +191,7 @@ ControllerNetworkfs.prototype.mountShare = function (data) {
 		}
 
 	} else { // nfs
-		pointer = config.get('NasMounts.' + shareid + '.ip') + ':' + path.replace(' ', '\ ');;
+		pointer = config.get('NasMounts.' + shareid + '.ip') + ':' + path;
 		if (options) {
 			fsopts ="ro,soft,noauto,"+options;
 		} else {
@@ -529,8 +528,9 @@ ControllerNetworkfs.prototype.getMountSize = function (share) {
 			mounted: mounted.mounted,
 			size: ''
 		};
+		var quotedmount = quotePath(mountpoint);
 		// cmd returns size in bytes with no units and no header line
-		var cmd="df -B1 --output=used '"+mountpoint+"' | tail -1";
+		var cmd="df -B1 --output=used " + quotedmount + " | tail -1";
 		var promise = libQ.ncall(exec,respShare,cmd).then(function (stdout){
 
 
@@ -556,6 +556,20 @@ ControllerNetworkfs.prototype.getMountSize = function (share) {
 		});
 	});
 };
+
+// Properly single-quote a path that will be handed to a shell exec.
+var quotePath = function (path) {
+	var self = this;
+	var output = '';
+
+	var pieces = path.split("'");
+	var n = pieces.length;
+	for (var i=0; i<n; i++) {
+		output = output + "'" + pieces[i] + "'";
+		if (i< (n-1)) output = output + "\\'";
+	}
+	return output;
+}
 
 /**
  * {

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -214,15 +214,15 @@ ControllerNetworkfs.prototype.mountShare = function (data) {
 			responsemessage = {status:"fail", reason:result.error}
 			defer.resolve(responsemessage);
 			if (data.init) {
-			if (trial < 4) {
-				trial++
-				self.logger.info("Cannot mount NAS "+mountid+" at system boot, trial number "+trial+" ,retrying in 5 seconds");
-				setTimeout(function () {
-				self.mountShare({init:true, key:data.key, trial:trial});
-				}, 5000);
-			} else {
-				self.logger.info("Cannot mount NAS at system boot, trial number "+trial+" ,stopping");
-			}
+				if (trial < 4) {
+					trial++
+					self.logger.info("Cannot mount NAS "+mountid+" at system boot, trial number "+trial+" ,retrying in 5 seconds");
+					setTimeout(function () {
+						self.mountShare({init:true, key:data.key, trial:trial});
+					}, 5000);
+				} else {
+					self.logger.info("Cannot mount NAS at system boot, trial number "+trial+" ,stopping");
+				}
 			}
 		} else {
 			responsemessage = {status:"success"}

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -208,7 +208,8 @@ ControllerNetworkfs.prototype.mountShare = function (data) {
 				result.error = 'Permission denied';
 			} else {
 				var splitreason = result.error.split('mount error');
-				result.error = splitreason[1]
+				// if the split does not match, splitreason[1] is undefined
+				if (splitreason.length > 1) result.error = splitreason[1];
 			}
 			responsemessage = {status:"fail", reason:result.error}
 			defer.resolve(responsemessage);


### PR DESCRIPTION
After tweaking the mountpoint paths a while ago, I started looking at strange paths on the remote share. After trying all sorts of quoting & escaping schemes I realised the problem was in linux-mountutils.

I've tested this with a few different strangely-named samba shares and tested mountpoints with things like () and ' in them, for CIFS and NFS. More testing would be welcome. Existing shares _should_ continue to work, as these changes don't affect how the mountpoint string is constructed.

The patch to linux-mountutils has been sent upstream but might have to be carried for a while.