### PR TITLE
Fixing Manual DNS entry

### DIFF
--- a/app/plugins/system_controller/network/index.js
+++ b/app/plugins/system_controller/network/index.js
@@ -844,15 +844,15 @@ ControllerNetwork.prototype.saveDnsSettings = function (data) {
 		config.set('secondary_dns', data.secondary_dns);
 	}
 
-	var dnsfile = '##custom DNS' + os.EOL + 'nameserver '+ data.primary_dns + os.EOL + 'nameserver '+ data.secondary_dns;
-	exec("/usr/bin/sudo /bin/chmod 777 /etc/resolv.conf.tail", {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
+	var dnsfile = '##custom DNS' + os.EOL + 'nameserver '+ data.primary_dns + os.EOL + 'nameserver '+ data.secondary_dns + os.EOL;
+	exec("/usr/bin/sudo /bin/chmod 666 /etc/resolv.conf.head", {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
 		if (error !== null) {
-			console.log('Canot set permissions for /etc/resolv.conf.tail: ' + error);
+			console.log('Canot set permissions for /etc/resolv.conf.head: ' + error);
 		} else {
-			self.logger.info('Permissions for /etc/resolv.conf.tail')
-			fs.writeFile('/etc/resolv.conf.tail', dnsfile, function (err) {
+			self.logger.info('Permissions for /etc/resolv.conf.head')
+			fs.writeFile('/etc/resolv.conf.head', dnsfile, function (err) {
 				if (err) {
-					self.logger.error('Cannot write wpasupplicant.conf ' + error);
+					self.logger.error('Cannot write DNS File' + error);
 				} else {
 					self.commandRouter.wirelessRestart();
 					self.commandRouter.networkRestart();

--- a/app/plugins/system_controller/network/index.js
+++ b/app/plugins/system_controller/network/index.js
@@ -164,10 +164,23 @@ ControllerNetwork.prototype.getUIConfig = function () {
 				uiconf.sections[4].content[4].value.label = config.get('hotspot_channel');
 			}
 
-			uiconf.sections[5].content[0].value = config.get('enable_custom_dns', false);
-			uiconf.sections[5].content[1].value = config.get('primary_dns', '208.67.222.222');
-			uiconf.sections[5].content[2].value = config.get('secondary_dns', '208.67.220.220');
+			if (config.get('enable_custom_dns') == undefined) {
+				uiconf.sections[5].content[0].value = false;
+			} else {
+				uiconf.sections[5].content[0].value = config.get('enable_custom_dns');
+			}
+			
+			if (config.get('primary_dns') == undefined) {
+				uiconf.sections[5].content[1].value = '208.67.222.222';
+			} else {
+				uiconf.sections[5].content[1].value = config.get('primary_dns');
+			}
 
+			if (config.get('secondary_dns') == undefined) {
+				uiconf.sections[5].content[2].value = '208.67.220.220';
+			} else {
+				uiconf.sections[5].content[2].value = config.get('secondary_dns');
+			}
 
 			//console.log(uiconf);
 


### PR DESCRIPTION
Use /etc/resolv.conf.head instead of /etc/resolv.conf.tail
As per https://github.com/volumio/Volumio2/issues/1031

Still need to fix:
- UI logic rework (critical)
------ ON/OFF should activate or clear the .head file (or move in/out with other name), and restart network
------ SAVE should should not do anything to the file if OFF
- UI display to show current DNS server used by /etc/resolv.conf