### PR TITLE
Fix crashes in last_100

### DIFF
--- a/app/plugins/music_service/last_100/index.js
+++ b/app/plugins/music_service/last_100/index.js
@@ -57,11 +57,12 @@ last_100.prototype.listenState = function () {
                     artist:data.artist, album:data.album, albumart:data.albumart, type:'song'};
                 newlastStates.push(currentsong);
                 try {
+                    // This may not always return an array
                     var lastStates = fs.readJsonSync(stateFile, {throws: true});
                 } catch (e) {
                     var lastStates = [];
                 }
-                if(lastStates.length > 0) {
+                if (Array.isArray(lastStates) && lastStates.length > 0) {
                     var j = 0;
                     for (var i in lastStates) {
                         if ((lastStates[i].uri != currentSong.uri) && j < 99) {

--- a/app/plugins/music_service/last_100/index.js
+++ b/app/plugins/music_service/last_100/index.js
@@ -71,7 +71,11 @@ last_100.prototype.listenState = function () {
 
                     }
                 }
-                fs.outputJsonSync("/data/laststates.json", newlastStates);
+                try {
+                    fs.outputJsonSync(stateFile, newlastStates);
+                } catch (e) {
+                    console.log("last_100 listenState failed to write " + stateFile);
+                }
             }
 
 

--- a/app/plugins/music_service/last_100/index.js
+++ b/app/plugins/music_service/last_100/index.js
@@ -75,7 +75,7 @@ last_100.prototype.listenState = function () {
                 try {
                     fs.outputJsonSync(stateFile, newlastStates);
                 } catch (e) {
-                    console.log("last_100 listenState failed to write " + stateFile);
+                    console.log('Error saving last played file: '+e);
                 }
             }
 

--- a/app/plugins/music_service/last_100/index.js
+++ b/app/plugins/music_service/last_100/index.js
@@ -48,6 +48,7 @@ last_100.prototype.listenState = function () {
 
     socket.on('pushState', function(data) {
 
+        var stateFile     = '/data/laststates.json';
         var newlastStates = [];
         if (data.status != 'stop' && data.service != 'webradio' && data.volatile != true){
             if (data.uri != currentSong.uri){
@@ -56,7 +57,7 @@ last_100.prototype.listenState = function () {
                     artist:data.artist, album:data.album, albumart:data.albumart, type:'song'};
                 newlastStates.push(currentsong);
                 try {
-                    var lastStates = fs.readJsonSync('/data/laststates.json', {throws: true});
+                    var lastStates = fs.readJsonSync(stateFile, {throws: true});
                 } catch (e) {
                     var lastStates = [];
                 }
@@ -94,9 +95,10 @@ last_100.prototype.handleBrowseUri = function (curUri) {
     var response = [];
     var lastPlayed = [];
     var defer = libQ.defer();
+    var stateFile = '/data/laststates.json';
 
     try {
-        lastPlayed = fs.readJsonSync('/data/laststates.json', {throws: true});
+        lastPlayed = fs.readJsonSync(stateFile, {throws: true});
         lastPlayed = self.rewriteForUri(lastPlayed);
         response = {
             navigation: {


### PR DESCRIPTION
Tested against 2.118, by  ```chmod 000 /data/laststates.json```. 
Before these changes, volumio crashes on trying to read and things get really weird if one plays a track while the state file unwriteable.
After, it does not crash and the last_100 list is updated (only tested going from 1 to 2 songs). 
The user gets no feedback that something is amiss, but that's a different issue.

This should fix #941 but could stand testing with a full last_100 list.