### PR TITLE
Working with share configuration objects

### DIFF
--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -362,10 +362,9 @@ ControllerNetworkfs.prototype.addShare = function (data) {
 	}
 
 	uuid = libUUID.v4();
-	var key = "NasMounts." + uuid + ".";
 	self.logger.info("No correspondence found in configuration for share " + name + " on IP " + ip);
 
-	var saveshare = self.saveShareConf(key, uuid, name, ip, path, fstype, username, password, options);
+	var saveshare = self.saveShareConf('NasMounts', uuid, name, ip, path, fstype, username, password, options);
 
 	saveshare.then(function () {
 		var mountshare = self.mountShare({key:uuid});
@@ -404,17 +403,18 @@ ControllerNetworkfs.prototype.addShare = function (data) {
 	return defer.promise;
 };
 
-ControllerNetworkfs.prototype.saveShareConf = function (key, uuid, name, ip, path, fstype, username, password, options) {
+ControllerNetworkfs.prototype.saveShareConf = function (parent, uuid, name, ip, path, fstype, username, password, options) {
 	var self = this;
 
 	var defer = libQ.defer();
-	config.addConfigValue(key + 'name', 'string', name);
-	config.addConfigValue(key + 'ip', 'string', ip);
-	config.addConfigValue(key + 'path', 'string', path);
-	config.addConfigValue(key + 'fstype', 'string', fstype);
-	config.addConfigValue(key + 'user', 'string', username);
-	config.addConfigValue(key + 'password', 'string', password);
-	config.addConfigValue(key + 'options', 'string', options);
+	var key = parent + '.' + uuid;
+	config.addConfigValue(key + '.name', 'string', name);
+	config.addConfigValue(key + '.ip', 'string', ip);
+	config.addConfigValue(key + '.path', 'string', path);
+	config.addConfigValue(key + '.fstype', 'string', fstype);
+	config.addConfigValue(key + '.user', 'string', username);
+	config.addConfigValue(key + '.password', 'string', password);
+	config.addConfigValue(key + '.options', 'string', options);
 
 	defer.resolve('ok')
 	return defer.promise;

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -658,37 +658,37 @@ ControllerNetworkfs.prototype.editShare = function (data) {
 				});
 			} else {
 				self.logger.info("Share " + mountidraw + " successfully unmounted");
-				var key = 'NasMounts.' + data['id'] + '.';
+				var key = 'NasMounts.' + data['id'];
 
-				var oldpath = config.get(key + 'path');
-				var oldname = config.get(key + 'name');
-				var oldip = config.get(key + 'ip');
-				var oldfstype = config.get(key + 'fstype');
-				var oldusername = config.get(key + 'user');
-				var oldpassword = config.get(key + 'password');
-				var oldoptions = config.get(key + 'options');
+				var oldpath = config.get(key + '.path');
+				var oldname = config.get(key + '.name');
+				var oldip = config.get(key + '.ip');
+				var oldfstype = config.get(key + '.fstype');
+				var oldusername = config.get(key + '.user');
+				var oldpassword = config.get(key + '.password');
+				var oldoptions = config.get(key + '.options');
 
 
 				if (data['name']) {
-				config.set(key + 'name', data['name']);
+				config.set(key + '.name', data['name']);
 				}
 				if(data['path']){
-				config.set(key + 'path', data['path']);
+				config.set(key + '.path', data['path']);
 				}
 				if(data['ip']) {
-					config.set(key + 'ip', data['ip']);
+					config.set(key + '.ip', data['ip']);
 				}
 				if (data['fstype']) {
-				config.set(key + 'fstype', data['fstype']);
+				config.set(key + '.fstype', data['fstype']);
 				}
 				if (data['username']) {
-					config.set(key + 'user', data['username']);
+					config.set(key + '.user', data['username']);
 				}
 				if (data['password']) {
-					config.set(key + 'password', data['password']);
+					config.set(key + '.password', data['password']);
 				}
 				if (data['options']) {
-					config.set(key + 'options', data['options']);
+					config.set(key + '.options', data['options']);
 				}
 
 
@@ -706,13 +706,13 @@ ControllerNetworkfs.prototype.editShare = function (data) {
 							if(data.reason) {
 
 								self.logger.info("An error occurred mounting the new share. Rolling back configuration");
-								config.set(key + 'name', oldname);
-								config.set(key + 'path', oldpath);
-								config.set(key + 'ip', oldip);
-								config.set(key + 'fstype', oldfstype);
-								config.set(key + 'user', oldusername);
-								config.set(key + 'password', oldpassword);
-								config.set(key + 'options', oldoptions);
+								config.set(key + '.name', oldname);
+								config.set(key + '.path', oldpath);
+								config.set(key + '.ip', oldip);
+								config.set(key + '.fstype', oldfstype);
+								config.set(key + '.user', oldusername);
+								config.set(key + '.password', oldpassword);
+								config.set(key + '.options', oldoptions);
 								if (data.reason === 'Permission denied') {
 									responsemessageedit = {emit: 'nasCredentialsCheck', data:{ 'id': id, 'name': name, 'username': username, 'password':password }};
 									defer.resolve(responsemessageedit);

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -646,9 +646,10 @@ ControllerNetworkfs.prototype.editShare = function (data) {
 		var password= data['password'];
 	}
 
-	if (config.has('NasMounts.' + data['id'])) {
+	var key = 'NasMounts.' + data['id'];
+	if (config.has(key)) {
 
-		var mountidraw = config.get('NasMounts.' + data['id'] + '.name');
+		var mountidraw = config.get(key + '.name');
 		var mountid    = mountidraw.replace(/[\s\n\\]/g,"_");
 		var mountpoint = '/mnt/NAS/' + mountid;
 		mountutil.umount(mountpoint, false, {"removeDir": true}, function (result) {
@@ -659,7 +660,6 @@ ControllerNetworkfs.prototype.editShare = function (data) {
 				});
 			} else {
 				self.logger.info("Share " + mountidraw + " successfully unmounted");
-				var key = 'NasMounts.' + data['id'];
 
 				var oldpath = config.get(key + '.path');
 				var oldname = config.get(key + '.name');

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -520,12 +520,12 @@ ControllerNetworkfs.prototype.getMountSize = function (share) {
 		var respShare = {
 			path: config.get(key + '.path'),
 			ip: config.get(key + '.ip'),
-			id: share,
-			name: name,
+			name: config.get(key + '.name'),
 			fstype: config.get(key + '.fstype'),
 			username: config.get(key + '.user'),
 			password: config.get(key + '.password'),
 			options: config.get(key + '.options'),
+			id: share,
 			mounted: mounted.mounted,
 			size: ''
 		};
@@ -597,12 +597,12 @@ ControllerNetworkfs.prototype.infoShare = function (data) {
 		var response = {
 			path: config.get(key + '.path'),
 			name: config.get(key + '.name'),
-			id: data['id'],
 			ip: config.get(key + '.ip'),
 			fstype: config.get(key + '.fstype'),
 			username: config.get(key + '.user'),
 			password: config.get(key + '.password'),
-			options: config.get(key + '.options')
+			options: config.get(key + '.options'),
+			id: data['id']
 		};
 
 		defer.resolve(response);

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -511,21 +511,21 @@ ControllerNetworkfs.prototype.listShares = function (data) {
 
 ControllerNetworkfs.prototype.getMountSize = function (share) {
 	return new Promise(function (resolve, reject) {
-		var key = 'NasMounts.' + share + '.';
-		var name = config.get(key + 'name');
+		var key = 'NasMounts.' + share;
+		var name = config.get(key + '.name');
 		var mountidraw = name;
 		var mountid    = mountidraw.replace(/[\s\n\\]/g,"_");
 		var mountpoint = '/mnt/NAS/' + mountid;
 		var mounted = mountutil.isMounted(mountpoint, false);
 		var respShare = {
-			path: config.get(key + 'path'),
-			ip: config.get(key + 'ip'),
+			path: config.get(key + '.path'),
+			ip: config.get(key + '.ip'),
 			id: share,
 			name: name,
-			fstype: config.get(key + 'fstype'),
-			username: config.get(key + 'user'),
-			password: config.get(key + 'password'),
-			options: config.get(key + 'options'),
+			fstype: config.get(key + '.fstype'),
+			username: config.get(key + '.user'),
+			password: config.get(key + '.password'),
+			options: config.get(key + '.options'),
 			mounted: mounted.mounted,
 			size: ''
 		};

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -593,16 +593,16 @@ ControllerNetworkfs.prototype.infoShare = function (data) {
 	var defer = libQ.defer();
 
 	if (config.has('NasMounts.' + data['id'])) {
-		var key = 'NasMounts.' + data['id'] + '.';
+		var key = 'NasMounts.' + data['id'];
 		var response = {
-			path: config.get(key + 'path'),
-			name: config.get(key + 'name'),
+			path: config.get(key + '.path'),
+			name: config.get(key + '.name'),
 			id: data['id'],
-			ip: config.get(key + 'ip'),
-			fstype: config.get(key + 'fstype'),
-			username: config.get(key + 'user'),
-			password: config.get(key + 'password'),
-			options: config.get(key + 'options')
+			ip: config.get(key + '.ip'),
+			fstype: config.get(key + '.fstype'),
+			username: config.get(key + '.user'),
+			password: config.get(key + '.password'),
+			options: config.get(key + '.options')
 		};
 
 		defer.resolve(response);

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -158,10 +158,11 @@ ControllerNetworkfs.prototype.mountShare = function (data) {
 		var trial = 0;
 	}
 
-	var fstype = config.get('NasMounts.' + shareid + '.fstype');
-	var options = config.get('NasMounts.' + shareid + '.options');
-	var path = config.get('NasMounts.' + shareid + '.path');
-	var mountidraw = config.get('NasMounts.' + shareid + '.name');
+	var key = 'NasMounts.' + shareid;
+	var fstype = config.get(key + '.fstype');
+	var options = config.get(key + '.options');
+	var path = config.get(key + '.path');
+	var mountidraw = config.get(key + '.name');
 	// Check we have sane data - operating on undefined values will crash us
 	if (fstype === 'undefined' || path === 'undefined') {
 		console.log('Unable to retrieve config for share '  + shareid + ', returning early');
@@ -179,8 +180,8 @@ ControllerNetworkfs.prototype.mountShare = function (data) {
 	if (fstype == "cifs") {
 		pointer = '//' + config.get('NasMounts.' + shareid + '.ip') + '/' + path;
 		//Password-protected mount
-		if (config.get('NasMounts.' + shareid + '.user') !== 'undefined' && config.get('NasMounts.' + shareid + '.user') !== '') {
-			credentials = 'username=' + config.get('NasMounts.' + shareid + '.user') + ',' + 'password=' + config.get('NasMounts.' + shareid + '.password') + ",";
+		if (config.get(key + '.user') !== 'undefined' && config.get(key + '.user') !== '') {
+			credentials = 'username=' + config.get(key + '.user') + ',' + 'password=' + config.get(key + '.password') + ",";
 		} else {
 			credentials = 'guest,';
 		}


### PR DESCRIPTION
This is cleanup, no functional changes. The focus is on making the way fields accessed with config.get() is consistent across functions within the module.
Tested on 2.118 + linux-mountutils-1.02 + the 'more robust mounting' patch. Add/edit/delete of shares seemed to work ok.