### PR TITLE
UI Issue 252

### DIFF
--- a/app/musiclibrary.js
+++ b/app/musiclibrary.js
@@ -282,6 +282,11 @@ CoreMusicLibrary.prototype.executeBrowseSource = function(curUri) {
     if (curUri.startsWith('favourites')) {
         return self.commandRouter.playListManager.listFavourites(curUri);
     }
+    else if (curUri.startsWith('search')) {
+        var splitted=curUri.split('/');
+
+        return this.search({"value":splitted[2]});
+    }
     else {
         for(var i in self.browseSources)
         {


### PR DESCRIPTION

.) Possibility to split up Artist/Genres/Albums by starting letter (A-Z lists). 
configurable in config.json
.) Possibility to ignore leading article in band/album names (The beatles will show up
under letter B) configurable in config.json
.) Possibility to optionally sort the results from the mpd server configurable in config.json
.) Skipping of tracks that are more than one time in db
.) Artist and Genres skip if Artist/Genre has eg only one entry in whole db  configurable in config.json

BUGFIXES:
.) search - only one artist was returned
.) lookup for album/artist takes albumartist not artist (otherwise all samplers are split up in different albums)
.) display of albums of one band - the lookup was only for album name -> all greates hits albums where always displayed 
.) back button sometimes wrong
