### PR TITLE
Avoid  upload failures on certain filenames

### DIFF
--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -422,7 +422,7 @@ PluginManager.prototype.installPlugin = function (url) {
 	self.pushMessage('installPluginStatus',{'progress': 10, 'message': 'Downloading plugin','title' : modaltitle, 'advancedLog': advancedlog});
 
 
-	exec("/usr/bin/wget -O /tmp/downloaded_plugin.zip "+url, function (error, stdout, stderr) {
+	exec("/usr/bin/wget -O /tmp/downloaded_plugin.zip '" + url + "'", function (error, stdout, stderr) {
 
 		if (error !== null) {
 			currentMessage = "Cannot download file "+url+ ' - ' + error;
@@ -551,7 +551,7 @@ PluginManager.prototype.updatePlugin = function (data) {
 	self.pushMessage('installPluginStatus',{'progress': 10, 'message': 'Downloading Update','title' : modaltitle, 'advancedLog': advancedlog});
 
 
-	exec("/usr/bin/wget -O /tmp/downloaded_plugin.zip "+url, function (error, stdout, stderr) {
+	exec("/usr/bin/wget -O /tmp/downloaded_plugin.zip '" + url + "'", function (error, stdout, stderr) {
 
 		if (error !== null) {
 			currentMessage = "Cannot download file "+url+ ' - ' + error;

--- a/http/index.js
+++ b/http/index.js
@@ -105,7 +105,7 @@ app.route('/plugin-upload')
                 console.log('Cannot Create Plugin DIR ')
             }
             //Path where image will be uploaded
-            fstream = fs.createWriteStream('/tmp/plugins/' + filename);
+            fstream = fs.createWriteStream(plugindir + filename);
             file.pipe(fstream);
             fstream.on('close', function () {
                 console.log("Upload Finished of " + filename);

--- a/http/index.js
+++ b/http/index.js
@@ -10,7 +10,7 @@ var busboy = require('connect-busboy');
 var path = require('path');
 var fs = require('fs-extra');
 var io=require('socket.io-client');
-
+var libUUID = require('node-uuid');
 
 var app = express();
 var dev = express();
@@ -98,19 +98,21 @@ app.route('/plugin-upload')
         req.pipe(req.busboy);
         req.busboy.on('file', function (fieldname, file, filename) {
             console.log("Uploading: " + filename);
+            var uniquename = libUUID.v4() + '.zip';
+            console.log("Created safe filename as '"+uniquename+"'");
 
             try {
                 fs.ensureDirSync(plugindir)
             } catch (err) {
-                console.log('Cannot Create Plugin DIR ')
+                console.log('Cannot Create Plugin Dir ' + plugindir)
             }
             //Path where image will be uploaded
-            fstream = fs.createWriteStream(plugindir + filename);
+            fstream = fs.createWriteStream(plugindir + '/' + uniquename);
             file.pipe(fstream);
             fstream.on('close', function () {
-                console.log("Upload Finished of " + filename);
+                console.log("Upload Finished of " + filename + " as " + uniquename);
                 var socket= io.connect('http://localhost:3000');
-                var pluginurl= 'http://127.0.0.1:3000/plugin-serve/'+filename.replace(/'|\\/g, '\\$&');;
+                var pluginurl= 'http://127.0.0.1:3000/plugin-serve/' + uniquename;
                 socket.emit('installPlugin', { url:pluginurl});
                 res.status(201);
                 //res.redirect('/');


### PR DESCRIPTION
The issue referenced below reports the upload stops part way through. This is because the wget command falls over:
```
Mar 22 11:25:35 volumio volumio[3248]: Uploading: auto_play(1).zip
Mar 22 11:25:35 volumio volumio[3248]: Upload Finished of auto_play(1).zip
Mar 22 11:25:36 volumio volumio[3248]: info: Downloading plugin at http://127.0.0.1:3000/plugin-ser
ve/auto_play(1).zip
Mar 22 11:25:36 volumio volumio[3248]: info: Cannot download file http://127.0.0.1:3000/plugin-serv
e/auto_play(1).zip - Error: Command failed: /usr/bin/wget -O /tmp/downloaded_plugin.zip http://127.
0.0.1:3000/plugin-serve/auto_play(1).zip
Mar 22 11:25:36 volumio volumio[3248]: /bin/sh: 1: Syntax error: "(" unexpected
Mar 22 11:25:36 volumio volumio[3248]: info: Error: Error: Error: Command failed: /usr/bin/wget -O 
/tmp/downloaded_plugin.zip http://127.0.0.1:3000/plugin-serve/auto_play(1).zip
Mar 22 11:25:36 volumio volumio[3248]: /bin/sh: 1: Syntax error: "(" unexpected
```
The changes in this PR should resolve this issue, please test.

Tested against 2.118, using a file named 'auto_play(1).zip'.

Fixes: volumio/Volumio2-UI#299
