### PR TITLE
Fixed MPD status samplerate:bits:channels when bits=f

### DIFF
--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -517,8 +517,9 @@ ControllerMpd.prototype.parseState = function (objState) {
 		var objMetrics = objState.audio.split(':');
 		var nSampleRateRaw = Number(objMetrics[0]) / 1000;
 		nBitDepth = Number(objMetrics[1])+' bit';
-
-		if (objMetrics[1] == 'dsd') {
+		if (objMetrics[1] == 'f')
+			nBitDepth = '32f bit';
+		else if (objMetrics[1] == 'dsd') {
 			if (nSampleRateRaw === 352.8) {
 				var nSampleRateRaw = 2.82 + ' MHz';
 				nBitDepth = '1 bit'


### PR DESCRIPTION
The bug arose from a NaN on UI (issue #1099) while playing a file with 32bit floating point bit depth