### PR TITLE
Rework plugin upload (RFC)

### DIFF
--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -413,7 +413,7 @@ PluginManager.prototype.installPlugin = function (data) {
 	var defer=libQ.defer();
 	var modaltitle= 'Installing Plugin';
 	var advancedlog = '';
-    var sourcefile = data.sourcefile;
+	var sourcefile = data.sourcefile;
 
 
 	var currentMessage = "Downloaded plugin is at "+sourcefile;

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -414,17 +414,27 @@ PluginManager.prototype.installPlugin = function (data) {
 	var modaltitle= 'Installing Plugin';
 	var advancedlog = '';
 	var sourcefile = '';
+	var currentMessage = '';
+
 	if ( data != undefined && data.sourcefile != undefined ) {
 		sourcefile = data.sourcefile;
 	} else {
-		var message = "Unable to locate uploaded plugin file";
-		self.logger.info(message);
+		currentMessage = "Unable to locate downloaded plugin file";
+		advancedlog = advancedlog + "<br>" + currentMessage;
+		self.logger.info(currentMessage);
+		self.pushMessage('installPluginStatus',
+							{'progress': 0,
+							 'message': 'Download failure',
+							 'title' : modaltitle,
+							 'advancedLog': advancedlog,
+							 'buttons':[{'name':'Close','class': 'btn btn-warning'}]
+							});
 		defer.reject(new Error());
-		return defer.promise
+		return defer.promise;
 	}
 
 
-	var currentMessage = "Downloaded plugin is at "+sourcefile;
+	currentMessage = "Downloaded plugin is at "+sourcefile;
 	self.logger.info(currentMessage);
 	advancedlog = currentMessage;
 

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -408,24 +408,23 @@ PluginManager.prototype.checkRequiredConfigurationParameters = function (require
 	configJson.save();
 };
 
-PluginManager.prototype.installPlugin = function (url) {
+PluginManager.prototype.installPlugin = function (data) {
 	var self=this;
 	var defer=libQ.defer();
 	var modaltitle= 'Installing Plugin';
 	var advancedlog = '';
+    var sourcefile = data.sourcefile;
 
 
-	var currentMessage = "Downloading plugin at "+url;
+	var currentMessage = "Downloaded plugin is at "+sourcefile;
 	self.logger.info(currentMessage);
 	advancedlog = currentMessage;
 
-	self.pushMessage('installPluginStatus',{'progress': 10, 'message': 'Downloading plugin','title' : modaltitle, 'advancedLog': advancedlog});
+	self.pushMessage('installPluginStatus',{'progress': 10, 'message': 'Downloaded plugin','title' : modaltitle, 'advancedLog': advancedlog});
 
-
-	exec("/usr/bin/wget -O /tmp/downloaded_plugin.zip '" + url + "'", function (error, stdout, stderr) {
-
+	exec("/bin/mv -f " + sourcefile + " /tmp/downloaded_plugin.zip", function (error, stdout, stderr) {
 		if (error !== null) {
-			currentMessage = "Cannot download file "+url+ ' - ' + error;
+			currentMessage = "Cannot handle file "+sourcefile+ ' - ' + error;
 			self.logger.info(currentMessage);
 			advancedlog = advancedlog + "<br>" + currentMessage;
 			defer.reject(new Error(error));

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -430,7 +430,7 @@ PluginManager.prototype.installPlugin = function (data) {
 			defer.reject(new Error(error));
 		}
 		else {
-			currentMessage = "END DOWNLOAD: "+url;
+			currentMessage = "END DOWNLOAD: "+sourcefile;
 			advancedlog = advancedlog + "<br>" + currentMessage;
 			self.logger.info(currentMessage);
 			currentMessage = 'Creating folder on disk';

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -693,6 +693,7 @@ PluginManager.prototype.tempCleanup = function () {
 
 	self.rmDir('/tmp/downloaded_plugin');
 	self.rmDir('/tmp/downloaded_plugin.zip');
+	self.rmDir('/tmp/downloadedPlugin');
 }
 
 PluginManager.prototype.createFolder = function (folder) {

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -413,7 +413,15 @@ PluginManager.prototype.installPlugin = function (data) {
 	var defer=libQ.defer();
 	var modaltitle= 'Installing Plugin';
 	var advancedlog = '';
-	var sourcefile = data.sourcefile;
+	var sourcefile = '';
+	if ( data != undefined && data.sourcefile != undefined ) {
+		sourcefile = data.sourcefile;
+	} else {
+		var message = "Unable to locate uploaded plugin file";
+		self.logger.info(message);
+		defer.reject(new Error());
+		return defer.promise
+	}
 
 
 	var currentMessage = "Downloaded plugin is at "+sourcefile;

--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -1269,7 +1269,7 @@ function InterfaceWebUI(context) {
             connWebSocket.on('installPlugin', function (data) {
                 var selfConnWebSocket = this;
 
-                var returnedData = self.commandRouter.installPlugin(data.url);
+                var returnedData = self.commandRouter.installPlugin(data);
 
                 if (returnedData != undefined) {
                     returnedData.then(function (data) {

--- a/http/index.js
+++ b/http/index.js
@@ -107,13 +107,13 @@ app.route('/plugin-upload')
                 console.log('Cannot Create Plugin Dir ' + plugindir)
             }
             //Path where image will be uploaded
-            fstream = fs.createWriteStream(plugindir + '/' + uniquename);
+            var uniquepath = plugindir + '/' + uniquename;
+            fstream = fs.createWriteStream(uniquepath);
             file.pipe(fstream);
             fstream.on('close', function () {
                 console.log("Upload Finished of " + filename + " as " + uniquename);
                 var socket= io.connect('http://localhost:3000');
-                var pluginurl= 'http://127.0.0.1:3000/plugin-serve/' + uniquename;
-                socket.emit('installPlugin', { url:pluginurl});
+                socket.emit('installPlugin', { sourcefile:uniquepath });
                 res.status(201);
                 //res.redirect('/');
             });

--- a/pluginapi/installPlugin.js
+++ b/pluginapi/installPlugin.js
@@ -6,7 +6,8 @@ var io=require('socket.io-client');
 var socket= io.connect('http://localhost:3000');
 
 console.log("GET BrowseLibrary\n\n");
-socket.emit('installPlugin', { url:'http://127.0.0.1:3000/plugin-serve/spotify.zip'});
+//socket.emit('installPlugin', { url:'http://127.0.0.1:3000/plugin-serve/spotify.zip'});
+socket.emit('installPlugin', { sourcefile:'/tmp/somefilewedownloaded.zip' } );
 
 socket.on('installPluginStatus',function(data)
 {


### PR DESCRIPTION
This is a Request For Comment more than a real pull request, because I'm proposing a change to the plugin installation API. Instead of re-uploading to the express server on port 3000 it just works at the filesystem level, which is a bit of a shift in paradigm. 

If this is considered a reasonable approach it could also be applied to upload of backgrounds.

It addresses the issue raised in #1104.

Tested on 2.118 with the patches from PR #1083 applied, for both the normal case and the case where the input 'data' object does not have the expected 'sourcefile' field. It seems to me it should be possible to write a mocha test for this but I'm not quite sure where to start.