### PR TITLE
Pi Models detection compatibility

### DIFF
--- a/app/plugins/system_controller/system/devices.json
+++ b/app/plugins/system_controller/system/devices.json
@@ -1,4 +1,7 @@
 {"devices":[
+  {"name":"Raspberry PI", "cpuid":"BCM2835"},
+  {"name":"Raspberry PI", "cpuid":"BCM2836"},
+  {"name":"Raspberry PI", "cpuid":"BCM2837"},
   {"name":"Raspberry PI", "cpuid":"BCM2709"},
   {"name":"Raspberry PI", "cpuid":"BCM2708"},
   {"name":"Odroid-C", "cpuid":"ODROIDC"},

--- a/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
@@ -60,7 +60,7 @@ echo "Done, you can now build and install out of kernel modules"
 }
 
 
-if (cat /proc/cpuinfo | grep "BCM2" > /dev/null); then
+if (cat /proc/cpuinfo | grep '^Hardware.*BCM2[78][03][5-9].*' > /dev/null); then
  kernelinstall
 else
  echo "This tool is available only for Raspberry PI, exiting"

--- a/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 
-HARDWARE_REV=`cat /proc/cpuinfo | grep "Hardware" | awk -F: '{print $NF}'`
-
 function kernelinstall {
 
 echo " ---- VOLUMIO RASPBERRY PI KERNEL SOURCE DOWNLOADER ----"
@@ -62,7 +60,7 @@ echo "Done, you can now build and install out of kernel modules"
 }
 
 
-if [ "$HARDWARE_REV" = " BCM2709" ] || [ "$HARDWARE_REV" = " BCM2708" ]; then
+if (cat /proc/cpuinfo | grep "BCM2" > /dev/null); then
  kernelinstall
 else
  echo "This tool is available only for Raspberry PI, exiting"

--- a/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
@@ -60,7 +60,7 @@ echo "Done, you can now build and install out of kernel modules"
 }
 
 
-if (cat /proc/cpuinfo | grep '^Hardware.*BCM2[78][03][5-9].*' > /dev/null); then
+if (cat /proc/cpuinfo | grep '^Hardware.*BCM2[78][013][05-9].*' > /dev/null); then
  kernelinstall
 else
  echo "This tool is available only for Raspberry PI, exiting"


### PR DESCRIPTION
Preparation for newer kernel support while ensuring full backward compatibility.
**cpuinfo Hardware** returned chipset families (BCM2708/09/10) before kernel 4.8.y, and returns SoC reference (BCM2835/6/7) since then.
