### PR TITLE
add pre-end-of-life actions mechanism on plugins

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1084,10 +1084,12 @@ CoreCommandRouter.prototype.pushAirplay = function (data) {
 // Platform specific & Hardware related options, they can be found in platformSpecific.js
 // This allows to change system commands across different devices\environments
 CoreCommandRouter.prototype.shutdown = function () {
+	this.pluginManager.onVolumioShutdown();
 	this.platformspecific.shutdown();
 };
 
 CoreCommandRouter.prototype.reboot = function () {
+	this.pluginManager.onVolumioReboot();
 	this.platformspecific.reboot();
 };
 

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -362,9 +362,33 @@ PluginManager.prototype.onVolumioStart = function () {
 
 	self.plugins.forEach(function (value, key) {
 		var plugin = value.instance;
-
 		if (plugin.onVolumioStart != undefined)
 			plugin.onVolumioStart();
+	});
+};
+
+PluginManager.prototype.onVolumioShutdown = function () {
+	var self = this;
+
+	self.plugins.forEach(function (value, key) {
+		if (self.isEnabled(value.category, value.name)) {
+			var plugin = value.instance;
+			if (plugin.onVolumioShutdown != undefined)
+				plugin.onVolumioShutdown();
+		}
+	});
+};
+
+PluginManager.prototype.onVolumioReboot = function () {
+	var self = this;
+
+	self.plugins.forEach(function (value, key) {
+		if (self.isEnabled(value.category, value.name)) {
+			var plugin = value.instance;
+
+			if (plugin.onVolumioReboot != undefined)
+				plugin.onVolumioReboot();
+		}
 	});
 };
 

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -362,6 +362,7 @@ PluginManager.prototype.onVolumioStart = function () {
 
 	self.plugins.forEach(function (value, key) {
 		var plugin = value.instance;
+		
 		if (plugin.onVolumioStart != undefined)
 			plugin.onVolumioStart();
 	});
@@ -385,7 +386,6 @@ PluginManager.prototype.onVolumioReboot = function () {
 	self.plugins.forEach(function (value, key) {
 		if (self.isEnabled(value.category, value.name)) {
 			var plugin = value.instance;
-
 			if (plugin.onVolumioReboot != undefined)
 				plugin.onVolumioReboot();
 		}


### PR DESCRIPTION
add 2 methods **onVolumioReboot** and **onVolumioShutdown** for **pluginManager**. These methods call respectively **onVolumioReboot** and **onVolumioShutdown** on every enabled plugins.
Update the CoreCommandRouter reboot and shutdown methods, calling the pluginManager.onVolumioReboot  or pluginManager.onVolumioShutdown just before the real reboot or shutdown
