### PR TITLE
missing onVolumioStart return libQ.resolve();

### DIFF
--- a/app/plugins/miscellanea/appearance/index.js
+++ b/app/plugins/miscellanea/appearance/index.js
@@ -38,6 +38,7 @@ volumioAppearance.prototype.onVolumioStart = function() {
     this.commandRouter.sharedVars.addConfigValue('language_code','string',config.get('language_code'));
     self.createThumbnailPath();
 
+    return libQ.resolve();
 };
 
 volumioAppearance.prototype.onStart = function() {

--- a/app/plugins/system_controller/my_volumio/index.js
+++ b/app/plugins/system_controller/my_volumio/index.js
@@ -20,6 +20,8 @@ myVolumio.prototype.onVolumioStart = function ()
         'config.json');
     self.config = new (require('v-conf'))();
     self.config.loadFile(configFile);
+    
+    return libQ.resolve();
 };
 
 


### PR DESCRIPTION
Adding `return libQ.resolve();` in `onVolumioStart()` for _appereance_ and _myvolumio_ plugins.