### PR TITLE
Pluginmanager: improve load, start, stop promise management

### DIFF
--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -134,11 +134,10 @@ PluginManager.prototype.loadPlugin = function (folder) {
 				// Handle non-compliant onVolumioStart(): push an error message and disable plugin
 				self.coreCommand.pushToastMessage('error',name + " Plugin","This plugin has failing init routine. Please install updated version, or contact plugin developper");
 				self.logger.error("Plugin " + name + " does not return adequate promise from onVolumioStart: please update!");
-				self.disablePlugin (category,name);
 				myPromise = libQ.resolve();  // passing a fake promise to avoid crashes in new promise management
 			}
-			else
-				self.plugins.set(key, pluginData);  // not set if no promise, so can't be started/stopped
+			
+			self.plugins.set(key, pluginData);  // set in any case, so it can be started/stopped
 		
 			defer.resolve();
 			return myPromise;
@@ -262,7 +261,6 @@ PluginManager.prototype.startPlugin = function (category, name) {
 				// Handle non-compliant onStart(): push an error message and disable plugin
 				self.coreCommand.pushToastMessage('error',name + " Plugin","This plugin has failing start routine. Please install updated version, or contact plugin developper");
 				self.logger.error("Plugin " + name + " does not return adequate promise from onStart: please update!");
-				self.disableAndStopPlugin (category,name);
 				myPromise = libQ.resolve();  // passing a fake promise to avoid crashes in new promise management
 			}
 
@@ -299,7 +297,6 @@ PluginManager.prototype.stopPlugin = function (category, name) {
 				// Handle non-compliant onStop(): push an error message and disable plugin
 				self.coreCommand.pushToastMessage('error',name + " Plugin","This plugin has failing stop routine. Please install updated version, or contact plugin developper");
 				self.logger.error("Plugin " + name + " does not return adequate promise from onStop: please update!");
-				self.disablePlugin (category,name);
 				myPromise = libQ.resolve();  // passing a fake promise to avoid crashes in new promise management
 			}
 			

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -117,19 +117,21 @@ PluginManager.prototype.loadPlugin = function (folder) {
 
 		self.initializeConfiguration(package_json, pluginInstance, folder);
 
-		if (pluginInstance.onVolumioStart !== undefined)
-			defer.promise=pluginInstance.onVolumioStart();
-		else
-			defer.resolve();
-			
 		var pluginData = {
 			name: name,
 			category: category,
 			folder: folder,
 			instance: pluginInstance
 		};
-		
+
 		self.plugins.set(key, pluginData);
+
+		if (pluginInstance.onVolumioStart !== undefined){
+			defer.resolve();
+			return pluginInstance.onVolumioStart();
+		}
+		else
+			defer.resolve();
 
 	}
 	else
@@ -238,8 +240,9 @@ PluginManager.prototype.startPlugin = function (category, name) {
 		if(plugin.onStart!==undefined)
 		{
 		    self.logger.info("PLUGIN START: "+name);
-			defer.promise=plugin.onStart();
 			self.config.set(category + '.' + name + '.status', "STARTED");
+			defer.resolve();
+			return plugin.onStart();
 		}
 		else
 		{
@@ -263,8 +266,9 @@ PluginManager.prototype.stopPlugin = function (category, name) {
 		if(plugin.onStop!==undefined)
 		{
 			self.logger.info("PLUGIN STOP: "+name);
-			defer.promise=plugin.onStop();
 			self.config.set(category + '.' + name + '.status', "STOPPED");					
+			defer.resolve();
+			return plugin.onStop();
 		}
 		else
 		{


### PR DESCRIPTION
This PR just focuses on improving promise management in load/start/stop plugins operations.
It fixes the infrastructure, so that later PR may further enhance load-order priorities management, make startup-sequence more deterministic, etc...
It does benefit right-now to add-on plugin Start/Stop operations which are more reliable.

Some important note:
- all plugins `onVolumioStart()` must now return promises and will crash if not.
Built-in plugins now comply with that, but some 3rd Party plugins may not. I contacted most plugins developers and submitted relevant PRs in [volumio-plugins](https://github.com/volumio/volumio-plugins/pulls): it should be ok when eventually merged. We may want to add a note into plugin [development docs about `onVolumioStart()`](https://volumio.github.io/docs/Plugin_System/Index.js.html) required promises for future reference.
- this PR does not require any other change: current `/volumio/app/index.js` startup sequence works as previously with it and is not affected (nor is fixed then). Startup sequence scheduling fixes will need a separate PR.
- In my testing process, I noticed that `onVolumioStart()` **system plugin** has `deviceDetect()` & `callHome()` calls "leaking" outside of the promise dependency: https://github.com/volumio/Volumio2/pull/1155 intends to fix that.
- similarly `onVolumioStart()` from **i2s_dacs plugin** has `i2sDetect()` call "leaking" outside of the promise, and may need a fix too.

@volumio and @fanciulli I welcome any feedback.

PS: this PR replaces https://github.com/volumio/Volumio2/pull/1145