### PR TITLE
Ensure mixer gets updated in shairport-sync.conf

### DIFF
--- a/app/plugins/music_service/airplay_emulation/index.js
+++ b/app/plugins/music_service/airplay_emulation/index.js
@@ -82,12 +82,13 @@ AirPlayInterface.prototype.startShairportSync = function () {
 			return console.log(err);
 		}
 
-		var conf1 = data.replace("${name}", name);
-		var conf2 = conf1.replace("${device}", outdev);
-		var conf3 = conf2.replace("${mixer}", mixer);
+		var conf = data;
+		conf = conf.replace("${name}", name);
+		conf = conf.replace("${device}", outdev);
+		conf = conf.replace("${mixer}", mixer);
 
 
-		fs.writeFile("/etc/shairport-sync.conf", conf3, 'utf8', function (err) {
+		fs.writeFile("/etc/shairport-sync.conf", conf, 'utf8', function (err) {
 			if (err) return console.log(err);
 			startAirPlay(self);
 		});

--- a/app/plugins/music_service/airplay_emulation/index.js
+++ b/app/plugins/music_service/airplay_emulation/index.js
@@ -84,10 +84,10 @@ AirPlayInterface.prototype.startShairportSync = function () {
 
 		var conf1 = data.replace("${name}", name);
 		var conf2 = conf1.replace("${device}", outdev);
-		var conf3 = conf1.replace("${mixer}", mixer);
+		var conf3 = conf2.replace("${mixer}", mixer);
 
 
-		fs.writeFile("/etc/shairport-sync.conf", conf2, 'utf8', function (err) {
+		fs.writeFile("/etc/shairport-sync.conf", conf3, 'utf8', function (err) {
 			if (err) return console.log(err);
 			startAirPlay(self);
 		});


### PR DESCRIPTION
I looked at the code and thought that can't possibly be right...the mixer never gets into the config file.

The only test I have made is uploading the modified file (to v2.129) and checking that volumio restarts cleanly and that /etc/shairport-sync.conf looks sane after being updated. I don't know how to test it further.

On my system the config file contains no mixer:
```
general =
{
    name = "Volumio";
log_verbosity = 0;
};

alsa =
{
  output_device = "plughw:0,0";
};

sessioncontrol =
{
  run_this_before_play_begins = "/usr/bin/mpc stop";
  allow_session_interruption = "yes";
};
```
