### PR TITLE
Fill Artist with name if Artist is undefined

### DIFF
--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -438,6 +438,8 @@ ControllerMpd.prototype.parseTrackInfo = function (objTrackInfo) {
 
 	if (objTrackInfo.Artist != undefined) {
 		resp.artist = objTrackInfo.Artist;
+	} else if (objTrackInfo.Name != undefined) {
+ +		resp.artist = objTrackInfo.Name;
 	} else {
 		resp.artist = null;
 	}


### PR DESCRIPTION
Fill Artist with name if Artist is undefined. This enables nicer parsing of radio stations for LCD's.
It allows the user to show the radio station in addition to any info streamed from the station (e.g. the currently playing track).