### PR TITLE
#1192 Enable plugin installation with changed OS password

### DIFF
--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -841,7 +841,7 @@ PluginManager.prototype.executeInstallationScript = function (folder) {
 		}
 		else {
 			self.logger.info("Executing install.sh");
-			exec('echo volumio | sudo -S sh ' + installScript+' > /tmp/installog', {uid:1000, gid:1000, maxBuffer: 2024000},function(error, stdout, stderr) {
+			exec('echo volumio | sh ' + installScript+' > /tmp/installog', {uid:1000, gid:1000, maxBuffer: 2024000},function(error, stdout, stderr) {
 				if (error!==undefined && error!==null) {
 					console.log(stdout);
 					console.log(stderr);


### PR DESCRIPTION
Platform: Raspberry Pi

A fix to #1192. Where the plugins could not be installed when the OS password changed.

Removes 'sudo' from the plugin installation script. 
Root seems not to be required by the installation scripts of current plugins.
This has the benefits that neither the program itself needs to know any standard or generated sudo password (which would leave the sudo password readable), nor has the UI request for the sudo password and send it through the (unencrypted) network.