### PR TITLE
volumio_command_line_client: Use POSIX syntax for functions

### DIFF
--- a/app/asd.sh
+++ b/app/asd.sh
@@ -34,23 +34,23 @@ case "$1" in
 esac
 
 
-function start {
+start() {
 systemctl start volumio.service
 }
 
-function stop {
+stop() {
 systemctl stop volumio.service
 }
 
-function status {
+status() {
 echo "Not Implemented yet"
 }
 
-function volume {
+volume() {
 echo "reading volume"
 }
 
-function volumeset {
+volumeset() {
 "echo setting volume $volumeval"
 }
 
@@ -90,23 +90,23 @@ case "$1" in
 esac
 
 
-function start {
+start() {
 systemctl start volumio.service
 }
 
-function stop {
+stop() {
 systemctl stop volumio.service
 }
 
-function status {
+status() {
 echo "Not Implemented yet"
 }
 
-function volume {
+volume() {
 echo "reading volume"
 }
 
-function volumeset {
+volumeset() {
 "echo setting volume $volumeval"
 }
 

--- a/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-function kernelinstall {
+kernelinstall() {
 
 echo " ---- VOLUMIO RASPBERRY PI KERNEL SOURCE DOWNLOADER ----"
 echo " "

--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-function doc {
+doc() {
 echo "
 Usage : volumio <argument1> <argument2>
 
@@ -51,17 +51,17 @@ plugin publish                     publishes the plugin on git
 
 #VOLUMIO SERVICE CONTROLS
 
-function start {
+start() {
 echo volumio | sudo -S systemctl start volumio.service
 }
 
-function vstop {
+vstop() {
 echo volumio | sudo -S systemctl stop volumio.service
 }
 
 #VOLUMIO DEVELOPMENT
 
-function pull {
+pull() {
 echo "Stopping Volumio"
 echo volumio | sudo -S systemctl stop volumio.service
 echo volumio | sudo -S sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/pull.sh
@@ -70,7 +70,7 @@ echo volumio | sudo -S systemctl start volumio.service
 echo "Done"
 }
 
-function kernelsource {
+kernelsource() {
 echo volumio | sudo -S sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
 }
 


### PR DESCRIPTION
The traditional bourne shell (sh) does not support the 'function foo { ... }'
syntax, use the POSIX standard syntax, 'foo() { ... }', to improve portability.
The later syntax works with bash, sh and many other standard shells.

Fixes issue #904.