### PR TITLE
Optimize plugin install/update

### DIFF
--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -436,16 +436,22 @@ PluginManager.prototype.installPlugin = function (url) {
 	var defer=libQ.defer();
 	var modaltitle= 'Installing Plugin';
 	var advancedlog = '';
-
+	var downloadCommand;
 
 	var currentMessage = "Downloading plugin at "+url;
+	var droppedFile = url.replace("http://127.0.0.1:3000/plugin-serve/", "");
 	self.logger.info(currentMessage);
 	advancedlog = currentMessage;
 
+	if (droppedFile == url)
+		downloadCommand = "/usr/bin/wget -O /tmp/downloaded_plugin.zip '" + url + "'";
+	else
+		downloadCommand = "/bin/mv /tmp/plugins/"+ droppedFile +" /tmp/downloaded_plugin.zip";
+
 	self.pushMessage('installPluginStatus',{'progress': 10, 'message': 'Downloading plugin','title' : modaltitle, 'advancedLog': advancedlog});
 
-
-	exec("/usr/bin/wget -O /tmp/downloaded_plugin.zip '" + url + "'", function (error, stdout, stderr) {
+	
+	exec(downloadCommand, function (error, stdout, stderr) {
 
 		if (error !== null) {
 			currentMessage = "Cannot download file "+url+ ' - ' + error;
@@ -455,6 +461,7 @@ PluginManager.prototype.installPlugin = function (url) {
 		}
 		else {
 			currentMessage = "END DOWNLOAD: "+url;
+			self.rmDir('/tmp/plugins');
 			advancedlog = advancedlog + "<br>" + currentMessage;
 			self.logger.info(currentMessage);
 			currentMessage = 'Creating folder on disk';

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "convert-seconds": "^1.0.1",
     "cookie-parser": "^1.4.3",
     "cue-parser": "0.0.4",
-    "decompress-zip": "^0.3.0",
     "ejs": "^2.5.6",
     "express": "^4.15.0",
     "fast.js": "^0.1.1",


### PR DESCRIPTION
plugin install eventually does some quite intensive file I/O operations for deflating and moving directories around.
This PR replaces `decompress-zip` by native `miniunzip` and use linux `mv` operations.
Installs are now much faster, but more importantly much more RAM efficient.
`/tmp` is only used for first download, deflating happens in storage location, hence saving RAM (intermediate files are cleaned as soon as possible too).

Notes:
- `decompress-zip` can be removed from Volumio2 modules (not used elsewhere)
- `minizip` must be added to Build as per [relevant PR](https://github.com/volumio/Build/pull/207) (used `minizip` as `unzip` is overflowing `stdout`)

fixes https://github.com/volumio/Volumio2/issues/1220