### PR TITLE
pluginhelper: fix compress

### DIFF
--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -348,8 +348,8 @@ function zip(){
     try {
         if(fs.existsSync("node_modules")) {
             var package = fs.readJsonSync("package.json");
-            execSync("cd " + process.cwd() + " && /usr/bin/zip -r " +
-                package.name + ".zip *");
+            execSync("cd " + process.cwd() + " && /usr/bin/minizip -o -9 " +
+                package.name + ".zip $(find -type f -printf '%P ')");
             console.log("Plugin succesfully compressed");
         }
         else{
@@ -357,8 +357,8 @@ function zip(){
             try{
                 execSync("/usr/local/bin/npm install");
                 var package = fs.readJsonSync("package.json");
-                execSync("cd " + process.cwd() + " && /usr/bin/zip -r " +
-                    package.name + ".zip *");
+                execSync("cd " + process.cwd() + " && /usr/bin/minizip -o -9 " +
+                    package.name + ".zip $(find -type f -printf '%P ')");
                 console.log("Plugin succesfully compressed");
             }
             catch (e){

--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -348,7 +348,7 @@ function zip(){
     try {
         if(fs.existsSync("node_modules")) {
             var package = fs.readJsonSync("package.json");
-            execSync("cd " + process.cwd() + " && /usr/bin/minizip -o -9 " +
+            execSync("cd " + process.cwd() + " && /usr/bin/minizip -a -9 " +
                 package.name + ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P ')");
             console.log("Plugin succesfully compressed");
         }
@@ -357,7 +357,7 @@ function zip(){
             try{
                 execSync("/usr/local/bin/npm install");
                 var package = fs.readJsonSync("package.json");
-                execSync("cd " + process.cwd() + " && /usr/bin/minizip -o -9 " +
+                execSync("cd " + process.cwd() + " && /usr/bin/minizip -a -9 " +
                     package.name + ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P ')");
                 console.log("Plugin succesfully compressed");
             }

--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -358,7 +358,7 @@ function zip(){
                 execSync("/usr/local/bin/npm install");
                 var package = fs.readJsonSync("package.json");
                 execSync("cd " + process.cwd() + " && /usr/bin/minizip -o -9 " +
-                	package.name + ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P ')");
+                    package.name + ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P ')");
                 console.log("Plugin succesfully compressed");
             }
             catch (e){

--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -349,7 +349,7 @@ function zip(){
         if(fs.existsSync("node_modules")) {
             var package = fs.readJsonSync("package.json");
             execSync("cd " + process.cwd() + " && /usr/bin/minizip -o -9 " +
-                package.name + ".zip $(find -type f -printf '%P ')");
+                package.name + ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P ')");
             console.log("Plugin succesfully compressed");
         }
         else{
@@ -358,7 +358,7 @@ function zip(){
                 execSync("/usr/local/bin/npm install");
                 var package = fs.readJsonSync("package.json");
                 execSync("cd " + process.cwd() + " && /usr/bin/minizip -o -9 " +
-                    package.name + ".zip $(find -type f -printf '%P ')");
+                	package.name + ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P ')");
                 console.log("Plugin succesfully compressed");
             }
             catch (e){

--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -346,26 +346,20 @@ function refresh() {
 function zip(){
     console.log("Compressing the plugin");
     try {
-        if(fs.existsSync("node_modules")) {
-            var package = fs.readJsonSync("package.json");
-            execSync("cd " + process.cwd() + " && /usr/bin/minizip -a -9 " +
-                package.name + ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P ')");
-            console.log("Plugin succesfully compressed");
-        }
-        else{
+        if(! fs.existsSync("node_modules")) {
             console.log("No modules found, running \"npm install\"");
             try{
                 execSync("/usr/local/bin/npm install");
-                var package = fs.readJsonSync("package.json");
-                execSync("cd " + process.cwd() + " && /usr/bin/minizip -a -9 " +
-                    package.name + ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P ')");
-                console.log("Plugin succesfully compressed");
             }
             catch (e){
                 console.log("Error installing node modules: " + e);
                 process.exit(1);
             }
-        }
+        }        
+        var package = fs.readJsonSync("package.json");
+        execSync("cd " + process.cwd() + " && /usr/bin/minizip -o -9 " +
+            package.name + ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P ')");
+        console.log("Plugin succesfully compressed");
     }
     catch (e){
         console.log("Error compressing plugin: " + e);


### PR DESCRIPTION
Volumio does not include `zip` utility by default, so compress fails (unless added extra).
Since `minizip` is readily available, we use it instead.