### PR TITLE
pluginhelper: always compress within Publish

### DIFF
--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -416,9 +416,9 @@ function publish() {
             catch (e){
                 console.log("Nothing to commit");
             }
-            if (!fs.existsSync(package.name + ".zip")) {
-                zip();
-            }
+            
+            zip();
+            
             execSync("/bin/cp -rp " + package.name + ".zip /tmp/");
             process.chdir("../../../");
             execSync("/usr/bin/git checkout gh-pages");


### PR DESCRIPTION
Pre-existing package may not have new version number set at publish time: therefore, previously generated zip file may contain `package.json` with out-of-sync version number...
So it is safer to always re-create archive during publish.
Note: `zip()` already takes care of overwriting eventual older package, so no need to wipe before.