### PR TITLE
Improve user input hygiene in logsubmit.js

### DIFF
--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -391,7 +391,8 @@ ControllerSystem.prototype.sendBugReport = function (message) {
 		message.text = 'No info available';
 	}
 	fs.appendFileSync('/tmp/logfields', 'Description="' + message.text + '"\r\n');
-	exec('/usr/local/bin/node /volumio/logsubmit.js "'+ message.text+'"', {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
+    // Must single-quote the message or the shell may interpret it and crash.
+	exec("/usr/local/bin/node /volumio/logsubmit.js '"+ message.text+"'", {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
 		if (error !== null) {
 			self.logger.info('Canot send bug report: ' + error);
 		} else {

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -58,11 +58,12 @@ for (var itemN in commandArray) {
 
 var variant = getSystemVersion();
 
-var command = '/usr/bin/curl -X POST -H "Content-Type: multipart/form-data"'
-            + ' -F "logFile=@' + logFile + '"'
-            + ' -F "desc=' + args[0] + '"'
-            + ' -F "variant=' + variant + '"'
-            + ' "http://logs.volumio.org:7171/logs/v1"';
+// Use single quotes to avoid the shell expanding any characters in the form data
+var command = "/usr/bin/curl -X POST -H 'Content-Type: multipart/form-data'"
+            + " -F 'logFile=@" + logFile + "'"
+            + " -F 'desc=" + args[0] + "'"
+            + " -F 'variant=" + variant + "'"
+            + " 'http://logs.volumio.org:7171/logs/v1'";
 
 exec(command , {uid: 1000, gid: 1000, encoding: 'utf8'}, function (error, stdout, stderr) {
     if (error !== null) {

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -26,7 +26,7 @@ if (process.argv.slice(2)) {
 try {
     var args = process.argv.slice(2);
     //If description is supplied, add it
-    execSync("echo " + args[0] +  " >>" + logFile);
+    execSync("echo '" + args[0] +  "' >>" + logFile);
 } catch (e) {
     console.log(error)
 }

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -58,7 +58,11 @@ for (var itemN in commandArray) {
 
 var variant = getSystemVersion();
 
-var command = '/usr/bin/curl -X POST -H "Content-Type: multipart/form-data" -F "logFile=@'+logFile+'" -F "desc='+args[0]+'" -F "variant='+variant+'" "http://logs.volumio.org:7171/logs/v1"';
+var command = '/usr/bin/curl -X POST -H "Content-Type: multipart/form-data"'
+            + ' -F "logFile=@' + logFile + '"'
+            + ' -F "desc=' + args[0] + '"'
+            + ' -F "variant=' + variant + '"'
+            + ' "http://logs.volumio.org:7171/logs/v1"';
 
 exec(command , {uid: 1000, gid: 1000, encoding: 'utf8'}, function (error, stdout, stderr) {
     if (error !== null) {


### PR DESCRIPTION
@pilifsch found, to his/her confusion, that logsubmit does silly things when given a description containing parentheses. This series improves the quoting of the data from the /dev form so that should no longer happen.

Tested on stock 2.201 with just these changes.