### PR TITLE
fix softvolume bugs

### DIFF
--- a/app/plugins/audio_interface/alsa_controller/index.js
+++ b/app/plugins/audio_interface/alsa_controller/index.js
@@ -649,13 +649,17 @@ ControllerAlsa.prototype.saveVolumeOptions = function (data) {
 	self.setConfigParam({key: 'mixer', value: data.mixer.value});
 	} else if (data.mixer_type.value === 'Software') {
 		var outdevice = self.config.get('outputdevice');
-		self.enableSoftMixer(outdevice);
+		if (outdevice != 'sofvolume'){
+			self.enableSoftMixer(outdevice);
+		}
 	} else if (data.mixer_type.value === 'None'){
 		self.setConfigParam({key: 'mixer', value: ''});
 		var outdevice = self.config.get('outputdevice');
 		if (outdevice === 'softvolume'){
             var outdevice = self.config.get('softvolumenumber');
             this.config.set('outputdevice', outdevice);
+            this.config.delete('softvolumenumber');
+            this.commandRouter.executeOnPlugin('music_service', 'mpd', 'restartMpd', '');
 		}
 		self.commandRouter.sharedVars.set('alsa.outputdevice', outdevice);
 		self.disableSoftMixer(outdevice);

--- a/app/plugins/audio_interface/alsa_controller/index.js
+++ b/app/plugins/audio_interface/alsa_controller/index.js
@@ -649,7 +649,7 @@ ControllerAlsa.prototype.saveVolumeOptions = function (data) {
 	self.setConfigParam({key: 'mixer', value: data.mixer.value});
 	} else if (data.mixer_type.value === 'Software') {
 		var outdevice = self.config.get('outputdevice');
-		if (outdevice != 'sofvolume'){
+		if (outdevice !== 'sofvolume'){
 			self.enableSoftMixer(outdevice);
 		}
 	} else if (data.mixer_type.value === 'None'){


### PR DESCRIPTION
This fix is related to issue #1168 and #1239

1. Fix crash after changing one of the Volume Option parameters when Mixer Type is already set to „Software“
2. Fix bug setting Mixer Type from „Software“ to „None“