### PR TITLE
Some small tweaks for Shuffle

### DIFF
--- a/app/randomqueue.js
+++ b/app/randomqueue.js
@@ -60,13 +60,16 @@ class RandomQueue {
         this.modifyQueueLength();
         this.position++;
 
-        if (this.position >= this.queueMap.length - 1 && this.stateMachine.currentRepeat) {
+        if (this.position > this.queueMap.length - 1 && this.stateMachine.currentRepeat) {
             this.position = 0;
         } else if (this.position > this.queueMap.length - 1) {
             this.queueMap = [];
         }
 
         var nextIndex = this.getRandomListPosition(this.position);
+        if (nextIndex === undefined) {
+          this.position = 0;
+        }
         return nextIndex !== undefined ? nextIndex : this.stateMachine.playQueue.arrayQueue.length;
     }
 
@@ -81,6 +84,9 @@ class RandomQueue {
         }
 
         var prevIndex = this.getRandomListPosition(this.position);
+        if (prevIndex === undefined) {
+          this.position = 0;
+        }
         return prevIndex !== undefined ? prevIndex : this.stateMachine.playQueue.arrayQueue.length;
     }
 


### PR DESCRIPTION
Hello,

I am thrilled that Volumio now have a real shuffle mode thanks to abrarmahmood's contribution. Elegant code. Well done! Thanks.

So I tested it as once I had 2.246 up and working. At least for me Shuffle works only once, when I start to play a track again after the playlist is done the first time it only plays one track. When I combine Shuffle and Repeat some tracks seem not be played at all.

In this pull request I think i have fixed those two minor issues. It works for me. Check it out.

Details:
a) In the original code this.position that acts as a kind of shuffle counter is not reset after shuffle is done. I added a conditional statement in next and previous for that.
b) When Shuffle and Repeat is combined I changed when this.position is reset (when the next value of this.position > the number of tracks).

Note:
Previous and Next seem to work pretty well. But as I remember it  even in ordinary default sequential play mode those two do not behave consistently and do not work with web radio. Those issues are beyond this pull request.

  Best regards, CB