### PR TITLE
More logsubmit work

### DIFF
--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -391,8 +391,18 @@ ControllerSystem.prototype.sendBugReport = function (message) {
 		message.text = 'No info available';
 	}
 	fs.appendFileSync('/tmp/logfields', 'Description="' + message.text + '"\r\n');
-    // Must single-quote the message or the shell may interpret it and crash.
-	exec("/usr/local/bin/node /volumio/logsubmit.js '"+ message.text+"'", {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
+	// Must single-quote the message or the shell may interpret it and crash.
+	// single-quotes already within the message need to be escaped.
+	// The resulting string always starts and ends with single quotes.
+	var description = '';
+	var pieces = message.text.split("'");
+	var n = pieces.length;
+	for (var i=0; i<n; i++) {
+		description = description + "'" + pieces[i] + "'";
+		if (i < (n-1)) description = description + "\\'";
+	}
+
+	exec("/usr/local/bin/node /volumio/logsubmit.js " + description, {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
 		if (error !== null) {
 			self.logger.info('Canot send bug report: ' + error);
 		} else {

--- a/http/dev/dev.js
+++ b/http/dev/dev.js
@@ -65,6 +65,10 @@ socket.on('pushQueue', function(arrayQueue) {
 
 socket.on('pushSendBugReport', function(data) {
 
+	// defensive: make sure data has no junk prefixed or suffixed
+	var str = data;
+	str = str.replace('^[^{]*{','{');
+	str = str.replace('}[^{]*$','}');
 	var json = JSON.parse(data);
 	document.getElementById('bug-form-description').value = json.link;
 	var btn = document.getElementById('bug-form-button');

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -36,7 +36,7 @@ try {
     //If description is supplied, add it
     execSync("echo " + description + " >>" + logFile);
 } catch (e) {
-    console.log(error)
+    console.log(e);
 }
 
 execSync("cat /tmp/logfields >> " + logFile);
@@ -60,7 +60,7 @@ for (var itemN in commandArray) {
 	try {
 		execSync(cmd);
 	} catch(e) {
-		console.log(error);
+		console.log(e);
 	}
 }
 

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -17,16 +17,24 @@ var logFile = "/tmp/logondemand";
 // Let's start fresh!
 execSync("date >" + logFile);
 
-if (process.argv.slice(2)) {
-    var args = process.argv.slice(2);
+var args = process.argv.slice(2);
+var description;
+if ( args[0] == undefined ) {
+    description = 'Unknown';
 } else {
-    var args = ['Unknown'];
+    description = '';
+    // This will always yield a string that starts and ends with single quotes.
+    var pieces = args[0].split("'");
+    var n = pieces.length;
+    for (var i=0; i<n; i++) {
+        description = description + "'" + pieces[i] + "'";
+        if (i < (n-1)) description = description + "\\'";
+    }
 }
 
 try {
-    var args = process.argv.slice(2);
     //If description is supplied, add it
-    execSync("echo '" + args[0] +  "' >>" + logFile);
+    execSync("echo " + description + " >>" + logFile);
 } catch (e) {
     console.log(error)
 }
@@ -59,9 +67,10 @@ for (var itemN in commandArray) {
 var variant = getSystemVersion();
 
 // Use single quotes to avoid the shell expanding any characters in the form data
+// description is a special case, see above
 var command = "/usr/bin/curl -X POST -H 'Content-Type: multipart/form-data'"
             + " -F 'logFile=@" + logFile + "'"
-            + " -F 'desc=" + args[0] + "'"
+            + " -F desc=" + description
             + " -F 'variant=" + variant + "'"
             + " 'http://logs.volumio.org:7171/logs/v1'";
 


### PR DESCRIPTION
The fix I submitted a few days ago did not handle an important case - single quotes in the description. I've fixed that now, in the same way as we did in networkfs. The fix has been tested, see eg pBwpQAT.

While I was there I noticed the catch() clauses were using what seemed to be the wrong name for the error object.

Finally as described in #1237 I found it may be useful to clean up the data sent to socket.on('pushSendBugReport` before trying to parse it into json.

Comments and further testing welcome. Tested on 2.201 plus these patches.