### PR TITLE
'volumio toggle' fix for webradio

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1235,9 +1235,13 @@ CoreCommandRouter.prototype.volumioToggle = function () {
 	if (state.status != undefined) {
 		if(state.status==='stop' || state.status==='pause')
 		{
-        		return this.stateMachine.play();
-    		} else {
-        		return this.stateMachine.pause();
+			return this.stateMachine.play();
+		} else {
+			if(state.trackType == 'webradio') {
+				return this.stateMachine.stop();
+			} else {
+				return this.stateMachine.pause();
+			}
 		}
     }
 };


### PR DESCRIPTION
Currently the GUI changes the start button in a pause button when playing local files, but changes it to a stop button when playing webradio, as webradio cannot be paused succesfully. This is correct.

The problem is with remote controls. A remote control without a dedicated stop button has its play/pause button mapped to execute 'volumio toggle'. In case of webradio this would pause the stream, which would put the player in a wrong state. Firstly, the stream cannot not be started again using the remote ('volumio toggle' stops working), and secondly, the button in the GUI does not change, i.e. in the GUI it looks like the stream is still playing.

This fix changes 'volumio toggle' to check if webradio is playing and issue a stop() instead of the normal pause(). The code is equivalent to the [GUI code](https://github.com/volumio/Volumio2-UI/blob/7fca2a0a5aaa1b7a4c88dec5fce22f5fd1c4169b/src/app/themes/volumio/components/player-buttons/volumio-player-buttons.html#L32).