### PR TITLE
Volumio pull feature for branch and forked repository

### DIFF
--- a/app/plugins/system_controller/volumio_command_line_client/commands/pull.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/pull.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 
+REPO='https://github.com/volumio/Volumio2.git'
+BRANCH=''
+
+if [ $# -eq 3 ]; then
+    BRANCH="$2"
+    REPO="$3"
+elif [ $# -eq 2 ]; then
+    BRANCH="$2"
+fi
+
 cd /home/volumio
 echo "Backing Up current Volumio folder in /volumio-current"
 mv /volumio /volumio-current
 echo "Cloning Volumio Backend repo"
-git clone https://github.com/volumio/Volumio2.git /volumio
+if [ -n "$BRANCH" ]; then
+    echo "Cloning branch $BRANCH from repository $REPO"
+    git clone -b "$BRANCH" "$REPO" /volumio
+else
+    echo "Cloning master from repository $REPO"
+    git clone "$REPO" /volumio
+fi
 echo "Copying Modules"
 cp -rp /volumio-current/node_modules /volumio/node_modules
 echo "Copying UI"

--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -39,7 +39,9 @@ restart                             Restarts Volumio Service
 
 [[VOLUMIO DEVELOPMENT]]
 
-pull                               Pulls latest github status on master
+pull                               Pulls latest github status on master from https://github.com/volumio/Volumio2.git
+pull -b <branch>                   Pulls branch <branch> from https://github.com/volumio/Volumio2.git
+pull -b <branch> <repository>      Pulls branch <branch> from git repository <repository>
 kernelsource                       Gets Current Kernel source (Raspberry PI only)
 plugin init                        Creates a new plugin
 plugin refresh                     updates plugin in the system
@@ -64,7 +66,7 @@ echo volumio | sudo -S systemctl stop volumio.service
 pull() {
 echo "Stopping Volumio"
 echo volumio | sudo -S systemctl stop volumio.service
-echo volumio | sudo -S sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/pull.sh
+echo volumio | sudo -S sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/pull.sh $1 $2 $3
 echo "Pull completed, restarting Volumio"
 echo volumio | sudo -S systemctl start volumio.service
 echo "Done"
@@ -150,7 +152,7 @@ case "$1" in
             fi
             ;;
 	    pull)
-            pull
+            pull $2 $3 $4
             ;;
 	    kernelsource)
 	        kernelsource


### PR DESCRIPTION
Add a feature to volumio pull command to be able to specify branch and forked github repository for easier testing.

`volumio pull` Pulls latest github status on **_master_** from _https://github.com/volumio/Volumio2.git_
`volumio pull -b <branch>`  Pulls branch **_branch_** from _https://github.com/volumio/Volumio2.git_
`volumio pull -b <branch> <repository>`  Pulls branch **_branch_** from git repository **_repository_**

You can choose if this feature makes sense to you.