### PR TITLE
Make it clearer in the log when a sleep has been disabled

### DIFF
--- a/app/plugins/miscellanea/alarm-clock/index.js
+++ b/app/plugins/miscellanea/alarm-clock/index.js
@@ -299,7 +299,7 @@ AlarmClock.prototype.setSleep = function(data)
 	};
 	self.setSleepConf(sleepTask);
 
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'SetSleep: ' + splitted[0] + ' hours ' + splitted[1] + ' minutes');
+	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'SetSleep: ' + splitted[0] + ' hours ' + splitted[1] + ' minutes ' + ', enabled: ' + data.enabled);
 
 
 	if(self.haltSchedule!=undefined)


### PR DESCRIPTION
It's easy to spot a sleep being enabled, (```Set Sleep at ...```), less so for one being disabled, because setSleep is called, usually with a nonzero timeout.

Tested on 2.201, rpi2.