### PR TITLE
pluginhelper: move package.zip out of source directory

### DIFF
--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -413,7 +413,7 @@ function publish() {
             
             zip();
             
-            execSync("/bin/cp -rp " + package.name + ".zip /tmp/");
+            execSync("/bin/mv " + package.name + ".zip /tmp/");
             process.chdir("../../../");
             execSync("/usr/bin/git checkout gh-pages");
             var arch = "";


### PR DESCRIPTION
`cp` command keeps a copy of plugin archive within source directory: at next submit this zip file will be part of commit in source directory, which is not desirable (plugin archive is submitted elsewhere).
We could do this differently (by having zip function always produce file in `/tmp` for instance), but this works and does not affect anything else.