### PR TITLE
Logsubmit3

### DIFF
--- a/logsubmit.js
+++ b/logsubmit.js
@@ -49,12 +49,12 @@ for (var itemN in commandArray) {
 
 // remove sensitive information
 commandArray = [
-    "sed -i -r -e 's/([Pp]assword:  *)([^ ]*)(.*)$/\1<elided> \3/'",
-    "sed -i -r -e 's/([Ss]potify  *.*token is )(.*)$/\1<elided>/'",
-    "sed -i -r -e 's/(--[Pp]assword[ ][ ]*)([^ ]*)/\1<elided>/'",
-    "sed -i -r -e 's/(wlan[0-9]: WPS: UUID [^:]*: ).*$/\1<elided>/'",
-    "sed -i -r -e 's/(mount .*username=)([^,]*,)(.*)$/\1<elided>,\3/'",
-    "sed -i -r -e 's/(mount .*password=)([^,]*,)(.*)$/\1<elided>,\3/'"
+    "sed -i -r -e 's/([Pp]assword:  *)([^ ]*)(.*)$/\\1<elided> \\3/'",
+    "sed -i -r -e 's/([Ss]potify  *.*token is )(.*)$/\\1<elided>/'",
+    "sed -i -r -e 's/(--[Pp]assword[ ][ ]*)([^ ]*)/\\1<elided>/'",
+    "sed -i -r -e 's/(wlan[0-9]: WPS: UUID [^:]*: ).*$/\\1<elided>/'",
+    "sed -i -r -e 's/(mount .*username=)([^,]*,)(.*)$/\\1<elided>,\\3/'",
+    "sed -i -r -e 's/(mount .*password=)([^,]*,)(.*)$/\\1<elided>,\\3/'"
 ];
 for (var itemN in commandArray) {
 	var item = commandArray[itemN];

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -52,7 +52,9 @@ commandArray = [
     "sed -i -r -e 's/([Pp]assword:  *)([^ ]*)(.*)$/\1<elided> \3/'",
     "sed -i -r -e 's/([Ss]potify  *.*token is )(.*)$/\1<elided>/'",
     "sed -i -r -e 's/(--[Pp]assword[ ][ ]*)([^ ]*)/\1<elided>/'",
-    "sed -i -r -e 's/(wlan[0-9]: WPS: UUID [^:]*: ).*$/\1<elided>/'"
+    "sed -i -r -e 's/(wlan[0-9]: WPS: UUID [^:]*: ).*$/\1<elided>/'",
+    "sed -i -r -e 's/(mount .*username=)([^,]*)(,.*)$/\1<elided>\3/'",
+    "sed -i -r -e 's/(mount .*password=)([^,]*)(,.*)$/\1<elided>\3/'"
 ];
 for (var itemN in commandArray) {
 	var item = commandArray[itemN];

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -53,8 +53,8 @@ commandArray = [
     "sed -i -r -e 's/([Ss]potify  *.*token is )(.*)$/\1<elided>/'",
     "sed -i -r -e 's/(--[Pp]assword[ ][ ]*)([^ ]*)/\1<elided>/'",
     "sed -i -r -e 's/(wlan[0-9]: WPS: UUID [^:]*: ).*$/\1<elided>/'",
-    "sed -i -r -e 's/(mount .*username=)([^,]*)(,.*)$/\1<elided>\3/'",
-    "sed -i -r -e 's/(mount .*password=)([^,]*)(,.*)$/\1<elided>\3/'"
+    "sed -i -r -e 's/(mount .*username=)([^,]*,)(.*)$/\1<elided>,\3/'",
+    "sed -i -r -e 's/(mount .*password=)([^,]*,)(.*)$/\1<elided>,\3/'"
 ];
 for (var itemN in commandArray) {
 	var item = commandArray[itemN];


### PR DESCRIPTION
Another place for passwords to lurk was reported. 
Tested with 2.246 on rpi2. That turned up another oversight, that the backslashes in the sed  backreferences needed to be doubled in order to survive the various quotings as we construct the string that gets ```execSync()```ed.
To add to the fun, the ```<elided>``` string ends up being invisible when viewing the htmlified log in a browser window, but can be revealed by 'view source'. We wanted to hide that text anyway, so no further change needed.
Please test...