### PR TITLE
Add to playlist from any music service plugin

### DIFF
--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -547,6 +547,33 @@ PlaylistManager.prototype.commonAddToPlaylist = function (folder, name, service,
 				});
 
 			});
+		} else {
+			// handle generally for all music service plugins
+			var result = self.commandRouter.executeOnPlugin('music_service', service, 'getTrackInfo', uri);
+			if (result) {
+				result.then(function (info) {
+					fs.readJson(filePath, function (err, data) {
+						if (err)
+							defer.resolve({ success: false });
+						else {
+							var output = data.concat(info);
+							fs.writeJson(filePath, output, function (err) {
+								if (err) {
+									defer.resolve({ success: false });
+								}
+								else {
+									defer.resolve(info);
+								}
+							})
+						}
+					});
+				}).fail(function (err) {
+					self.logger.error('Failed adding to playlist with error: ' + err);
+					defer.resolve({ success: false });
+				});
+			} else {
+				defer.resolve({ success: false });
+			}
 		}
 	});
 
@@ -571,7 +598,6 @@ PlaylistManager.prototype.commonRemoveFromPlaylist = function (folder, name, ser
 					defer.resolve({ success: false });
 				else {
 					var newData = [];
-
 					for (var i = 0; i < data.length; i++) {
 						if (data[i].uri !== uri) {
 							newData.push(data[i]);

--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -32,12 +32,13 @@ PlaylistManager.prototype.createPlaylist = function (name) {
 
 	fs.exists(filePath, function (exists) {
 		if (exists)
-			defer.resolve({success: false, reason: 'Playlist already exists'});
+			defer.resolve({ success: false, reason: 'Playlist already exists' });
 		else {
 			fs.writeJson(filePath, playlist, function (err) {
 				if (err)
-					defer.resolve({success: false});
-				else defer.resolve({success: true});
+					defer.resolve({ success: false });
+				else
+					defer.resolve({ success: true });
 			});
 		}
 
@@ -58,15 +59,15 @@ PlaylistManager.prototype.deletePlaylist = function (name) {
 
 	fs.exists(filePath, function (exists) {
 		if (!exists)
-			defer.resolve({success: false, reason: 'Playlist does not exist'});
+			defer.resolve({ success: false, reason: 'Playlist does not exist' });
 		else {
 			fs.unlink(filePath, function (err) {
 				if (err) {
-					defer.resolve({success: false});
+					defer.resolve({ success: false });
 				} else {
 					var playlists = self.listPlaylist();
 					self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('PLAYLIST.REMOVE_SUCCESS'),
-						name + ' ' +  self.commandRouter.getI18nString('PLAYLIST.REMOVE_SUCCESS'));
+						name + ' ' + self.commandRouter.getI18nString('PLAYLIST.REMOVE_SUCCESS'));
 					defer.resolve(playlists);
 				}
 			});
@@ -83,7 +84,7 @@ PlaylistManager.prototype.listPlaylist = function () {
 
 	this.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Listing playlists');
 
-	fs.readdir(this.playlistFolder, function(err,folderContents) {
+	fs.readdir(this.playlistFolder, function (err, folderContents) {
 		defer.resolve(folderContents);
 	});
 
@@ -111,22 +112,22 @@ PlaylistManager.prototype.addToPlaylist = function (name, service, uri) {
 
 	//self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Adding uri '+uri+' to playlist '+name);
 	self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('PLAYLIST.ADDED_TITLE'),
-        uri +  self.commandRouter.getI18nString('PLAYLIST.ADDED_TO_PLAYLIST') + name);
+		uri + self.commandRouter.getI18nString('PLAYLIST.ADDED_TO_PLAYLIST') + name);
 	return self.commonAddToPlaylist(self.playlistFolder, name, service, uri);
 };
 
 PlaylistManager.prototype.addItemsToPlaylist = function (name, data) {
-    var self = this;
+	var self = this;
 
-    //self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Adding uri '+uri+' to playlist '+name);
-    return self.commonAddToPlaylist(self.playlistFolder, name, service, uri);
+	//self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Adding uri '+uri+' to playlist '+name);
+	return self.commonAddToPlaylist(self.playlistFolder, name, service, uri);
 };
 
 
 PlaylistManager.prototype.removeFromPlaylist = function (name, service, uri) {
 	var self = this;
 
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Removing uri ' + uri + ' to playlist ' + name);
+	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Removing uri ' + uri + ' from playlist ' + name);
 
 	return self.commonRemoveFromPlaylist(self.playlistFolder, name, service, uri);
 };
@@ -150,34 +151,34 @@ PlaylistManager.prototype.enqueue = function (name) {
 
 	fs.exists(filePath, function (exists) {
 		if (!exists)
-			defer.resolve({success: false, reason: 'Playlist does not exist'});
+			defer.resolve({ success: false, reason: 'Playlist does not exist' });
 		else {
 			fs.readJson(filePath, function (err, data) {
 				if (err)
-					defer.resolve({success: false});
+					defer.resolve({ success: false });
 				else {
-                    var promises = [];
-                    var promise;
+					var promises = [];
+					var promise;
 
-                    var array = [];
+					var array = [];
 
-                    for (var i in data) {
-                        var item = {
-                            service: data[i].service,
-                            uri: data[i].uri,
-                            name: data[i].title,
-                            artist: data[i].artist,
-                            album: data[i].album,
-                            albumart: data[i].albumart
-                        }
+					for (var i in data) {
+						var item = {
+							service: data[i].service,
+							uri: data[i].uri,
+							name: data[i].title,
+							artist: data[i].artist,
+							album: data[i].album,
+							albumart: data[i].albumart
+						}
 
-                        array.push(item);
-                    }
+						array.push(item);
+					}
 
-                    self.commandRouter.addQueueItems(array);
+					self.commandRouter.addQueueItems(array);
 
-                    defer.resolve();
-                }
+					defer.resolve();
+				}
 			});
 		}
 
@@ -196,7 +197,7 @@ PlaylistManager.prototype.getFavouritesContent = function (name) {
 PlaylistManager.prototype.addToFavourites = function (service, uri, title) {
 	var self = this;
 
-	if (title){
+	if (title) {
 		self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('PLAYLIST.ADDED_TITLE'), title + self.commandRouter.getI18nString('PLAYLIST.ADDED_TO_FAVOURITES'));
 	} else self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('PLAYLIST.ADDED_TITLE'), uri + self.commandRouter.getI18nString('PLAYLIST.ADDED_TO_FAVOURITES'));
 
@@ -213,9 +214,9 @@ PlaylistManager.prototype.removeFromFavourites = function (name, service, uri) {
 	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'Removing uri ' + uri + ' from favourites');
 
 	if (service === 'webradio') {
-		return self.commonRemoveFromPlaylist(self.favouritesPlaylistFolder,'radio-favourites',service,uri);
+		return self.commonRemoveFromPlaylist(self.favouritesPlaylistFolder, 'radio-favourites', service, uri);
 	} else {
-		return self.commonRemoveFromPlaylist(self.favouritesPlaylistFolder,'favourites',service,uri);
+		return self.commonRemoveFromPlaylist(self.favouritesPlaylistFolder, 'favourites', service, uri);
 	}
 };
 
@@ -282,7 +283,7 @@ PlaylistManager.prototype.addToMyWebRadio = function (service, radio_name, uri) 
 
 		fs.readJson(filePath, function (err, data) {
 			if (err)
-				defer.resolve({success: false});
+				defer.resolve({ success: false });
 			else {
 				//searching for item with same name
 				var alreadyExists = false;
@@ -295,17 +296,17 @@ PlaylistManager.prototype.addToMyWebRadio = function (service, radio_name, uri) 
 				}
 
 				if (alreadyExists == false) {
-					data.push({service: service, name: radio_name, uri: uri});
+					data.push({ service: service, name: radio_name, uri: uri });
 				}
 
 				fs.writeJson(filePath, data, function (err) {
 					if (err) {
-						self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('WEBRADIO.WEBRADIO') , '');
-						defer.resolve({success: false});
+						self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('WEBRADIO.WEBRADIO'), '');
+						defer.resolve({ success: false });
 					}
 
 					else {
-						defer.resolve({success: true});
+						defer.resolve({ success: true });
 						self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('WEBRADIO.WEBRADIO') + ' ' + self.commandRouter.getI18nString('PLAYLIST.ADDED_TITLE'), radio_name);
 					}
 				})
@@ -331,7 +332,7 @@ PlaylistManager.prototype.removeFromMyWebRadio = function (name, service, uri) {
 
 		fs.readJson(filePath, function (err, data) {
 			if (err)
-				defer.resolve({success: false});
+				defer.resolve({ success: false });
 			else {
 				//searching for item with same name
 				for (var i in data) {
@@ -342,8 +343,8 @@ PlaylistManager.prototype.removeFromMyWebRadio = function (name, service, uri) {
 
 				fs.writeJson(filePath, data, function (err) {
 					if (err)
-						defer.resolve({success: false});
-					else defer.resolve({success: true});
+						defer.resolve({ success: false });
+					else defer.resolve({ success: true });
 				})
 			}
 		});
@@ -380,131 +381,127 @@ PlaylistManager.prototype.commonAddToPlaylist = function (folder, name, service,
 			fs.writeJsonSync(filePath, playlist);
 		}
 		if (service === 'mpd') {
-		    var listingDefer=libQ.defer();;
+			var listingDefer = libQ.defer();;
 
-            var mpdPlugin = self.commandRouter.pluginManager.getPlugin('music_service', 'mpd');
+			var mpdPlugin = self.commandRouter.pluginManager.getPlugin('music_service', 'mpd');
 
-            if(uri.startsWith("genres://"))
-            {
-               mpdPlugin.listGenre(uri)
-                    .then(function(entries){
-                    listingDefer.resolve(entries.navigation.lists[2].items);
-                }).fail(function(){
-                    listingDefer.reject(new Error());
-                })
-            }
-            else if(uri.startsWith("artists://"))
-            {
-                mpdPlugin.listArtist(uri,2,'')
-                    .then(function(entries){
-                        listingDefer.resolve(entries.navigation.lists[1].items);
-                    }).fail(function(){
-                    listingDefer.reject(new Error());
-                })
-            }
-            else if(uri.startsWith("albums://"))
-            {
-                mpdPlugin.listAlbumSongs(uri,2,'')
-                    .then(function(entries){
-                        listingDefer.resolve(entries.navigation.lists[0].items);
-                    }).fail(function(){
-                    listingDefer.reject(new Error());
-                })
-            }
-            else if (uri.startsWith("mnt/")) {
-
-                var lsfolder = mpdPlugin.listallFolder(uri);
-                lsfolder.then(function (info) {
-                    var list = info.navigation.lists[0].items;
-                    var nItems = list.length;
-                    var entries = [];
-                    for (var i = 0; i < nItems; i++) {
-                        var item = list[i];
-                        if (item.type == 'song') {
-                            if (item.uri.indexOf('music-library/') >= 0) {
-                                var itemUri = item.uri.replace('music-library', '');
-                            } 
-                            else {
-                                var itemUri = item.uri;
-                            }
-                            entries.push({
-                                service: service,
-                                uri: itemUri,
-                                title: item.title,
-                                artist: item.artist,
-                                album: item.album,
-                                albumart: item.albumart
-                            });
-                        } 
-                    }
-                    listingDefer.resolve(entries);
-                });							
+			if (uri.startsWith("genres://")) {
+				mpdPlugin.listGenre(uri)
+					.then(function (entries) {
+						listingDefer.resolve(entries.navigation.lists[2].items);
+					}).fail(function () {
+						listingDefer.reject(new Error());
+					})
 			}
-		    else {
-                var prms = self.commandRouter.executeOnPlugin('music_service', 'mpd', 'lsInfo', uri);
-                prms.then(function (info) {
-                    //
-                    // Collate new entries
-                    //
+			else if (uri.startsWith("artists://")) {
+				mpdPlugin.listArtist(uri, 2, '')
+					.then(function (entries) {
+						listingDefer.resolve(entries.navigation.lists[1].items);
+					}).fail(function () {
+						listingDefer.reject(new Error());
+					})
+			}
+			else if (uri.startsWith("albums://")) {
+				mpdPlugin.listAlbumSongs(uri, 2, '')
+					.then(function (entries) {
+						listingDefer.resolve(entries.navigation.lists[0].items);
+					}).fail(function () {
+						listingDefer.reject(new Error());
+					})
+			}
+			else if (uri.startsWith("mnt/")) {
 
-                    var list = info.navigation.lists[0].items;
-                    var nItems = list.length;
+				var lsfolder = mpdPlugin.listallFolder(uri);
+				lsfolder.then(function (info) {
+					var list = info.navigation.lists[0].items;
+					var nItems = list.length;
+					var entries = [];
+					for (var i = 0; i < nItems; i++) {
+						var item = list[i];
+						if (item.type == 'song') {
+							if (item.uri.indexOf('music-library/') >= 0) {
+								var itemUri = item.uri.replace('music-library', '');
+							}
+							else {
+								var itemUri = item.uri;
+							}
+							entries.push({
+								service: service,
+								uri: itemUri,
+								title: item.title,
+								artist: item.artist,
+								album: item.album,
+								albumart: item.albumart
+							});
+						}
+					}
+					listingDefer.resolve(entries);
+				});
+			}
+			else {
+				var prms = self.commandRouter.executeOnPlugin('music_service', 'mpd', 'lsInfo', uri);
+				prms.then(function (info) {
+					//
+					// Collate new entries
+					//
 
-                    var entries = [];
-                    for (var i = 0; i < nItems; i++) {
-                        var item = list[i];
+					var list = info.navigation.lists[0].items;
+					var nItems = list.length;
 
-                        if (item.type == 'song') {
-                            var artUrl = self.commandRouter.executeOnPlugin('music_service', 'mpd', 'getAlbumArt', {
-                                artist: item.artist,
-                                album: item.album
-                            }, path, '');
-                            if (item.uri.indexOf('music-library/') >= 0) {
-                                var itemUri = item.uri.replace('music-library', '');
-                            } else var itemUri = item.uri;
+					var entries = [];
+					for (var i = 0; i < nItems; i++) {
+						var item = list[i];
 
-                            entries.push({
-                                service: service,
-                                uri: itemUri,
-                                title: item.title,
-                                artist: item.artist,
-                                album: item.album,
-                                albumart: artUrl
-                            });
-                        } else if (item.type == 'folder') {
-                            // TODO: Deal with folders
-                        }
-                    }
+						if (item.type == 'song') {
+							var artUrl = self.commandRouter.executeOnPlugin('music_service', 'mpd', 'getAlbumArt', {
+								artist: item.artist,
+								album: item.album
+							}, path, '');
+							if (item.uri.indexOf('music-library/') >= 0) {
+								var itemUri = item.uri.replace('music-library', '');
+							} else var itemUri = item.uri;
 
-                    listingDefer.resolve(entries);
-                });
-            }
+							entries.push({
+								service: service,
+								uri: itemUri,
+								title: item.title,
+								artist: item.artist,
+								album: item.album,
+								albumart: artUrl
+							});
+						} else if (item.type == 'folder') {
+							// TODO: Deal with folders
+						}
+					}
+
+					listingDefer.resolve(entries);
+				});
+			}
 
 
-            listingDefer.then(function(entries)
-            {
-                fs.readJson(filePath, function (err, data) {
-                    if (err)
-                        defer.resolve({success: false});
-                    else {
-                        var output = data.concat(entries);
-                        console.log(filePath)
-                        fs.writeJson(filePath, output, function (err) {
-                            if (err!==undefined && err!==null)
-                                defer.resolve({success: false});
-                            else {
-                                var favourites = self.commandRouter.checkFavourites({uri: path});
-                                defer.resolve({});
-                            }
-                        })
-                    }
-                });
-            });
+			listingDefer.then(function (entries) {
+				fs.readJson(filePath, function (err, data) {
+					if (err)
+						defer.resolve({ success: false });
+					else {
+						var output = data.concat(entries);
+						console.log(filePath)
+						fs.writeJson(filePath, output, function (err) {
+							if (err !== undefined && err !== null)
+								defer.resolve({ success: false });
+							else {
+								var favourites = self.commandRouter.checkFavourites({ uri: path });
+								defer.resolve({});
+							}
+						})
+					}
+				});
+			});
 
 		} else if (service === 'webradio') {
 			fs.readJson(filePath, function (err, data) {
 				if (err)
-					defer.resolve({success: false});
+					defer.resolve({ success: false });
 				else {
 					data.push({
 						service: service, uri: uri, title: title,
@@ -513,9 +510,9 @@ PlaylistManager.prototype.commonAddToPlaylist = function (folder, name, service,
 
 					fs.writeJson(filePath, data, function (err) {
 						if (err)
-							defer.resolve({success: false});
+							defer.resolve({ success: false });
 						else
-							var favourites = self.commandRouter.checkFavourites({uri: uri});
+							var favourites = self.commandRouter.checkFavourites({ uri: uri });
 						defer.resolve(favourites);
 					})
 				}
@@ -536,14 +533,14 @@ PlaylistManager.prototype.commonAddToPlaylist = function (folder, name, service,
 				});
 				fs.readJson(filePath, function (err, data) {
 					if (err)
-						defer.resolve({success: false});
+						defer.resolve({ success: false });
 					else {
 						var output = data.concat(entries);
 						fs.writeJson(filePath, output, function (err) {
 							if (err)
-								defer.resolve({success: false});
+								defer.resolve({ success: false });
 							else
-								var favourites = self.commandRouter.checkFavourites({uri: path});
+								var favourites = self.commandRouter.checkFavourites({ uri: path });
 							defer.resolve(favourites);
 						})
 					}
@@ -567,11 +564,11 @@ PlaylistManager.prototype.commonRemoveFromPlaylist = function (folder, name, ser
 
 	fs.exists(filePath, function (exists) {
 		if (!exists)
-			defer.resolve({success: false, reason: 'Playlist does not exist'});
+			defer.resolve({ success: false, reason: 'Playlist does not exist' });
 		else {
 			fs.readJson(filePath, function (err, data) {
 				if (err)
-					defer.resolve({success: false});
+					defer.resolve({ success: false });
 				else {
 					var newData = [];
 
@@ -611,11 +608,11 @@ PlaylistManager.prototype.commonPlayPlaylist = function (folder, name) {
 
 	fs.exists(filePath, function (exists) {
 		if (!exists)
-			defer.resolve({success: false, reason: 'Playlist does not exist'});
+			defer.resolve({ success: false, reason: 'Playlist does not exist' });
 		else {
 			fs.readJson(filePath, function (err, data) {
 				if (err)
-					defer.resolve({success: false});
+					defer.resolve({ success: false });
 				else {
 					self.commandRouter.volumioClearQueue();
 
@@ -631,25 +628,23 @@ PlaylistManager.prototype.commonPlayPlaylist = function (folder, name) {
 						}*/ else uri = data[i].uri;
 
 
-                        var service;
+						var service;
 
-                        if(data[i].service===undefined)
-                            service='mpd';
-                        else service=data[i].service;
+						if (data[i].service === undefined)
+							service = 'mpd';
+						else service = data[i].service;
 
-						uris.push({uri:uri,service:service});
+						uris.push({ uri: uri, service: service });
 					}
 
-                    self.commandRouter.addQueueItems(uris)
-                        .then(function()
-                        {
-                            self.commandRouter.volumioPlay(0);
-                            defer.resolve();
-                        })
-                        .fail(function()
-                        {
-                            defer.reject(new Error());
-                        })
+					self.commandRouter.addQueueItems(uris)
+						.then(function () {
+							self.commandRouter.volumioPlay(0);
+							defer.resolve();
+						})
+						.fail(function () {
+							defer.reject(new Error());
+						})
 					//self.commandRouter.executeOnPlugin('music_service', 'mpd', 'clearAddPlayTracks', uris);
 
 				}
@@ -694,33 +689,33 @@ PlaylistManager.prototype.listFavourites = function (uri) {
 
 	var promise = self.getFavouritesContent();
 	promise.then(function (data) {
-			var response = {
-				navigation: {
-					prev: {
-						uri: ''
-					},
-					lists: [{availableListViews:['list'],items:[]}]
-				}
+		var response = {
+			navigation: {
+				prev: {
+					uri: ''
+				},
+				lists: [{ availableListViews: ['list'], items: [] }]
+			}
+		};
+
+		for (var i in data) {
+			var ithdata = data[i];
+			var song = {
+				service: ithdata.service,
+				type: 'song',
+				title: ithdata.title,
+				artist: ithdata.artist,
+				album: ithdata.album,
+				albumart: ithdata.albumart,
+				uri: ithdata.uri
 			};
 
-			for (var i in data) {
-				var ithdata = data[i];
-				var song = {
-					service: ithdata.service,
-					type: 'song',
-					title: ithdata.title,
-					artist: ithdata.artist,
-					album: ithdata.album,
-					albumart: ithdata.albumart,
-					uri: ithdata.uri
-				};
+			response.navigation.lists[0].items.push(song);
+		}
 
-				response.navigation.lists[0].items.push(song);
-			}
+		defer.resolve(response);
 
-			defer.resolve(response);
-
-		})
+	})
 		.fail(function () {
 			defer.reject(new Error("Cannot list Favourites"));
 		});
@@ -731,35 +726,33 @@ PlaylistManager.prototype.listFavourites = function (uri) {
 
 
 PlaylistManager.prototype.commonAddItemsToPlaylist = function (folder, name, data) {
-    var self = this;
+	var self = this;
 
-    var defer = libQ.defer();
+	var defer = libQ.defer();
 
-    var playlist = [];
-    var filePath = folder + name;
+	var playlist = [];
+	var filePath = folder + name;
 
-    for(var i in data)
-    {
-        playlist.push({
-            service: data[i].service,
-            uri: self.sanitizeUri(data[i].uri),
-            title: data[i].name,
-            artist: data[i].artist,
-            album: data[i].album,
-            albumart: data[i].albumart
-        });
-    }
+	for (var i in data) {
+		playlist.push({
+			service: data[i].service,
+			uri: self.sanitizeUri(data[i].uri),
+			title: data[i].name,
+			artist: data[i].artist,
+			album: data[i].album,
+			albumart: data[i].albumart
+		});
+	}
 
-    fs.writeJson(filePath,playlist,function(err)
-    {
-        if(err)
-            defer.reject(new Error('Cannot write playlist file'));
-        else defer.resolve();
-    });
+	fs.writeJson(filePath, playlist, function (err) {
+		if (err)
+			defer.reject(new Error('Cannot write playlist file'));
+		else defer.resolve();
+	});
 
-    return defer.promise;
+	return defer.promise;
 };
 
 PlaylistManager.prototype.sanitizeUri = function (uri) {
-    return uri.replace('music-library/', '').replace('mnt/', '');
+	return uri.replace('music-library/', '').replace('mnt/', '');
 }

--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -573,11 +573,9 @@ PlaylistManager.prototype.commonRemoveFromPlaylist = function (folder, name, ser
 					var newData = [];
 
 					for (var i = 0; i < data.length; i++) {
-						if (!(data[i].service == service &&
-							data[i].uri == uri)) {
+						if (data[i].uri !== uri) {
 							newData.push(data[i]);
 						}
-
 					}
 
 					fs.writeJson(filePath, newData, function (err) {

--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -599,7 +599,7 @@ PlaylistManager.prototype.commonRemoveFromPlaylist = function (folder, name, ser
 				else {
 					var newData = [];
 					for (var i = 0; i < data.length; i++) {
-						if (data[i].uri !== uri) {
+						if (!(data[i].service == service && data[i].uri == uri)) {
 							newData.push(data[i]);
 						}
 					}

--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -756,7 +756,6 @@ function InterfaceWebUI(context) {
       connWebSocket.on('removeFromPlaylist', function (data) {
         var selfConnWebSocket = this;
         var playlistname = data.name;
-        console.log(data);
         var returnedData = self.commandRouter.playListManager.removeFromPlaylist(data.name, data.service, data.uri);
         returnedData.then(function (name) {
           var response = self.musicLibrary.executeBrowseSource('playlists/' + playlistname);

--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -9,31 +9,31 @@ var fs = require('fs-extra');
  */
 module.exports = InterfaceWebUI;
 function InterfaceWebUI(context) {
-	var self = this;
+  var self = this;
 
-	self.context = context;
-	self.commandRouter = self.context.coreCommand;
-    self.musicLibrary=self.commandRouter.musicLibrary;
+  self.context = context;
+  self.commandRouter = self.context.coreCommand;
+  self.musicLibrary = self.commandRouter.musicLibrary;
 
-	self.logger = self.commandRouter.logger;
+  self.logger = self.commandRouter.logger;
 
-	/** Init SocketIO listener */
-	self.libSocketIO = require('socket.io')(self.context.websocketServer);
+  /** Init SocketIO listener */
+  self.libSocketIO = require('socket.io')(self.context.websocketServer);
 
-	/** On Client Connection, listen for various types of clients requests */
-	self.libSocketIO.on('connection', function (connWebSocket) {
-		try {
-            connWebSocket.on('getDeviceInfo', function () {
-                var uuid=self.commandRouter.sharedVars.get('system.uuid');
-                var name=self.commandRouter.sharedVars.get('system.name');
+  /** On Client Connection, listen for various types of clients requests */
+  self.libSocketIO.on('connection', function (connWebSocket) {
+    try {
+      connWebSocket.on('getDeviceInfo', function () {
+        var uuid = self.commandRouter.sharedVars.get('system.uuid');
+        var name = self.commandRouter.sharedVars.get('system.name');
 
-                var data={
-                    "uuid":uuid,
-                    "name":name
-                };
-                connWebSocket.emit('pushDeviceInfo', data);
+        var data = {
+          "uuid": uuid,
+          "name": name
+        };
+        connWebSocket.emit('pushDeviceInfo', data);
 
-            });
+      });
 
 			/** Request Volumio State
 			 * It returns an array definining the Playback state, Volume and other amenities
@@ -52,18 +52,18 @@ function InterfaceWebUI(context) {
 			 * @mute if true, Volumio is muted
 			 * @service current playback service (mpd, spop...)
 			 */
-			connWebSocket.on('getState', function () {
-				var selfConnWebSocket = this;
+      connWebSocket.on('getState', function () {
+        var selfConnWebSocket = this;
 
-				var timeStart = Date.now();
-				var state = self.commandRouter.volumioGetState();
-				self.logStart('Client requests Volumio state')
-					.then(self.pushState.bind(self, state, selfConnWebSocket))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
+        var timeStart = Date.now();
+        var state = self.commandRouter.volumioGetState();
+        self.logStart('Client requests Volumio state')
+          .then(self.pushState.bind(self, state, selfConnWebSocket))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
 			/* Error handling: causes  Maximum call stack size exceeded
 			 connWebSocket.on('error', function () {
 			 selfConnWebSocket = this;
@@ -72,964 +72,918 @@ function InterfaceWebUI(context) {
 
 			 });
 			 */
-			connWebSocket.on('getQueue', function () {
-				var selfConnWebSocket = this;
+      connWebSocket.on('getQueue', function () {
+        var selfConnWebSocket = this;
 
-				var timeStart = Date.now();
-				var queue = self.commandRouter.volumioGetQueue();
-				self.logStart('Client requests Volumio queue')
-					.then(self.pushQueue.bind(self, queue, selfConnWebSocket))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
+        var timeStart = Date.now();
+        var queue = self.commandRouter.volumioGetQueue();
+        self.logStart('Client requests Volumio queue')
+          .then(self.pushQueue.bind(self, queue, selfConnWebSocket))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
 
-			connWebSocket.on('removeQueueItem', function (nIndex) {
-				var timeStart = Date.now();
-				self.logStart('Client requests remove Volumio queue item')
-					.then(function () {
-						return self.commandRouter.volumioRemoveQueueItem.call(self.commandRouter, nIndex);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
+      connWebSocket.on('removeQueueItem', function (nIndex) {
+        var timeStart = Date.now();
+        self.logStart('Client requests remove Volumio queue item')
+          .then(function () {
+            return self.commandRouter.volumioRemoveQueueItem.call(self.commandRouter, nIndex);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
 
-			connWebSocket.on('addQueueUids', function (arrayUids) {
-				var timeStart = Date.now();
-				self.logStart('Client requests add Volumio queue items')
-					.then(function () {
+      connWebSocket.on('addQueueUids', function (arrayUids) {
+        var timeStart = Date.now();
+        self.logStart('Client requests add Volumio queue items')
+          .then(function () {
 
-                        self.logger.info("POST");
-						return self.commandRouter.volumioAddQueueUids.call(self.commandRouter, arrayUids);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
+            self.logger.info("POST");
+            return self.commandRouter.volumioAddQueueUids.call(self.commandRouter, arrayUids);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
 
-			connWebSocket.on('addToQueue', function (data) {
-                var timeStart = Date.now();
+      connWebSocket.on('addToQueue', function (data) {
+        var timeStart = Date.now();
 
-                 self.commandRouter.addQueueItems(data);
-			});
+        self.commandRouter.addQueueItems(data);
+      });
 
-			connWebSocket.on('replaceAndPlay', function (data) {
-				var timeStart = Date.now();
+      connWebSocket.on('replaceAndPlay', function (data) {
+        var timeStart = Date.now();
 
-				self.commandRouter.replaceAndPlay(data)
-				.then(function(e){
-					return self.commandRouter.volumioPlay(e.firstItemIndex);
-				});
-			});
+        self.commandRouter.replaceAndPlay(data)
+          .then(function (e) {
+            return self.commandRouter.volumioPlay(e.firstItemIndex);
+          });
+      });
 
-            connWebSocket.on('replaceAndPlayCue', function (data) {
-                var timeStart = Date.now();
+      connWebSocket.on('replaceAndPlayCue', function (data) {
+        var timeStart = Date.now();
 
-                if (data.service == undefined || data.service == 'mpd') {
-                    var uri = data.uri;
-                    var arr = uri.split("/");
-                    arr.shift();
-                    var str = arr.join('/');
+        if (data.service == undefined || data.service == 'mpd') {
+          var uri = data.uri;
+          var arr = uri.split("/");
+          arr.shift();
+          var str = arr.join('/');
+        }
+        else str = data.uri;
+
+        self.logStart('Client requests Volumio Clear Queue')
+          .then(self.commandRouter.volumioClearQueue.bind(self.commandRouter))
+          .then(function () {
+            self.commandRouter.executeOnPlugin('music_service', 'mpd', 'addPlayCue', {
+              'uri': str,
+              'number': data.number
+            });
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+
+      });
+
+      connWebSocket.on('addPlay', function (data) {
+
+        self.commandRouter.addQueueItems(data)
+          .then(function (e) {
+            return self.commandRouter.volumioPlay(e.firstItemIndex);
+          });
+        /*
+        
+        
+                        var timeStart = Date.now();
+                        self.logStart('Client requests add and Play Volumio queue item')
+                            .then(function () {
+                                return self.commandRouter.addQueueItem.call(self.commandRouter, data);
+                            })
+                            .fail(self.pushError.bind(self))
+                            .done(function () {
+                                return self.logDone(timeStart);
+                            });
+        
+        
+        
+                        if (data.service == undefined || data.service == 'mpd') {
+                  var uri = data.uri;
+                  var arr = uri.split("/");
+                  arr.shift();
+                  var str = arr.join('/');
                 }
                 else str = data.uri;
-
-                self.logStart('Client requests Volumio Clear Queue')
-                    .then(self.commandRouter.volumioClearQueue.bind(self.commandRouter))
-					.then(function () {
-						self.commandRouter.executeOnPlugin('music_service', 'mpd', 'addPlayCue', {
-                        'uri': str,
-                        'number': data.number
-                    });
-                })
-                    .fail(self.pushError.bind(self))
-                    .done(function () {
-                        return self.logDone(timeStart);
-                    });
-
-            });
-
-			connWebSocket.on('addPlay', function (data) {
-
-                self.commandRouter.addQueueItems(data)
-                    .then(function(e){
-                        return self.commandRouter.volumioPlay(e.firstItemIndex);
-                    });
-/*
-
-
+        
+        
+                //TODO add proper service handler
                 var timeStart = Date.now();
-                self.logStart('Client requests add and Play Volumio queue item')
-                    .then(function () {
-                        return self.commandRouter.addQueueItem.call(self.commandRouter, data);
-                    })
-                    .fail(self.pushError.bind(self))
-                    .done(function () {
-                        return self.logDone(timeStart);
-                    });
+                self.logStart('Client requests add and Play Volumio queue items')
+                  .then(function () {
+                    return self.commandRouter.executeOnPlugin('music_service', 'mpd', 'addPlay', str);
+                  })
+                  .fail(self.pushError.bind(self))
+                  .done(function () {
+                    return self.commandRouter.pushToastMessage('success', "Play", str);
+                  });*/
+      });
 
+      connWebSocket.on('addPlayCue', function (data) {
+        if (data.service == undefined || data.service == 'mpd') {
+          var uri = data.uri;
+          var arr = uri.split("/");
+          arr.shift();
+          var str = arr.join('/');
+        }
+        else str = data.uri;
 
-
-                if (data.service == undefined || data.service == 'mpd') {
-					var uri = data.uri;
-					var arr = uri.split("/");
-					arr.shift();
-					var str = arr.join('/');
-				}
-				else str = data.uri;
-
-
-				//TODO add proper service handler
-				var timeStart = Date.now();
-				self.logStart('Client requests add and Play Volumio queue items')
-					.then(function () {
-						return self.commandRouter.executeOnPlugin('music_service', 'mpd', 'addPlay', str);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.commandRouter.pushToastMessage('success', "Play", str);
-					});*/
-			});
-
-			connWebSocket.on('addPlayCue', function (data) {
-				if (data.service == undefined || data.service == 'mpd') {
-					var uri = data.uri;
-					var arr = uri.split("/");
-					arr.shift();
-					var str = arr.join('/');
-				}
-				else str = data.uri;
-
-				//TODO add proper service handler
-				var timeStart = Date.now();
-				self.logStart('Client requests add and Play Volumio CUE entry')
-					.then(function () {
-						return self.commandRouter.executeOnPlugin('music_service', 'mpd', 'addPlayCue', {
-							'uri': str,
-							'number': data.number
-						});
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('COMMON.PLAY'), str);
-					});
-			});
-
-			connWebSocket.on('removeFromQueue', function (positionN) {
-				//TODO add proper service handler
-				var timeStart = Date.now();
-				var position = positionN.value;
-				self.logStart('Client requests remove Volumio queue items')
-					.then(function () {
-						return self.commandRouter.volumioRemoveQueueItem(positionN);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('seek', function (position) {
-				//TODO add proper service handler
-				var timeStart = Date.now();
-				self.logStart('Client requests Seek to ' + position)
-					.then(function () {
-						return self.commandRouter.volumioSeek(position);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('getLibraryListing', function (objParams) {
-				var selfConnWebSocket = this;
-
-				var timeStart = Date.now();
-				self.logStart('Client requests get library listing')
-					.then(function () {
-						return self.commandRouter.volumioGetLibraryListing.call(self.commandRouter, objParams.uid, objParams.options);
-					})
-					.then(function (objBrowseData) {
-						if (objBrowseData) {
-							return self.pushLibraryListing.call(self, objBrowseData, selfConnWebSocket);
-						}
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('getLibraryFilters', function (sUid) {
-				var selfConnWebSocket = this;
-
-				var timeStart = Date.now();
-				self.logStart('Client requests get library index')
-					.then(function () {
-						return self.commandRouter.volumioGetLibraryFilters.call(self.commandRouter, sUid);
-					})
-					.then(function (objBrowseData) {
-						if (objBrowseData) {
-							return self.pushLibraryFilters.call(self, objBrowseData, selfConnWebSocket);
-						}
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('getPlaylistIndex', function (sUid) {
-				var selfConnWebSocket = this;
-
-				var timeStart = Date.now();
-				self.logStart('Client requests get playlist index')
-					.then(function () {
-						return self.commandRouter.volumioGetPlaylistIndex.call(self.commandRouter, sUid);
-					})
-					.then(function (objBrowseData) {
-						if (objBrowseData) {
-							return self.pushPlaylistIndex.call(self, objBrowseData, selfConnWebSocket);
-						}
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('play', function (N) {
-				var timeStart = Date.now();
-				if (N == null) {
-					self.logStart('Client requests Volumio play')
-						.then(self.commandRouter.volumioPlay.bind(self.commandRouter))
-						.fail(self.pushError.bind(self))
-						.done(function () {
-							return self.logDone(timeStart);
-						});
-				} else if (N.value != undefined) {
-                    self.logStart('Client requests Volumio play at index '+N.value)
-                        .then(self.commandRouter.volumioPlay.bind(self.commandRouter,N.value))
-                        .done(function () {
-                            return self.logDone(timeStart);
-                        });
-				}
-			});
-
-			connWebSocket.on('pause', function () {
-				var timeStart = Date.now();
-				self.logStart('Client requests Volumio pause')
-					.then(self.commandRouter.volumioPause.bind(self.commandRouter))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-            connWebSocket.on('toggle', function () {
-                var timeStart = Date.now();
-                self.logStart('Client requests Volumio toggle')
-                    .then(self.commandRouter.volumioToggle.bind(self.commandRouter))
-                    .fail(self.pushError.bind(self))
-                    .done(function () {
-                        return self.logDone(timeStart);
-                    });
+        //TODO add proper service handler
+        var timeStart = Date.now();
+        self.logStart('Client requests add and Play Volumio CUE entry')
+          .then(function () {
+            return self.commandRouter.executeOnPlugin('music_service', 'mpd', 'addPlayCue', {
+              'uri': str,
+              'number': data.number
             });
-
-			connWebSocket.on('stop', function () {
-				var timeStart = Date.now();
-				self.logStart('Client requests Volumio stop')
-					.then(self.commandRouter.volumioStop.bind(self.commandRouter))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('clearQueue', function () {
-				var timeStart = Date.now();
-				self.logStart('Client requests Volumio Clear Queue')
-					.then(self.commandRouter.volumioClearQueue.bind(self.commandRouter))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('prev', function () {
-				var timeStart = Date.now();
-				self.logStart('Client requests Volumio previous')
-					.then(self.commandRouter.volumioPrevious.bind(self.commandRouter))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('next', function () {
-				var timeStart = Date.now();
-				self.logStart('Client requests Volumio next')
-					.then(self.commandRouter.volumioNext.bind(self.commandRouter))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('setRandom', function (data) {
-				//TODO add proper service handler
-				var timeStart = Date.now();
-				self.logStart('Client requests Volumio Random ' + data.value)
-					.then(function () {
-                        return self.commandRouter.volumioRandom(data.value);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('setRepeat', function (data) {
-				//TODO add proper service handler
-				var timeStart = Date.now();
-				self.logStart('Client requests Volumio Repeat ' + data.value+' single '+data.repeatSingle)
-					.then(function () {
-                        return self.commandRouter.volumioRepeat(data.value,data.repeatSingle);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('serviceUpdateTracklist', function (sService) {
-				var timeStart = Date.now();
-				self.logStart('Client requests Update Tracklist')
-					.then(function () {
-						self.commandRouter.serviceUpdateTracklist.call(self.commandRouter, sService);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('rebuildLibrary', function () {
-				var timeStart = Date.now();
-				self.logStart('Client requests Volumio Rebuild Library')
-					.then(self.commandRouter.volumioRebuildLibrary.bind(self.commandRouter))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('updateAllMetadata', function () {
-				var timeStart = Date.now();
-				self.logStart('Client requests update metadata cache')
-					.then(self.commandRouter.updateAllMetadata.bind(self.commandRouter))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('volume', function (VolumeInteger) {
-				var timeStart = Date.now();
-				self.logStart('Client requests Volume ' + VolumeInteger)
-					.then(function () {
-						return self.commandRouter.volumiosetvolume.call(self.commandRouter, VolumeInteger);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('mute', function () {
-				var timeStart = Date.now();
-				var VolumeInteger = 'mute';
-				self.logStart('Client requests Mute')
-					.then(function () {
-						return self.commandRouter.volumiosetvolume.call(self.commandRouter, VolumeInteger);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('unmute', function () {
-				var timeStart = Date.now();
-				var VolumeInteger = 'unmute';
-				self.logStart('Client requests Unmute')
-					.then(function () {
-						return self.commandRouter.volumiosetvolume.call(self.commandRouter, VolumeInteger);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('importServicePlaylists', function () {
-				var timeStart = Date.now();
-				self.logStart('Client requests import of playlists')
-					.then(self.commandRouter.volumioImportServicePlaylists.bind(self.commandRouter))
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-
-			connWebSocket.on('getMenuItems', function () {
-				var timeStart = Date.now();
-				self.logStart('Client requests Menu Items')
-					.then(function () {
-
-						var lang_code = self.commandRouter.sharedVars.get('language_code');
-
-						var defer=libQ.defer();
-						self.commandRouter.i18nJson(__dirname+'/../../../i18n/strings_'+lang_code+'.json',
-							__dirname+'/../../../i18n/strings_en.json',
-							__dirname + '/../../../mainmenu.json')
-							.then(function(menuitems)
-							{
-
-
-						//console.log(JSON.stringify(menuitems['menuItems']));
-
-						self.libSocketIO.emit('printConsoleMessage', menuitems['menuItems']);
-						return self.libSocketIO.emit('pushMenuItems', menuitems['menuItems']);
-					})
-					.fail(self.pushError.bind(self))
-					.done(function () {
-						return self.logDone(timeStart);
-					});
-			});
-			});
-
-			connWebSocket.on('callMethod', function (dataJson) {
-				var promise;
-
-				var category = dataJson.endpoint.substring(0, dataJson.endpoint.indexOf('/'));
-				var name = dataJson.endpoint.substring(dataJson.endpoint.indexOf('/') + 1);
-
-                self.logger.info("CALLMETHOD: "+category+" "+name+" "+dataJson.method+" "+dataJson.data);
-				var promise = self.commandRouter.executeOnPlugin(category, name, dataJson.method, dataJson.data);
-				if (promise != undefined) {
-							connWebSocket.emit(promise.message, promise.payload);
-				} else {
-				}
-			});
-
-			connWebSocket.on('getUiConfig', function (data) {
-				var selfConnWebSocket = this;
-
-				var splitted = data.page.split('/');
-				var response;
-
-				if (splitted.length == 2) {
-					response = self.commandRouter.getUIConfigOnPlugin(splitted[0], splitted[1], {});
-					response.then(function(config)
-					{
-						selfConnWebSocket.emit('pushUiConfig', config);
-					});
-				} else if (splitted.length == 3) {
-					selfConnWebSocket.emit('pushUiConfig', {"page": {"label": ""},"sections": [{"coreSection":splitted[2]}]});
-				} else {
-					response = self.commandRouter.getUIConfigOnPlugin('system_controller', splitted[0], {});
-					response.then(function(config)
-					{
-						selfConnWebSocket.emit('pushUiConfig', config);
-					});
-				}
-
-
-
-
-			});
-
-			connWebSocket.on('getMultiRoomDevices', function (data) {
-				var selfConnWebSocket = this;
-
-				self.pushMultiroom(selfConnWebSocket);
-			});
-
-			connWebSocket.on('getBrowseSources', function (date) {
-				var selfConnWebSocket = this;
-				var response;
-
-				response = self.commandRouter.volumioGetBrowseSources();
-
-				selfConnWebSocket.emit('pushBrowseSources', response);
-			});
-
-			connWebSocket.on('browseLibrary', function (data) {
-				var selfConnWebSocket = this;
-
-				var curUri = data.uri;
-
-				var response;
-
-				response=self.musicLibrary.executeBrowseSource(curUri);
-
-				if (response != undefined) {
-					response.then(function (result) {
-							selfConnWebSocket.emit('pushBrowseLibrary', result);
-						})
-						.fail(function () {
-							self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
-						});
-				}
-
-			});
-
-			// TO DO: ADD TRANSLATIONS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-			connWebSocket.on('manageBackup', function (data) {
-				var selfConnWebSocket = this;
-
-				var value = data;
-
-				var response;
-
-				response=self.commandRouter.managePlaylists(value)
-					.then(self.commandRouter.manageFavourites(value))
-					.fail(function () {
-						self.printToastMessage('error', "Backup error", 'An error occurred while managing backups');
-					});
-			});
-
-			connWebSocket.on('getBackup', function (data) {
-				var selfConnWebSocket = this;
-
-				var response = self.commandRouter.loadBackup(data);
-
-				if (response != undefined) {
-					response.then(function (result) {
-						selfConnWebSocket.emit('pushBackup', result);
-					})
-						.fail(function () {
-							self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
-						});
-				}
-
-			});
-
-			connWebSocket.on('restoreConfig', function (data) {
-				var selfConnWebSocket = this;
-
-				var response = self.commandRouter.restorePluginsConf()
-					.then(self.commandRouter.restorePluginsConf())
-					.fail(function () {
-							self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
-						});
-			});
-
-			connWebSocket.on('search', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.musicLibrary.search(data);
-				returnedData.then(function (result) {
-					selfConnWebSocket.emit('pushBrowseLibrary', result);
-				});
-			});
-
-			connWebSocket.on('goTo', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.musicLibrary.goto(data);
-				returnedData.then(function (result) {
-					selfConnWebSocket.emit('pushBrowseLibrary', result);
-				});
-			});
-
-
-			connWebSocket.on('GetTrackInfo', function (data) {
-				var selfConnWebSocket = this;
-				selfConnWebSocket.emit('pushGetTrackInfo', data);
-			});
-
-			//add my web radio
-			connWebSocket.on('addWebRadio', function (data) {
-				var selfConnWebSocket = this;
-
-				var response;
-
-				response = self.commandRouter.executeOnPlugin('music_service', 'webradio', 'addMyWebRadio', data);
-
-				if (response != undefined) {
-					response.then(function (result) {
-							selfConnWebSocket.emit('pushAddWebRadio', result);
-						})
-						.fail(function () {
-							self.printToastMessage('error', "Search error", 'An error occurred while Searching');
-						});
-				}
-			});
-
-
-			connWebSocket.on('removeWebRadio', function (data) {
-				var selfConnWebSocket = this;
-
-				var response;
-
-				response = self.commandRouter.executeOnPlugin('music_service', 'webradio', 'removeMyWebRadio', data);
-
-				if (response != undefined) {
-					response.then(function (result) {
-
-						var response2=self.musicLibrary.executeBrowseSource('radio/myWebRadio');
-
-						if (response2 != undefined) {
-							response2.then(function (result2) {
-								selfConnWebSocket.emit('pushBrowseLibrary', result2);
-							})
-								.fail(function () {
-									self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
-								});
-						}
-						})
-						.fail(function () {
-							self.printToastMessage('error', "Search error", 'An error occurred while Searching');
-						});
-				}
-			});
-
-
-			// PLAYLIST MANAGEMENT
-			connWebSocket.on('createPlaylist', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.playListManager.createPlaylist(data.name);
-				returnedData.then(function (data) {
-                    selfConnWebSocket.emit('pushListPlaylist', data);
-					selfConnWebSocket.emit('pushCreatePlaylist', data);
-				});
-
-
-			});
-
-			connWebSocket.on('deletePlaylist', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.playListManager.deletePlaylist(data.name);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushListPlaylist', data);
-					var response=self.musicLibrary.executeBrowseSource('playlists');
-
-					if (response != undefined) {
-						response.then(function (result) {
-							selfConnWebSocket.emit('pushBrowseLibrary', result);
-						})
-							.fail(function () {
-								self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
-							});
-					}
-				});
-
-
-
-
-			});
-
-			connWebSocket.on('listPlaylist', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.playListManager.listPlaylist();
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushListPlaylist', data);
-				});
-
-
-			});
-
-			connWebSocket.on('addToPlaylist', function (data) {
-			    var selfConnWebSocket = this;
-
-                var returnedData = self.commandRouter.playListManager.addToPlaylist(data.name, data.service, data.uri);
-				returnedData.then(function (data) {
-                    var returnedListData = self.commandRouter.playListManager.listPlaylist();
-                    returnedListData.then(function (listdata) {
-                        selfConnWebSocket.emit('pushListPlaylist', listdata);
-                    });
-
-                    selfConnWebSocket.emit('pushAddToPlaylist', data);
-				});
-
-			});
-
-			connWebSocket.on('removeFromPlaylist', function (data) {
-				var selfConnWebSocket = this;
-				var playlistname = data.name;
-				var returnedData = self.commandRouter.playListManager.removeFromPlaylist(data.name, 'mpd', data.uri);
-				returnedData.then(function (name) {
-					var response=self.musicLibrary.executeBrowseSource('playlists/'+playlistname);
-					if (response != undefined) {
-						response.then(function (result) {
-							selfConnWebSocket.emit('pushBrowseLibrary', result);
-						})
-							.fail(function () {
-								self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
-							});
-					}
-				});
-
-
-			});
-
-			connWebSocket.on('playPlaylist', function (data) {
-				var selfConnWebSocket = this;
-				var returnedData = self.commandRouter.playPlaylist(data.name);
-
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushPlayPlaylist', data);
-				});
-
-
-			});
-
-			connWebSocket.on('enqueue', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.playListManager.enqueue(data.name);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushEnqueue', data);
-				});
-
-
-			});
-
-			//Favourites
-
-			connWebSocket.on('addToFavourites', function (data) {
-				var selfConnWebSocket = this;
-				//console.log(data);
-
-				var returnedData = self.commandRouter.playListManager.addToFavourites(data.service, data.uri, data.title);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('urifavourites', data);
-				});
-
-			});
-
-			connWebSocket.on('removeFromFavourites', function (data) {
-				var selfConnWebSocket = this;
-				var returnedData = self.commandRouter.playListManager.removeFromFavourites(data.name, data.service, data.uri);
-				returnedData.then(function () {
-					if (data.service === 'shoutcast') {
-						response = self.commandRouter.executeOnPlugin('music_service', 'shoutcast', 'listRadioFavourites');
-						if (response != undefined) {
-							response.then(function (result) {
-									selfConnWebSocket.emit('pushBrowseLibrary', result);
-								})
-								.fail(function () {
-									self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
-								});
-						}
-					} else {
-					var response = self.commandRouter.playListManager.listFavourites();
-					if (response != undefined) {
-						response.then(function (result) {
-								selfConnWebSocket.emit('pushBrowseLibrary', result);
-							})
-							.fail(function () {
-								self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
-							});
-					}
-					}
-				});
-
-
-			});
-
-			connWebSocket.on('playFavourites', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.playListManager.playFavourites(data.name);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushPlayFavourites', data);
-				});
-
-
-			});
-
-			// Radio Favourites
-
-			connWebSocket.on('addToRadioFavourites', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.playListManager.addToRadioFavourites('shoutcast', data.uri);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushAddToRadioFavourites', data);
-				});
-
-			});
-
-			connWebSocket.on('removeFromRadioFavourites', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.playListManager.removeFromRadioFavourites(data.name, 'shoutcast', data.uri);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushRemoveFromRadioFavourites', data);
-				});
-
-
-			});
-
-			connWebSocket.on('playRadioFavourites', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.playListManager.playRadioFavourites();
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushPlayRadioFavourites', data);
-				});
-
-
-			});
-
-
-			connWebSocket.on('getSleep', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'alarm-clock', 'getSleep', data);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushSleep', data);
-				});
-
-
-			});
-
-
-			connWebSocket.on('setSleep', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'alarm-clock', 'setSleep', data);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushSleep', data);
-				});
-
-
-			});
-
-			connWebSocket.on('getAlarms', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'alarm-clock', 'getAlarms', '');
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushAlarm', data);
-				});
-
-
-			});
-
-
-			connWebSocket.on('saveAlarm', function (data) {
-				var selfConnWebSocket = this;
-				//console.log(data);
-
-				var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'alarm-clock', 'saveAlarm', data);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushSleep', data);
-				});
-
-
-
-			});
-
-			connWebSocket.on('getMultiroom', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'getMultiroom', data);
-
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						if (data != undefined) {
-							selfConnWebSocket.emit('pushMultiroom', data);
-						}
-					});
-				}
-				else console.log("Plugin multiroom or method getMultiroom not found");
-
-
-			});
-
-
-			connWebSocket.on('setMultiroom', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'setMultiroom', data);
-				returnedData.then(function (data) {
-					selfConnWebSocket.emit('pushMultiroom', data);
-				});
-
-
-			});
-
-			connWebSocket.on('writeMultiroom', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'writeMultiRoom', data);
-
-			});
-
-			connWebSocket.on('receiveMultiroomDeviceUpdate', function (data) {
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'volumiodiscovery', 'receiveMultiroomDeviceUpdate', data);
-			});
-
-
-			connWebSocket.on('setAsMultiroomSingle', function (data) {
-				//console.log("Setting as multiroomSingle");
-				var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'setSingle', data);
-
-			});
-			connWebSocket.on('setAsMultiroomServer', function (data) {
-				//console.log("Setting as multiroomServer");
-				var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'setServer', data);
-				//selfConnWebSocket.emit('pushWriteMultiroom',data);
-
-			});
-			connWebSocket.on('setAsMultiroomClient', function (data) {
-				//console.log("Setting as multiroomClient");
-				var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'setClient', data);
-				//selfConnWebSocket.emit('pushWriteMultiroom',data);
-
-			});
-
-			connWebSocket.on('shutdown', function () {
-				//console.log('Received Shutdown Command');
-
-				return self.commandRouter.shutdown();
-
-			});
-
-			connWebSocket.on('reboot', function () {
-				//console.log('Received Reboot Command');
-				return self.commandRouter.reboot();
-
-			});
-
-			connWebSocket.on('getWirelessNetworks', function () {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'network', 'getWirelessNetworks', '');
-
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						selfConnWebSocket.emit('pushWirelessNetworks', data);
-					});
-				}
-				else console.log("Error on returning wireless networks");
-
-
-			});
-
-			connWebSocket.on('saveWirelessNetworkSettings', function (data) {
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'network', 'saveWirelessNetworkSettings', data);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('COMMON.PLAY'), str);
+          });
+      });
+
+      connWebSocket.on('removeFromQueue', function (positionN) {
+        //TODO add proper service handler
+        var timeStart = Date.now();
+        var position = positionN.value;
+        self.logStart('Client requests remove Volumio queue items')
+          .then(function () {
+            return self.commandRouter.volumioRemoveQueueItem(positionN);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('seek', function (position) {
+        //TODO add proper service handler
+        var timeStart = Date.now();
+        self.logStart('Client requests Seek to ' + position)
+          .then(function () {
+            return self.commandRouter.volumioSeek(position);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('getLibraryListing', function (objParams) {
+        var selfConnWebSocket = this;
+
+        var timeStart = Date.now();
+        self.logStart('Client requests get library listing')
+          .then(function () {
+            return self.commandRouter.volumioGetLibraryListing.call(self.commandRouter, objParams.uid, objParams.options);
+          })
+          .then(function (objBrowseData) {
+            if (objBrowseData) {
+              return self.pushLibraryListing.call(self, objBrowseData, selfConnWebSocket);
+            }
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('getLibraryFilters', function (sUid) {
+        var selfConnWebSocket = this;
+
+        var timeStart = Date.now();
+        self.logStart('Client requests get library index')
+          .then(function () {
+            return self.commandRouter.volumioGetLibraryFilters.call(self.commandRouter, sUid);
+          })
+          .then(function (objBrowseData) {
+            if (objBrowseData) {
+              return self.pushLibraryFilters.call(self, objBrowseData, selfConnWebSocket);
+            }
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('getPlaylistIndex', function (sUid) {
+        var selfConnWebSocket = this;
+
+        var timeStart = Date.now();
+        self.logStart('Client requests get playlist index')
+          .then(function () {
+            return self.commandRouter.volumioGetPlaylistIndex.call(self.commandRouter, sUid);
+          })
+          .then(function (objBrowseData) {
+            if (objBrowseData) {
+              return self.pushPlaylistIndex.call(self, objBrowseData, selfConnWebSocket);
+            }
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('play', function (N) {
+        var timeStart = Date.now();
+        if (N == null) {
+          self.logStart('Client requests Volumio play')
+            .then(self.commandRouter.volumioPlay.bind(self.commandRouter))
+            .fail(self.pushError.bind(self))
+            .done(function () {
+              return self.logDone(timeStart);
+            });
+        } else if (N.value != undefined) {
+          self.logStart('Client requests Volumio play at index ' + N.value)
+            .then(self.commandRouter.volumioPlay.bind(self.commandRouter, N.value))
+            .done(function () {
+              return self.logDone(timeStart);
+            });
+        }
+      });
+
+      connWebSocket.on('pause', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests Volumio pause')
+          .then(self.commandRouter.volumioPause.bind(self.commandRouter))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('toggle', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests Volumio toggle')
+          .then(self.commandRouter.volumioToggle.bind(self.commandRouter))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('stop', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests Volumio stop')
+          .then(self.commandRouter.volumioStop.bind(self.commandRouter))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('clearQueue', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests Volumio Clear Queue')
+          .then(self.commandRouter.volumioClearQueue.bind(self.commandRouter))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('prev', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests Volumio previous')
+          .then(self.commandRouter.volumioPrevious.bind(self.commandRouter))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('next', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests Volumio next')
+          .then(self.commandRouter.volumioNext.bind(self.commandRouter))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('setRandom', function (data) {
+        //TODO add proper service handler
+        var timeStart = Date.now();
+        self.logStart('Client requests Volumio Random ' + data.value)
+          .then(function () {
+            return self.commandRouter.volumioRandom(data.value);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('setRepeat', function (data) {
+        //TODO add proper service handler
+        var timeStart = Date.now();
+        self.logStart('Client requests Volumio Repeat ' + data.value + ' single ' + data.repeatSingle)
+          .then(function () {
+            return self.commandRouter.volumioRepeat(data.value, data.repeatSingle);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('serviceUpdateTracklist', function (sService) {
+        var timeStart = Date.now();
+        self.logStart('Client requests Update Tracklist')
+          .then(function () {
+            self.commandRouter.serviceUpdateTracklist.call(self.commandRouter, sService);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('rebuildLibrary', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests Volumio Rebuild Library')
+          .then(self.commandRouter.volumioRebuildLibrary.bind(self.commandRouter))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('updateAllMetadata', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests update metadata cache')
+          .then(self.commandRouter.updateAllMetadata.bind(self.commandRouter))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('volume', function (VolumeInteger) {
+        var timeStart = Date.now();
+        self.logStart('Client requests Volume ' + VolumeInteger)
+          .then(function () {
+            return self.commandRouter.volumiosetvolume.call(self.commandRouter, VolumeInteger);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('mute', function () {
+        var timeStart = Date.now();
+        var VolumeInteger = 'mute';
+        self.logStart('Client requests Mute')
+          .then(function () {
+            return self.commandRouter.volumiosetvolume.call(self.commandRouter, VolumeInteger);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('unmute', function () {
+        var timeStart = Date.now();
+        var VolumeInteger = 'unmute';
+        self.logStart('Client requests Unmute')
+          .then(function () {
+            return self.commandRouter.volumiosetvolume.call(self.commandRouter, VolumeInteger);
+          })
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('importServicePlaylists', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests import of playlists')
+          .then(self.commandRouter.volumioImportServicePlaylists.bind(self.commandRouter))
+          .fail(self.pushError.bind(self))
+          .done(function () {
+            return self.logDone(timeStart);
+          });
+      });
+
+      connWebSocket.on('getMenuItems', function () {
+        var timeStart = Date.now();
+        self.logStart('Client requests Menu Items')
+          .then(function () {
+
+            var lang_code = self.commandRouter.sharedVars.get('language_code');
+
+            var defer = libQ.defer();
+            self.commandRouter.i18nJson(__dirname + '/../../../i18n/strings_' + lang_code + '.json',
+              __dirname + '/../../../i18n/strings_en.json',
+              __dirname + '/../../../mainmenu.json')
+              .then(function (menuitems) {
+
+
+                //console.log(JSON.stringify(menuitems['menuItems']));
+
+                self.libSocketIO.emit('printConsoleMessage', menuitems['menuItems']);
+                return self.libSocketIO.emit('pushMenuItems', menuitems['menuItems']);
+              })
+              .fail(self.pushError.bind(self))
+              .done(function () {
+                return self.logDone(timeStart);
+              });
+          });
+      });
+
+      connWebSocket.on('callMethod', function (dataJson) {
+        var promise;
+
+        var category = dataJson.endpoint.substring(0, dataJson.endpoint.indexOf('/'));
+        var name = dataJson.endpoint.substring(dataJson.endpoint.indexOf('/') + 1);
+
+        self.logger.info("CALLMETHOD: " + category + " " + name + " " + dataJson.method + " " + dataJson.data);
+        var promise = self.commandRouter.executeOnPlugin(category, name, dataJson.method, dataJson.data);
+        if (promise != undefined) {
+          connWebSocket.emit(promise.message, promise.payload);
+        } else {
+        }
+      });
+
+      connWebSocket.on('getUiConfig', function (data) {
+        var selfConnWebSocket = this;
+
+        var splitted = data.page.split('/');
+        var response;
+
+        if (splitted.length == 2) {
+          response = self.commandRouter.getUIConfigOnPlugin(splitted[0], splitted[1], {});
+          response.then(function (config) {
+            selfConnWebSocket.emit('pushUiConfig', config);
+          });
+        } else if (splitted.length == 3) {
+          selfConnWebSocket.emit('pushUiConfig', { "page": { "label": "" }, "sections": [{ "coreSection": splitted[2] }] });
+        } else {
+          response = self.commandRouter.getUIConfigOnPlugin('system_controller', splitted[0], {});
+          response.then(function (config) {
+            selfConnWebSocket.emit('pushUiConfig', config);
+          });
+        }
+
+
+
+
+      });
+
+      connWebSocket.on('getMultiRoomDevices', function (data) {
+        var selfConnWebSocket = this;
+
+        self.pushMultiroom(selfConnWebSocket);
+      });
+
+      connWebSocket.on('getBrowseSources', function (date) {
+        var selfConnWebSocket = this;
+        var response;
+
+        response = self.commandRouter.volumioGetBrowseSources();
+
+        selfConnWebSocket.emit('pushBrowseSources', response);
+      });
+
+      connWebSocket.on('browseLibrary', function (data) {
+        var selfConnWebSocket = this;
+
+        var curUri = data.uri;
+
+        var response;
+
+        response = self.musicLibrary.executeBrowseSource(curUri);
+
+        if (response != undefined) {
+          response.then(function (result) {
+            selfConnWebSocket.emit('pushBrowseLibrary', result);
+          })
+            .fail(function () {
+              self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
+            });
+        }
+
+      });
+
+      // TO DO: ADD TRANSLATIONS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      connWebSocket.on('manageBackup', function (data) {
+        var selfConnWebSocket = this;
+
+        var value = data;
+
+        var response;
+
+        response = self.commandRouter.managePlaylists(value)
+          .then(self.commandRouter.manageFavourites(value))
+          .fail(function () {
+            self.printToastMessage('error', "Backup error", 'An error occurred while managing backups');
+          });
+      });
+
+      connWebSocket.on('getBackup', function (data) {
+        var selfConnWebSocket = this;
+
+        var response = self.commandRouter.loadBackup(data);
+
+        if (response != undefined) {
+          response.then(function (result) {
+            selfConnWebSocket.emit('pushBackup', result);
+          })
+            .fail(function () {
+              self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
+            });
+        }
+
+      });
+
+      connWebSocket.on('restoreConfig', function (data) {
+        var selfConnWebSocket = this;
+
+        var response = self.commandRouter.restorePluginsConf()
+          .then(self.commandRouter.restorePluginsConf())
+          .fail(function () {
+            self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
+          });
+      });
+
+      connWebSocket.on('search', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.musicLibrary.search(data);
+        returnedData.then(function (result) {
+          selfConnWebSocket.emit('pushBrowseLibrary', result);
+        });
+      });
+
+      connWebSocket.on('goTo', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.musicLibrary.goto(data);
+        returnedData.then(function (result) {
+          selfConnWebSocket.emit('pushBrowseLibrary', result);
+        });
+      });
+
+
+      connWebSocket.on('GetTrackInfo', function (data) {
+        var selfConnWebSocket = this;
+        selfConnWebSocket.emit('pushGetTrackInfo', data);
+      });
+
+      //add my web radio
+      connWebSocket.on('addWebRadio', function (data) {
+        var selfConnWebSocket = this;
+
+        var response;
+
+        response = self.commandRouter.executeOnPlugin('music_service', 'webradio', 'addMyWebRadio', data);
+
+        if (response != undefined) {
+          response.then(function (result) {
+            selfConnWebSocket.emit('pushAddWebRadio', result);
+          })
+            .fail(function () {
+              self.printToastMessage('error', "Search error", 'An error occurred while Searching');
+            });
+        }
+      });
+
+
+      connWebSocket.on('removeWebRadio', function (data) {
+        var selfConnWebSocket = this;
+
+        var response;
+
+        response = self.commandRouter.executeOnPlugin('music_service', 'webradio', 'removeMyWebRadio', data);
+
+        if (response != undefined) {
+          response.then(function (result) {
+
+            var response2 = self.musicLibrary.executeBrowseSource('radio/myWebRadio');
+
+            if (response2 != undefined) {
+              response2.then(function (result2) {
+                selfConnWebSocket.emit('pushBrowseLibrary', result2);
+              })
+                .fail(function () {
+                  self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
+                });
+            }
+          })
+            .fail(function () {
+              self.printToastMessage('error', "Search error", 'An error occurred while Searching');
+            });
+        }
+      });
+
+
+      // PLAYLIST MANAGEMENT
+      connWebSocket.on('createPlaylist', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.playListManager.createPlaylist(data.name);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushListPlaylist', data);
+          selfConnWebSocket.emit('pushCreatePlaylist', data);
+        });
+
+
+      });
+
+      connWebSocket.on('deletePlaylist', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.playListManager.deletePlaylist(data.name);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushListPlaylist', data);
+          var response = self.musicLibrary.executeBrowseSource('playlists');
+
+          if (response != undefined) {
+            response.then(function (result) {
+              selfConnWebSocket.emit('pushBrowseLibrary', result);
+            })
+              .fail(function () {
+                self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
+              });
+          }
+        });
+      });
+
+      connWebSocket.on('listPlaylist', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.playListManager.listPlaylist();
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushListPlaylist', data);
+        });
+      });
+
+      connWebSocket.on('addToPlaylist', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.playListManager.addToPlaylist(data.name, data.service, data.uri);
+        returnedData.then(function (data) {
+          var returnedListData = self.commandRouter.playListManager.listPlaylist();
+          returnedListData.then(function (listdata) {
+            selfConnWebSocket.emit('pushListPlaylist', listdata);
+          });
+
+          selfConnWebSocket.emit('pushAddToPlaylist', data);
+        });
+      });
+
+      connWebSocket.on('removeFromPlaylist', function (data) {
+        var selfConnWebSocket = this;
+        var playlistname = data.name;
+        console.log(data);
+        var returnedData = self.commandRouter.playListManager.removeFromPlaylist(data.name, data.service, data.uri);
+        returnedData.then(function (name) {
+          var response = self.musicLibrary.executeBrowseSource('playlists/' + playlistname);
+          if (response != undefined) {
+            response.then(function (result) {
+              selfConnWebSocket.emit('pushBrowseLibrary', result);
+            })
+              .fail(function () {
+                self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
+              });
+          }
+        });
+      });
+
+      connWebSocket.on('playPlaylist', function (data) {
+        var selfConnWebSocket = this;
+        var returnedData = self.commandRouter.playPlaylist(data.name);
+
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushPlayPlaylist', data);
+        });
+      });
+
+      connWebSocket.on('enqueue', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.playListManager.enqueue(data.name);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushEnqueue', data);
+        });
+      });
+
+      //Favourites
+
+      connWebSocket.on('addToFavourites', function (data) {
+        var selfConnWebSocket = this;
+        //console.log(data);
+
+        var returnedData = self.commandRouter.playListManager.addToFavourites(data.service, data.uri, data.title);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('urifavourites', data);
+        });
+      });
+
+      connWebSocket.on('removeFromFavourites', function (data) {
+        var selfConnWebSocket = this;
+        console.log(data);
+        var returnedData = self.commandRouter.playListManager.removeFromFavourites(data.name, data.service, data.uri);
+        returnedData.then(function () {
+          if (data.service === 'shoutcast') {
+            response = self.commandRouter.executeOnPlugin('music_service', 'shoutcast', 'listRadioFavourites');
+            if (response != undefined) {
+              response.then(function (result) {
+                selfConnWebSocket.emit('pushBrowseLibrary', result);
+              })
+                .fail(function () {
+                  self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
+                });
+            }
+          } else {
+            var response = self.commandRouter.playListManager.listFavourites();
+            if (response != undefined) {
+              response.then(function (result) {
+                selfConnWebSocket.emit('pushBrowseLibrary', result);
+              })
+                .fail(function () {
+                  self.printToastMessage('error', "Browse error", 'An error occurred while browsing the folder.');
+                });
+            }
+          }
+        });
+      });
+
+      connWebSocket.on('playFavourites', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.playListManager.playFavourites(data.name);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushPlayFavourites', data);
+        });
+      });
+
+      // Radio Favourites
+      connWebSocket.on('addToRadioFavourites', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.playListManager.addToRadioFavourites('shoutcast', data.uri);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushAddToRadioFavourites', data);
+        });
+      });
+
+      connWebSocket.on('removeFromRadioFavourites', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.playListManager.removeFromRadioFavourites(data.name, 'shoutcast', data.uri);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushRemoveFromRadioFavourites', data);
+        });
+      });
+
+      connWebSocket.on('playRadioFavourites', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.playListManager.playRadioFavourites();
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushPlayRadioFavourites', data);
+        });
+      });
+
+
+      connWebSocket.on('getSleep', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'alarm-clock', 'getSleep', data);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushSleep', data);
+        });
+      });
+
+
+      connWebSocket.on('setSleep', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'alarm-clock', 'setSleep', data);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushSleep', data);
+        });
+      });
+
+      connWebSocket.on('getAlarms', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'alarm-clock', 'getAlarms', '');
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushAlarm', data);
+        });
+      });
+
+
+      connWebSocket.on('saveAlarm', function (data) {
+        var selfConnWebSocket = this;
+        //console.log(data);
+
+        var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'alarm-clock', 'saveAlarm', data);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushSleep', data);
+        });
+      });
+
+      connWebSocket.on('getMultiroom', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'getMultiroom', data);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            if (data != undefined) {
+              selfConnWebSocket.emit('pushMultiroom', data);
+            }
+          });
+        }
+        else console.log("Plugin multiroom or method getMultiroom not found");
+      });
+
+
+      connWebSocket.on('setMultiroom', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'setMultiroom', data);
+        returnedData.then(function (data) {
+          selfConnWebSocket.emit('pushMultiroom', data);
+        });
+      });
+
+      connWebSocket.on('writeMultiroom', function (data) {
+        var selfConnWebSocket = this;
+        var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'writeMultiRoom', data);
+      });
+
+      connWebSocket.on('receiveMultiroomDeviceUpdate', function (data) {
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'volumiodiscovery', 'receiveMultiroomDeviceUpdate', data);
+      });
+
+
+      connWebSocket.on('setAsMultiroomSingle', function (data) {
+        //console.log("Setting as multiroomSingle");
+        var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'setSingle', data);
+
+      });
+      connWebSocket.on('setAsMultiroomServer', function (data) {
+        //console.log("Setting as multiroomServer");
+        var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'setServer', data);
+        //selfConnWebSocket.emit('pushWriteMultiroom',data);
+
+      });
+      connWebSocket.on('setAsMultiroomClient', function (data) {
+        //console.log("Setting as multiroomClient");
+        var returnedData = self.commandRouter.executeOnPlugin('audio_interface', 'multiroom', 'setClient', data);
+        //selfConnWebSocket.emit('pushWriteMultiroom',data);
+      });
+
+      connWebSocket.on('shutdown', function () {
+        //console.log('Received Shutdown Command');
+        return self.commandRouter.shutdown();
+      });
+
+      connWebSocket.on('reboot', function () {
+        //console.log('Received Reboot Command');
+        return self.commandRouter.reboot();
+      });
+
+      connWebSocket.on('getWirelessNetworks', function () {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'network', 'getWirelessNetworks', '');
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushWirelessNetworks', data);
+          });
+        }
+        else console.log("Error on returning wireless networks");
+      });
+
+      connWebSocket.on('saveWirelessNetworkSettings', function (data) {
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'network', 'saveWirelessNetworkSettings', data);
 
 				/*if (returnedData != undefined) {
 				 returnedData.then(function (data) {
@@ -1037,916 +991,885 @@ function InterfaceWebUI(context) {
 				 });
 				 }
 				 else console.log("Error on returning wireless networks");*/
-			});
+      });
 
-			connWebSocket.on('getInfoNetwork', function () {
-				var selfConnWebSocket = this;
+      connWebSocket.on('getInfoNetwork', function () {
+        var selfConnWebSocket = this;
 
-				var defer = self.commandRouter.executeOnPlugin('system_controller', 'network', 'getInfoNetwork', '');
+        var defer = self.commandRouter.executeOnPlugin('system_controller', 'network', 'getInfoNetwork', '');
 
-				defer.then(function (data) {
-						selfConnWebSocket.emit('pushInfoNetwork', data);
-					})
-					.fail(function () {
-						selfConnWebSocket.emit('pushInfoNetwork', {status: "Not Connected", online: "no"});
-					});
-			});
-
-
-			//Updater
-			connWebSocket.on('updateCheck', function () {
-
-                self.commandRouter.broadcastMessage('ClientUpdateCheck', 'search-for-upgrade');
-
-			});
-
-            connWebSocket.on('ClientUpdateReady', function (message) {
-                var selfConnWebSocket = this;
-
-                var updateMessage = JSON.parse(message)
-				self.logger.info("Update Ready: " + updateMessage);
-                self.commandRouter.broadcastMessage('updateReady', updateMessage);
-            });
+        defer.then(function (data) {
+          selfConnWebSocket.emit('pushInfoNetwork', data);
+        })
+          .fail(function () {
+            selfConnWebSocket.emit('pushInfoNetwork', { status: "Not Connected", online: "no" });
+          });
+      });
 
 
-			connWebSocket.on('update', function (data) {
-				var selfConnWebSocket = this;
-				self.logger.info("Update: " + data);
+      //Updater
+      connWebSocket.on('updateCheck', function () {
 
-                self.commandRouter.broadcastMessage('ClientUpdate', {value:"now"});
-                var started = { 'downloadSpeed': '','eta': '5m','progress': 1, 'status': 'Starting Software Update'};
-                selfConnWebSocket.emit('updateProgress', started);
-                self.commandRouter.executeOnPlugin('system_controller', 'updater_comm', 'notifyProgress', '');
-			});
+        self.commandRouter.broadcastMessage('ClientUpdateCheck', 'search-for-upgrade');
 
-			connWebSocket.on('deleteUserData', function () {
-				var selfConnWebSocket = this;
-				self.logger.info("Command Delete User Data Received");
-				self.commandRouter.executeOnPlugin('system_controller', 'system', 'deleteUserData', '');
+      });
 
-			});
+      connWebSocket.on('ClientUpdateReady', function (message) {
+        var selfConnWebSocket = this;
 
-			connWebSocket.on('factoryReset', function () {
-				var selfConnWebSocket = this;
-				self.logger.info("Command Factory Reset Received");
-
-				self.commandRouter.broadcastMessage('ClientFactoryReset', {value:"now"});
-			});
-
-			connWebSocket.on('getSystemVersion', function () {
-				var selfConnWebSocket = this;
-				self.logger.info("Received Get System Version");
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'system', 'getSystemVersion');
-
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						if (data != undefined) {
-							selfConnWebSocket.emit('pushSystemVersion', data);
-						}
-					});
-				}
-				else console.log("Plugin multiroom or method getMultiroom not found");
+        var updateMessage = JSON.parse(message)
+        self.logger.info("Update Ready: " + updateMessage);
+        self.commandRouter.broadcastMessage('updateReady', updateMessage);
+      });
 
 
-			});
+      connWebSocket.on('update', function (data) {
+        var selfConnWebSocket = this;
+        self.logger.info("Update: " + data);
+
+        self.commandRouter.broadcastMessage('ClientUpdate', { value: "now" });
+        var started = { 'downloadSpeed': '', 'eta': '5m', 'progress': 1, 'status': 'Starting Software Update' };
+        selfConnWebSocket.emit('updateProgress', started);
+        self.commandRouter.executeOnPlugin('system_controller', 'updater_comm', 'notifyProgress', '');
+      });
+
+      connWebSocket.on('deleteUserData', function () {
+        var selfConnWebSocket = this;
+        self.logger.info("Command Delete User Data Received");
+        self.commandRouter.executeOnPlugin('system_controller', 'system', 'deleteUserData', '');
+
+      });
+
+      connWebSocket.on('factoryReset', function () {
+        var selfConnWebSocket = this;
+        self.logger.info("Command Factory Reset Received");
+
+        self.commandRouter.broadcastMessage('ClientFactoryReset', { value: "now" });
+      });
+
+      connWebSocket.on('getSystemVersion', function () {
+        var selfConnWebSocket = this;
+        self.logger.info("Received Get System Version");
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'system', 'getSystemVersion');
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            if (data != undefined) {
+              selfConnWebSocket.emit('pushSystemVersion', data);
+            }
+          });
+        }
+        else console.log("Plugin multiroom or method getMultiroom not found");
+      });
 
 			/**
 			 * Executes the getMyCollectionStats method on the MPD plugin
 			 */
-			connWebSocket.on('getMyCollectionStats', function (data) {
-				var selfConnWebSocket = this;
+      connWebSocket.on('getMyCollectionStats', function (data) {
+        var selfConnWebSocket = this;
 
-				var returnedData = self.commandRouter.executeOnPlugin('music_service', 'mpd', 'getMyCollectionStats', '');
+        var returnedData = self.commandRouter.executeOnPlugin('music_service', 'mpd', 'getMyCollectionStats', '');
 
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						selfConnWebSocket.emit('pushMyCollectionStats', data);
-					});
-				}
-				else console.log("Error on Wireless Scan");
-			});
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushMyCollectionStats', data);
+          });
+        }
+        else console.log("Error on Wireless Scan");
+      });
 
 
 			/**
 			 * Executes the rescanDb method on the MPD plugin. No response is foreseen
 			 */
-			connWebSocket.on('rescanDb', function (data) {
-				self.commandRouter.executeOnPlugin('music_service', 'mpd', 'rescanDb', '');
-			});
+      connWebSocket.on('rescanDb', function (data) {
+        self.commandRouter.executeOnPlugin('music_service', 'mpd', 'rescanDb', '');
+      });
 
-			connWebSocket.on('updateDb', function (data) {
-				self.commandRouter.executeOnPlugin('music_service', 'mpd', 'updateDb', '');
-			});
+      connWebSocket.on('updateDb', function (data) {
+        self.commandRouter.executeOnPlugin('music_service', 'mpd', 'updateDb', '');
+      });
 
 
 			/**
 			 * New share APIs
 			 */
-			connWebSocket.on('addShare', function (data) {
-				var selfConnWebSocket = this;
+      connWebSocket.on('addShare', function (data) {
+        var selfConnWebSocket = this;
 
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'addShare', data);
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'addShare', data);
 
-				if (returnedData != undefined) {
-					returnedData.then(function (datas) {
-						selfConnWebSocket.emit(datas.emit, datas.data);
-						setTimeout(function () {
-						var listdata = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listShares', '');
-						if (listdata != undefined) {
-							listdata.then(function (datalist) {
-								selfConnWebSocket.emit('pushListShares', datalist);
-							});
-						}
-						}, 1000)
-					});
-				}
-				else self.logger.error("Error on adding share");
-			});
+        if (returnedData != undefined) {
+          returnedData.then(function (datas) {
+            selfConnWebSocket.emit(datas.emit, datas.data);
+            setTimeout(function () {
+              var listdata = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listShares', '');
+              if (listdata != undefined) {
+                listdata.then(function (datalist) {
+                  selfConnWebSocket.emit('pushListShares', datalist);
+                });
+              }
+            }, 1000)
+          });
+        }
+        else self.logger.error("Error on adding share");
+      });
 
-			connWebSocket.on('deleteShare', function (data) {
-				var selfConnWebSocket = this;
+      connWebSocket.on('deleteShare', function (data) {
+        var selfConnWebSocket = this;
 
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'deleteShare', data);
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'deleteShare', data);
 
-				if (returnedData != undefined) {
-					returnedData.then(function (datas) {
-						selfConnWebSocket.emit(datas.emit, datas.data);
-						setTimeout(function () {
-							var listdata = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listShares', '');
-							if (listdata != undefined) {
-								listdata.then(function (datalist) {
-									selfConnWebSocket.emit('pushListShares', datalist);
-								});
-							}
-						}, 1000)
-					});
-				}
-				else self.logger.error("Error on deleting share");
-			});
+        if (returnedData != undefined) {
+          returnedData.then(function (datas) {
+            selfConnWebSocket.emit(datas.emit, datas.data);
+            setTimeout(function () {
+              var listdata = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listShares', '');
+              if (listdata != undefined) {
+                listdata.then(function (datalist) {
+                  selfConnWebSocket.emit('pushListShares', datalist);
+                });
+              }
+            }, 1000)
+          });
+        }
+        else self.logger.error("Error on deleting share");
+      });
 
-			connWebSocket.on('getListShares', function (data) {
-				var selfConnWebSocket = this;
+      connWebSocket.on('getListShares', function (data) {
+        var selfConnWebSocket = this;
 
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listShares', data);
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listShares', data);
 
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						selfConnWebSocket.emit('pushListShares', data);
-					});
-				}
-				else self.logger.error("Error on deleting share");
-			});
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushListShares', data);
+          });
+        }
+        else self.logger.error("Error on deleting share");
+      });
 
-			connWebSocket.on('getInfoShare', function (data) {
-				var selfConnWebSocket = this;
+      connWebSocket.on('getInfoShare', function (data) {
+        var selfConnWebSocket = this;
 
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'infoShare', data);
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'infoShare', data);
 
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						selfConnWebSocket.emit('pushInfoShare', data);
-					});
-				}
-				else self.logger.error("Error on getting information on share");
-			});
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushInfoShare', data);
+          });
+        }
+        else self.logger.error("Error on getting information on share");
+      });
 
-			connWebSocket.on('editShare', function (data) {
-				var selfConnWebSocket = this;
+      connWebSocket.on('editShare', function (data) {
+        var selfConnWebSocket = this;
 
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'editShare', data);
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'editShare', data);
 
-				if (returnedData != undefined) {
-					returnedData.then(function (datas) {
-						selfConnWebSocket.emit(datas.emit, datas.data);
-						setTimeout(function () {
-							var listdata = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listShares', '');
-							if (listdata != undefined) {
-								listdata.then(function (datalist) {
-									selfConnWebSocket.emit('pushListShares', datalist);
-								});
-							}
-						}, 1000)
-					});
-				} else self.logger.error("Error on storing on share");
-			});
-
-
-			connWebSocket.on('listUsbDrives', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listUsbDrives', data);
-
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						selfConnWebSocket.emit('pushListUsbDrives', data);
-					});
-				}
-				else self.logger.error("Error on listing USB devices");
-			});
+        if (returnedData != undefined) {
+          returnedData.then(function (datas) {
+            selfConnWebSocket.emit(datas.emit, datas.data);
+            setTimeout(function () {
+              var listdata = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listShares', '');
+              if (listdata != undefined) {
+                listdata.then(function (datalist) {
+                  selfConnWebSocket.emit('pushListShares', datalist);
+                });
+              }
+            }, 1000)
+          });
+        } else self.logger.error("Error on storing on share");
+      });
 
 
-            /*
-                PLUGIN INSTALLATION METHODS
-             */
+      connWebSocket.on('listUsbDrives', function (data) {
+        var selfConnWebSocket = this;
 
-            /*
-                Format expected: tar.gz
-                data:   {uri:'http://....../plugin.tar.gz'}
-             */
-            connWebSocket.on('installPlugin', function (data) {
-                var selfConnWebSocket = this;
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'listUsbDrives', data);
 
-                var returnedData = self.commandRouter.installPlugin(data.url);
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushListUsbDrives', data);
+          });
+        }
+        else self.logger.error("Error on listing USB devices");
+      });
 
-                if (returnedData != undefined) {
-                    returnedData.then(function (data) {
-                        selfConnWebSocket.emit('pushInstallPlugin', data);
-						var installed = self.commandRouter.getInstalledPlugins();
-						if (installed != undefined) {
-							installed.then(function (installedPLugins) {
-								self.broadcastMessage('pushInstalledPlugins',installedPLugins);
-							});
-						}
-						var available = self.commandRouter.getAvailablePlugins();
-						if (available != undefined) {
-							available.then(function (AvailablePlugins) {
-								selfConnWebSocket.emit('pushAvailablePlugins',AvailablePlugins);
-							});
-						}
-                    });
-                }
-                else self.logger.error("Error on installing plugin");
+
+      /*
+          PLUGIN INSTALLATION METHODS
+       */
+
+      /*
+          Format expected: tar.gz
+          data:   {uri:'http://....../plugin.tar.gz'}
+       */
+      connWebSocket.on('installPlugin', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.installPlugin(data.url);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushInstallPlugin', data);
+            var installed = self.commandRouter.getInstalledPlugins();
+            if (installed != undefined) {
+              installed.then(function (installedPLugins) {
+                self.broadcastMessage('pushInstalledPlugins', installedPLugins);
+              });
+            }
+            var available = self.commandRouter.getAvailablePlugins();
+            if (available != undefined) {
+              available.then(function (AvailablePlugins) {
+                selfConnWebSocket.emit('pushAvailablePlugins', AvailablePlugins);
+              });
+            }
+          });
+        }
+        else self.logger.error("Error on installing plugin");
+      });
+
+      connWebSocket.on('updatePlugin', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.updatePlugin(data);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushInstallPlugin', data);
+            var installed = self.commandRouter.getInstalledPlugins();
+            if (installed != undefined) {
+              installed.then(function (installedPLugins) {
+                self.logger.info(JSON.stringify(installedPLugins));
+                selfConnWebSocket.emit('pushInstalledPlugins', installedPLugins);
+              });
+            }
+            var available = self.commandRouter.getAvailablePlugins();
+            if (available != undefined) {
+              available.then(function (AvailablePlugins) {
+                selfConnWebSocket.emit('pushAvailablePlugins', AvailablePlugins);
+              });
+            }
+          });
+        }
+        else self.logger.error("Error on installing plugin");
+      });
+
+      connWebSocket.on('unInstallPlugin', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.unInstallPlugin(data);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushUnInstallPlugin', data);
+            var installed = self.commandRouter.getInstalledPlugins();
+            if (installed != undefined) {
+              installed.then(function (installedPLugins) {
+                self.logger.info(JSON.stringify(installedPLugins));
+                selfConnWebSocket.emit('pushInstalledPlugins', installedPLugins);
+              });
+            }
+            var available = self.commandRouter.getAvailablePlugins();
+            if (available != undefined) {
+              available.then(function (AvailablePlugins) {
+                selfConnWebSocket.emit('pushAvailablePlugins', AvailablePlugins);
+              });
+            }
+          });
+        }
+        else self.logger.error("Error on installing plugin");
+      });
+
+      connWebSocket.on('enablePlugin', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.enablePlugin(data);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushEnablePlugin', data);
+            var installed = self.commandRouter.getInstalledPlugins();
+            if (installed != undefined) {
+              installed.then(function (installedPLugins) {
+                self.logger.info(JSON.stringify(installedPLugins));
+                selfConnWebSocket.emit('pushInstalledPlugins', installedPLugins);
+              });
+            }
+          });
+        }
+        else self.logger.error("Error on installing plugin");
+      });
+
+      connWebSocket.on('disablePlugin', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.disablePlugin(data);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushDisablePlugin', data);
+            var installed = self.commandRouter.getInstalledPlugins();
+            if (installed != undefined) {
+              installed.then(function (installedPLugins) {
+                self.logger.info(JSON.stringify(installedPLugins));
+                selfConnWebSocket.emit('pushInstalledPlugins', installedPLugins);
+              });
+            }
+          });
+        }
+        else self.logger.error("Error on disabling plugin");
+      });
+
+      connWebSocket.on('modifyPluginStatus', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.modifyPluginStatus(data);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushModifyPluginStatus', data);
+            var installed = self.commandRouter.getInstalledPlugins();
+            if (installed != undefined) {
+              installed.then(function (installedPLugins) {
+                self.logger.info(JSON.stringify(installedPLugins));
+                selfConnWebSocket.emit('pushInstalledPlugins', installedPLugins);
+              });
+            }
+          });
+        }
+        else self.logger.error("Error on disabling plugin");
+      });
+
+      connWebSocket.on('getInstalledPlugins', function (pippo) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.getInstalledPlugins();
+
+        if (returnedData != undefined) {
+          returnedData.then(function (installedPLugins) {
+            self.logger.info(JSON.stringify(installedPLugins));
+            selfConnWebSocket.emit('pushInstalledPlugins', installedPLugins);
+          });
+        }
+        else self.logger.error("Error on getting installed plugins");
+      });
+
+      connWebSocket.on('getAvailablePlugins', function (pippo) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.getAvailablePlugins();
+
+        if (returnedData != undefined) {
+          returnedData.then(function (AvailablePlugins) {
+            selfConnWebSocket.emit('pushAvailablePlugins', AvailablePlugins);
+          });
+        }
+        else self.logger.error("Error on getting Available plugins");
+      });
+
+      connWebSocket.on('getPluginDetails', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.getPluginDetails(data);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (Details) {
+            selfConnWebSocket.emit('openModal', Details);
+          });
+        }
+        else self.logger.error("Error on getting Plugin Details");
+      });
+
+      connWebSocket.on('pluginManager', function (data) {
+        var selfConnWebSocket = this;
+
+        if (data.action === 'getUiConfig') {
+          return self.commandRouter.executeOnPlugin(data.category, data.name, 'getUiConfig');
+        }
+        else if (data.action === 'setUiConfig') {
+          return self.commandRouter.executeOnPlugin(data.category, data.name, 'setUiConfig', data);
+        }
+        else if (data.action === 'enable') {
+          var returnedData = self.commandRouter.enableAndStartPlugin(data.category, data.name);
+
+
+          returnedData.then(function (data) {
+            var installed = self.commandRouter.getInstalledPlugins();
+            if (installed != undefined) {
+              installed.then(function (installedPLugins) {
+                selfConnWebSocket.emit('pushInstalledPlugins', installedPLugins);
+              });
+            }
+          });
+        }
+        else if (data.action === 'disable') {
+          var returnedData = self.commandRouter.disableAndStopPlugin(data.category, data.name);
+
+          if (returnedData != undefined) {
+            returnedData.then(function (data) {
+              selfConnWebSocket.emit('pushDisablePlugin', data);
+              var installed = self.commandRouter.getInstalledPlugins();
+              if (installed != undefined) {
+                installed.then(function (installedPLugins) {
+                  selfConnWebSocket.emit('pushInstalledPlugins', installedPLugins);
+                });
+              }
             });
-
-			connWebSocket.on('updatePlugin', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.updatePlugin(data);
-
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						selfConnWebSocket.emit('pushInstallPlugin', data);
-						var installed = self.commandRouter.getInstalledPlugins();
-						if (installed != undefined) {
-							installed.then(function (installedPLugins) {
-								self.logger.info(JSON.stringify(installedPLugins));
-								selfConnWebSocket.emit('pushInstalledPlugins',installedPLugins);
-							});
-						}
-						var available = self.commandRouter.getAvailablePlugins();
-						if (available != undefined) {
-							available.then(function (AvailablePlugins) {
-								selfConnWebSocket.emit('pushAvailablePlugins',AvailablePlugins);
-							});
-						}
-					});
-				}
-				else self.logger.error("Error on installing plugin");
-			});
-
-            connWebSocket.on('unInstallPlugin', function (data) {
-                var selfConnWebSocket = this;
-
-                var returnedData = self.commandRouter.unInstallPlugin(data);
-
-                if (returnedData != undefined) {
-                    returnedData.then(function (data) {
-                        selfConnWebSocket.emit('pushUnInstallPlugin', data);
-						var installed = self.commandRouter.getInstalledPlugins();
-						if (installed != undefined) {
-							installed.then(function (installedPLugins) {
-								self.logger.info(JSON.stringify(installedPLugins));
-								selfConnWebSocket.emit('pushInstalledPlugins',installedPLugins);
-							});
-						}
-						var available = self.commandRouter.getAvailablePlugins();
-						if (available != undefined) {
-							available.then(function (AvailablePlugins) {
-								selfConnWebSocket.emit('pushAvailablePlugins',AvailablePlugins);
-							});
-						}
-                    });
-                }
-                else self.logger.error("Error on installing plugin");
-            });
-
-            connWebSocket.on('enablePlugin', function (data) {
-                var selfConnWebSocket = this;
-
-                var returnedData = self.commandRouter.enablePlugin(data);
-
-                if (returnedData != undefined) {
-                    returnedData.then(function (data) {
-                        selfConnWebSocket.emit('pushEnablePlugin', data);
-						var installed = self.commandRouter.getInstalledPlugins();
-						if (installed != undefined) {
-							installed.then(function (installedPLugins) {
-								self.logger.info(JSON.stringify(installedPLugins));
-								selfConnWebSocket.emit('pushInstalledPlugins',installedPLugins);
-							});
-						}
-                    });
-                }
-                else self.logger.error("Error on installing plugin");
-            });
-
-            connWebSocket.on('disablePlugin', function (data) {
-                var selfConnWebSocket = this;
-
-                var returnedData = self.commandRouter.disablePlugin(data);
-
-                if (returnedData != undefined) {
-                    returnedData.then(function (data) {
-                        selfConnWebSocket.emit('pushDisablePlugin', data);
-						var installed = self.commandRouter.getInstalledPlugins();
-						if (installed != undefined) {
-							installed.then(function (installedPLugins) {
-								self.logger.info(JSON.stringify(installedPLugins));
-								selfConnWebSocket.emit('pushInstalledPlugins',installedPLugins);
-							});
-						}
-                    });
-                }
-                else self.logger.error("Error on disabling plugin");
-            });
-
-            connWebSocket.on('modifyPluginStatus', function (data) {
-                var selfConnWebSocket = this;
-
-                var returnedData = self.commandRouter.modifyPluginStatus(data);
-
-                if (returnedData != undefined) {
-                    returnedData.then(function (data) {
-                        selfConnWebSocket.emit('pushModifyPluginStatus', data);
-						var installed = self.commandRouter.getInstalledPlugins();
-						if (installed != undefined) {
-							installed.then(function (installedPLugins) {
-								self.logger.info(JSON.stringify(installedPLugins));
-								selfConnWebSocket.emit('pushInstalledPlugins',installedPLugins);
-							});
-						}
-                    });
-                }
-                else self.logger.error("Error on disabling plugin");
-            });
-
-            connWebSocket.on('getInstalledPlugins', function (pippo) {
-                var selfConnWebSocket = this;
-
-                var returnedData = self.commandRouter.getInstalledPlugins();
-
-                if (returnedData != undefined) {
-                    returnedData.then(function (installedPLugins) {
-                        self.logger.info(JSON.stringify(installedPLugins));
-                        selfConnWebSocket.emit('pushInstalledPlugins',installedPLugins);
-                    });
-                }
-                else self.logger.error("Error on getting installed plugins");
-            });
-
-			connWebSocket.on('getAvailablePlugins', function (pippo) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.getAvailablePlugins();
-
-				if (returnedData != undefined) {
-					returnedData.then(function (AvailablePlugins) {
-						selfConnWebSocket.emit('pushAvailablePlugins',AvailablePlugins);
-					});
-				}
-				else self.logger.error("Error on getting Available plugins");
-			});
-
-			connWebSocket.on('getPluginDetails', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.getPluginDetails(data);
-
-				if (returnedData != undefined) {
-					returnedData.then(function (Details) {
-						selfConnWebSocket.emit('openModal',Details);
-					});
-				}
-				else self.logger.error("Error on getting Plugin Details");
-			});
-
-            connWebSocket.on('pluginManager', function (data) {
-                var selfConnWebSocket = this;
-
-                if(data.action==='getUiConfig')
-                {
-                    return self.commandRouter.executeOnPlugin(data.category,data.name,'getUiConfig');
-                }
-                else if(data.action==='setUiConfig')
-                {
-                    return self.commandRouter.executeOnPlugin(data.category,data.name,'setUiConfig',data);
-                }
-                else if(data.action==='enable')
-                {
-					var returnedData = self.commandRouter.enableAndStartPlugin(data.category,data.name);
-
-
-						returnedData.then(function (data) {
-							var installed = self.commandRouter.getInstalledPlugins();
-							if (installed != undefined) {
-								installed.then(function (installedPLugins) {
-									selfConnWebSocket.emit('pushInstalledPlugins',installedPLugins);
-								});
-							}
-						});
-
-                }
-                else if(data.action==='disable')
-                {
-					var returnedData = self.commandRouter.disableAndStopPlugin(data.category,data.name);
-
-					if (returnedData != undefined) {
-						returnedData.then(function (data) {
-							selfConnWebSocket.emit('pushDisablePlugin', data);
-							var installed = self.commandRouter.getInstalledPlugins();
-							if (installed != undefined) {
-								installed.then(function (installedPLugins) {
-									selfConnWebSocket.emit('pushInstalledPlugins',installedPLugins);
-								});
-							}
-						});
-					}
-                }
-            });
-
-
-            connWebSocket.on('preUninstallPlugin', function (data) {
-                var selfConnWebSocket = this;
-
-
-                selfConnWebSocket.emit('openModal', {'title':self.commandRouter.getI18nString('PLUGINS.CONFIRM_PLUGIN_UNINSTALL'), 'message':self.commandRouter.getI18nString('PLUGINS.CONFIRM_PLUGIN_UNINSTALL_MESSAGE')+'?', 'buttons':[{'name':self.commandRouter.getI18nString('PLUGINS.UNINSTALL'), 'class':'btn btn-info', 'emit':'unInstallPlugin', 'payload':{'category':data.category,'name':data.name}},{'name':self.commandRouter.getI18nString('COMMON.CANCEL'),'class':'btn btn-warning'}]});
-
-            });
-
-
-
-	connWebSocket.on('saveQueueToPlaylist', function (data) {
-                var selfConnWebSocket = this;
-
-		var returnedData = self.commandRouter.volumioSaveQueueToPlaylist(data.name);
-
-                if (returnedData != undefined) {
-                    returnedData.then(function (data) {
-                        selfConnWebSocket.emit('pushSaveQueueToPlaylist', data);
-		    });
-                }
-                else self.logger.error("Error on saving queue to playlist");
-
-
-            });
-
-            connWebSocket.on('setConsume', function (data) {
-                var selfConnWebSocket = this;
-
-                var returnedData = self.commandRouter.volumioConsume(data.value);
-
-                if (returnedData != undefined) {
-                    returnedData.then(function (data) {
-                        selfConnWebSocket.emit('pushSetConsume', data);
-                    });
-                }
-                else self.logger.error("Error on setting consume mode");
-
-
-            });
-
-
-            connWebSocket.on('moveQueue', function (data) {
-                var selfConnWebSocket = this;
-
-                var returnedData = self.commandRouter.volumioMoveQueue(data.from,data.to);
-
-                if (returnedData != undefined) {
-                    returnedData.then(function (data) {
-                        selfConnWebSocket.emit('pushMoveQueue', data);
-                    });
-                }
-                else self.logger.error("Error on moving item in list");
-
-
-            });
-
-			connWebSocket.on('getUiSettings', function () {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getUiSettings', '');
-
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						selfConnWebSocket.emit('pushUiSettings', data);
-					});
-				}
-				else self.logger.error("Cannot get UI Settings");
-
-
-			});
-
-			connWebSocket.on('getBackgrounds', function () {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getBackgrounds', '');
-
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-						selfConnWebSocket.emit('pushBackgrounds', data);
-					});
-				}
-				else self.logger.error("Cannot get UI Settings");
-
-
-			});
-
-			connWebSocket.on('setBackgrounds', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'setBackgrounds', data);
-
-				if (returnedData != undefined) {
-						var backgrounds=self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getBackgrounds', '');
-						if (backgrounds != undefined) {
-							backgrounds.then(function (backgroundsdata) {
-								selfConnWebSocket.emit('pushBackgrounds', backgroundsdata);
-								var returnedData2 = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getUiSettings', '');
-
-								if (returnedData2 != undefined) {
-									returnedData2.then(function (data2) {
-										selfConnWebSocket.emit('pushUiSettings', data2);
-									});
-								}
-
-
-							});
-						}
-				}
-				else self.logger.error("Cannot set UI Settings");
-
-			});
-
-			connWebSocket.on('deleteBackground', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'deleteBackgrounds', data);
-
-				if (returnedData != undefined) {
-					returnedData.then(function (backgroundsdata) {
-							selfConnWebSocket.emit('pushBackgrounds', backgroundsdata);
-						});
-					}
-				else self.logger.error("Cannot Delete Image");
-			});
-
-			connWebSocket.on('regenerateThumbnails', function (data) {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'generateThumbnails', '' );
-
-				if (returnedData != undefined) {
-					var backgrounds=self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getBackgrounds', '');
-					if (backgrounds != undefined) {
-						backgrounds.then(function (backgroundsdata) {
-							setTimeout(function () {
-							self.libSocketIO.sockets.emit('pushBackgrounds', backgroundsdata);
-							}, 1000)
-						});
-					}
-				}
-				else self.logger.error("Cannot Regenerate Thumbnails");
-			});
-
-			connWebSocket.on('getNetworkSharesDiscovery', function () {
-				var selfConnWebSocket = this;
-
-				var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'discoverShares', '');
-
-				if (returnedData != undefined) {
-					returnedData.then(function (data) {
-							selfConnWebSocket.emit('pushNetworkSharesDiscovery', data);
-						});
-					}
-
-			});
-
-			connWebSocket.on('getWizard', function () {
-				var selfConnWebSocket = this;
-
-                var showWizard = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getShowWizard', '');
-				selfConnWebSocket.emit('pushWizard', {"openWizard": showWizard});
-			});
-
-            connWebSocket.on('runFirstConfigWizard', function () {
-                var selfConnWebSocket = this;
-
-                selfConnWebSocket.emit('pushWizard', {"openWizard": true});
-            });
-
-			connWebSocket.on('getWizardSteps', function () {
-				var selfConnWebSocket = this;
-
-				var wizardSteps = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getWizardSteps', '');
-				selfConnWebSocket.emit('pushWizardSteps', wizardSteps);
-			});
-
-            connWebSocket.on('setWizardAction', function (data) {
-                var selfConnWebSocket = this;
-
-               return self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'setWizardAction', data);
-            });
-
-            connWebSocket.on('getWizardUiConfig', function (data) {
-                var selfConnWebSocket = this;
-
-                var wizardConfig = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getWizardConfig', data);
-
-                if (wizardConfig != undefined) {
-                    wizardConfig.then(function (data) {
-                        selfConnWebSocket.emit('pushUiConfig', data);
-                    });
-                }
-            });
-
-			connWebSocket.on('getAvailableLanguages', function () {
-				var selfConnWebSocket = this;
-
-				//var languages =  {'defaultLanguage':{'language': 'English', 'code': 'en'}, 'available':[{'language': 'English', 'code': 'en'},{'language': 'Italiano', 'code': 'it'}]};
-				var languages = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getAvailableLanguages', '');
-
-				if (languages != undefined) {
-					languages.then(function (data) {
-						selfConnWebSocket.emit('pushAvailableLanguages', data);
-					});
-				}
-			});
-
-			connWebSocket.on('setLanguage', function (data) {
-				//var self = this;
-				var disallowReload = false;
-				var value = data.defaultLanguage.code;
-				var label = data.defaultLanguage.language;
-				if (data.disallowReload != undefined) {
-                    disallowReload = data.disallowReload;
-				}
-				var languagedata = {'language':{'value':value,'label':label}, 'disallowReload': disallowReload}
-
-				//var lang = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'setLanguage', languagedata);
-				var name = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'setLanguage', languagedata);
-			});
-
-
-
-			connWebSocket.on('getDeviceName', function () {
-				var selfConnWebSocket = this;
-
-				var name = self.commandRouter.sharedVars.get('system.name');
-				selfConnWebSocket.emit('pushDeviceName', {'name':name});
-			});
-
-			connWebSocket.on('setDeviceName', function (data) {
-				var selfConnWebSocket = this;
-				var options = {'player_name':data.name};
-				var name = self.commandRouter.executeOnPlugin('system_controller', 'system', 'saveGeneralSettings', options);
-			});
-
-			connWebSocket.on('getOutputDevices', function () {
-				var selfConnWebSocket = this;
-
-				var audiolist = self.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getAudioDevices', '');
-
-				if (audiolist != undefined) {
-					audiolist.then(function (data) {
-						selfConnWebSocket.emit('pushOutputDevices', data);
-					});
-				}
-			});
-
-			connWebSocket.on('setOutputDevices', function (data) {
-				var selfConnWebSocket = this;
-				data.disallowPush = true;
-
-                return self.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'saveAlsaOptions', data);
-			});
-
-
-			connWebSocket.on('getDonePage', function () {
-				var selfConnWebSocket = this;
-
-
-				var donation = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getDonation', '');
-				var contributionsarray =  self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getDonationsArray', '');
-				var lastStepMessage = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getDoneMessage', '');
-				var laststep = {"congratulations":lastStepMessage.congratulations, "title":lastStepMessage.title,"message":lastStepMessage.message,"donation":donation, "donationAmount": contributionsarray};
-
-				selfConnWebSocket.emit('pushDonePage', laststep);
-			});
-
-			connWebSocket.on('checkPassword', function (data) {
-				var selfConnWebSocket = this;
-
-
-				var check = self.commandRouter.executeOnPlugin('system_controller', 'system', 'checkPassword', data);
-
-				if (check != undefined) {
-					check.then(function (data) {
-						selfConnWebSocket.emit('checkPassword', data);
-					});
-				}
-
-
-			});
-
-            connWebSocket.on('connectWirelessNetworkWizard', function (data) {
-                var selfConnWebSocket = this;
-
-                var connectWifiWizard = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'connectWirelessNetwork', data);
-
-                if (connectWifiWizard != undefined) {
-                    connectWifiWizard.then(function (data) {
-                        selfConnWebSocket.emit('pushWizardWirelessConnResults', data);
-                    });
-                }
+          }
+        }
+      });
+
+      connWebSocket.on('preUninstallPlugin', function (data) {
+        var selfConnWebSocket = this;
+
+        selfConnWebSocket.emit('openModal', { 'title': self.commandRouter.getI18nString('PLUGINS.CONFIRM_PLUGIN_UNINSTALL'), 'message': self.commandRouter.getI18nString('PLUGINS.CONFIRM_PLUGIN_UNINSTALL_MESSAGE') + '?', 'buttons': [{ 'name': self.commandRouter.getI18nString('PLUGINS.UNINSTALL'), 'class': 'btn btn-info', 'emit': 'unInstallPlugin', 'payload': { 'category': data.category, 'name': data.name } }, { 'name': self.commandRouter.getI18nString('COMMON.CANCEL'), 'class': 'btn btn-warning' }] });
+      });
+
+      connWebSocket.on('saveQueueToPlaylist', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.volumioSaveQueueToPlaylist(data.name);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushSaveQueueToPlaylist', data);
+          });
+        }
+        else self.logger.error("Error on saving queue to playlist");
+      });
+
+      connWebSocket.on('setConsume', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.volumioConsume(data.value);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushSetConsume', data);
+          });
+        }
+        else self.logger.error("Error on setting consume mode");
+      });
+
+
+      connWebSocket.on('moveQueue', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.volumioMoveQueue(data.from, data.to);
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushMoveQueue', data);
+          });
+        }
+        else self.logger.error("Error on moving item in list");
+      });
+
+      connWebSocket.on('getUiSettings', function () {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getUiSettings', '');
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushUiSettings', data);
+          });
+        }
+        else self.logger.error("Cannot get UI Settings");
+      });
+
+      connWebSocket.on('getBackgrounds', function () {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getBackgrounds', '');
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushBackgrounds', data);
+          });
+        }
+        else self.logger.error("Cannot get UI Settings");
+      });
+
+      connWebSocket.on('setBackgrounds', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'setBackgrounds', data);
+
+        if (returnedData != undefined) {
+          var backgrounds = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getBackgrounds', '');
+          if (backgrounds != undefined) {
+            backgrounds.then(function (backgroundsdata) {
+              selfConnWebSocket.emit('pushBackgrounds', backgroundsdata);
+              var returnedData2 = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getUiSettings', '');
+
+              if (returnedData2 != undefined) {
+                returnedData2.then(function (data2) {
+                  selfConnWebSocket.emit('pushUiSettings', data2);
+                });
+              }
 
 
             });
+          }
+        }
+        else self.logger.error("Cannot set UI Settings");
+      });
 
-            connWebSocket.on('safeRemoveDrive', function (data) {
-                var selfConnWebSocket = this;
+      connWebSocket.on('deleteBackground', function (data) {
+        var selfConnWebSocket = this;
 
-                var remove = self.commandRouter.safeRemoveDrive(data);
+        var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'deleteBackgrounds', data);
 
-                if (remove != undefined) {
-                    remove.then(function (result) {
-                        selfConnWebSocket.emit('pushBrowseLibrary', result);
-                    })
-                        .fail(function () {
-                        });
-                }
+        if (returnedData != undefined) {
+          returnedData.then(function (backgroundsdata) {
+            selfConnWebSocket.emit('pushBackgrounds', backgroundsdata);
+          });
+        }
+        else self.logger.error("Cannot Delete Image");
+      });
+
+      connWebSocket.on('regenerateThumbnails', function (data) {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'generateThumbnails', '');
+
+        if (returnedData != undefined) {
+          var backgrounds = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getBackgrounds', '');
+          if (backgrounds != undefined) {
+            backgrounds.then(function (backgroundsdata) {
+              setTimeout(function () {
+                self.libSocketIO.sockets.emit('pushBackgrounds', backgroundsdata);
+              }, 1000)
             });
+          }
+        }
+        else self.logger.error("Cannot Regenerate Thumbnails");
+      });
 
-		}
-		catch (ex) {
-			self.logger.error("Catched an error in socketio. Details: " + ex);
-		}
-	});
+      connWebSocket.on('getNetworkSharesDiscovery', function () {
+        var selfConnWebSocket = this;
+
+        var returnedData = self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'discoverShares', '');
+
+        if (returnedData != undefined) {
+          returnedData.then(function (data) {
+            selfConnWebSocket.emit('pushNetworkSharesDiscovery', data);
+          });
+        }
+
+      });
+
+      connWebSocket.on('getWizard', function () {
+        var selfConnWebSocket = this;
+
+        var showWizard = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getShowWizard', '');
+        selfConnWebSocket.emit('pushWizard', { "openWizard": showWizard });
+      });
+
+      connWebSocket.on('runFirstConfigWizard', function () {
+        var selfConnWebSocket = this;
+
+        selfConnWebSocket.emit('pushWizard', { "openWizard": true });
+      });
+
+      connWebSocket.on('getWizardSteps', function () {
+        var selfConnWebSocket = this;
+
+        var wizardSteps = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getWizardSteps', '');
+        selfConnWebSocket.emit('pushWizardSteps', wizardSteps);
+      });
+
+      connWebSocket.on('setWizardAction', function (data) {
+        var selfConnWebSocket = this;
+
+        return self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'setWizardAction', data);
+      });
+
+      connWebSocket.on('getWizardUiConfig', function (data) {
+        var selfConnWebSocket = this;
+
+        var wizardConfig = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getWizardConfig', data);
+
+        if (wizardConfig != undefined) {
+          wizardConfig.then(function (data) {
+            selfConnWebSocket.emit('pushUiConfig', data);
+          });
+        }
+      });
+
+      connWebSocket.on('getAvailableLanguages', function () {
+        var selfConnWebSocket = this;
+
+        //var languages =  {'defaultLanguage':{'language': 'English', 'code': 'en'}, 'available':[{'language': 'English', 'code': 'en'},{'language': 'Italiano', 'code': 'it'}]};
+        var languages = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getAvailableLanguages', '');
+
+        if (languages != undefined) {
+          languages.then(function (data) {
+            selfConnWebSocket.emit('pushAvailableLanguages', data);
+          });
+        }
+      });
+
+      connWebSocket.on('setLanguage', function (data) {
+        //var self = this;
+        var disallowReload = false;
+        var value = data.defaultLanguage.code;
+        var label = data.defaultLanguage.language;
+        if (data.disallowReload != undefined) {
+          disallowReload = data.disallowReload;
+        }
+        var languagedata = { 'language': { 'value': value, 'label': label }, 'disallowReload': disallowReload }
+
+        //var lang = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'setLanguage', languagedata);
+        var name = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'setLanguage', languagedata);
+      });
+
+      connWebSocket.on('getDeviceName', function () {
+        var selfConnWebSocket = this;
+
+        var name = self.commandRouter.sharedVars.get('system.name');
+        selfConnWebSocket.emit('pushDeviceName', { 'name': name });
+      });
+
+      connWebSocket.on('setDeviceName', function (data) {
+        var selfConnWebSocket = this;
+        var options = { 'player_name': data.name };
+        var name = self.commandRouter.executeOnPlugin('system_controller', 'system', 'saveGeneralSettings', options);
+      });
+
+      connWebSocket.on('getOutputDevices', function () {
+        var selfConnWebSocket = this;
+
+        var audiolist = self.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getAudioDevices', '');
+
+        if (audiolist != undefined) {
+          audiolist.then(function (data) {
+            selfConnWebSocket.emit('pushOutputDevices', data);
+          });
+        }
+      });
+
+      connWebSocket.on('setOutputDevices', function (data) {
+        var selfConnWebSocket = this;
+        data.disallowPush = true;
+
+        return self.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'saveAlsaOptions', data);
+      });
+
+      connWebSocket.on('getDonePage', function () {
+        var selfConnWebSocket = this;
+
+
+        var donation = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getDonation', '');
+        var contributionsarray = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getDonationsArray', '');
+        var lastStepMessage = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'getDoneMessage', '');
+        var laststep = { "congratulations": lastStepMessage.congratulations, "title": lastStepMessage.title, "message": lastStepMessage.message, "donation": donation, "donationAmount": contributionsarray };
+
+        selfConnWebSocket.emit('pushDonePage', laststep);
+      });
+
+      connWebSocket.on('checkPassword', function (data) {
+        var selfConnWebSocket = this;
+
+
+        var check = self.commandRouter.executeOnPlugin('system_controller', 'system', 'checkPassword', data);
+
+        if (check != undefined) {
+          check.then(function (data) {
+            selfConnWebSocket.emit('checkPassword', data);
+          });
+        }
+      });
+
+      connWebSocket.on('connectWirelessNetworkWizard', function (data) {
+        var selfConnWebSocket = this;
+
+        var connectWifiWizard = self.commandRouter.executeOnPlugin('miscellanea', 'wizard', 'connectWirelessNetwork', data);
+
+        if (connectWifiWizard != undefined) {
+          connectWifiWizard.then(function (data) {
+            selfConnWebSocket.emit('pushWizardWirelessConnResults', data);
+          });
+        }
+      });
+
+      connWebSocket.on('safeRemoveDrive', function (data) {
+        var selfConnWebSocket = this;
+
+        var remove = self.commandRouter.safeRemoveDrive(data);
+
+        if (remove != undefined) {
+          remove.then(function (result) {
+            selfConnWebSocket.emit('pushBrowseLibrary', result);
+          })
+            .fail(function () {
+            });
+        }
+      });
+    }
+    catch (ex) {
+      self.logger.error("Catched an error in socketio. Details: " + ex);
+    }
+  });
 };
 
 // Receive console messages from commandRouter and broadcast to all connected clients
 InterfaceWebUI.prototype.printConsoleMessage = function (message) {
-	var self = this;
+  var self = this;
 
-	// Push the message all clients
-	self.libSocketIO.emit('printConsoleMessage', message);
+  // Push the message all clients
+  self.libSocketIO.emit('printConsoleMessage', message);
 
-	// Return a resolved empty promise to represent completion
-	return libQ.resolve();
+  // Return a resolved empty promise to represent completion
+  return libQ.resolve();
 };
 
 // Receive player queue updates from commandRouter and broadcast to all connected clients
 InterfaceWebUI.prototype.pushQueue = function (queue, connWebSocket) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushQueue');
+  var self = this;
+  self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushQueue');
 
-	// If a specific client is given, push to just that client
-	if (connWebSocket) {
-		return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushQueue', queue);
-		// Else push to all connected clients
-	} else {
-		return libQ.fcall(self.libSocketIO.emit.bind(self.libSocketIO), 'pushQueue', queue);
-	}
+  // If a specific client is given, push to just that client
+  if (connWebSocket) {
+    return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushQueue', queue);
+    // Else push to all connected clients
+  } else {
+    return libQ.fcall(self.libSocketIO.emit.bind(self.libSocketIO), 'pushQueue', queue);
+  }
 };
 
 // Push the library root
 InterfaceWebUI.prototype.pushLibraryFilters = function (browsedata, connWebSocket) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushLibraryFilters');
+  var self = this;
+  self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushLibraryFilters');
 
-	// If a specific client is given, push to just that client
-	if (connWebSocket) {
-		return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushLibraryFilters', browsedata);
-	}
+  // If a specific client is given, push to just that client
+  if (connWebSocket) {
+    return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushLibraryFilters', browsedata);
+  }
 };
 
 // Receive music library data from commandRouter and send to requester
 InterfaceWebUI.prototype.pushLibraryListing = function (browsedata, connWebSocket) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushLibraryListing');
+  var self = this;
+  self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushLibraryListing');
 
-	// If a specific client is given, push to just that client
-	if (connWebSocket) {
-		return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushLibraryListing', browsedata);
-	}
+  // If a specific client is given, push to just that client
+  if (connWebSocket) {
+    return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushLibraryListing', browsedata);
+  }
 };
 
 // Push the playlist view
 InterfaceWebUI.prototype.pushPlaylistIndex = function (browsedata, connWebSocket) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushPlaylistIndex');
+  var self = this;
+  self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushPlaylistIndex');
 
-	// If a specific client is given, push to just that client
-	if (connWebSocket) {
-		return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushPlaylistIndex', browsedata);
-	}
+  // If a specific client is given, push to just that client
+  if (connWebSocket) {
+    return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushPlaylistIndex', browsedata);
+  }
 };
 
 InterfaceWebUI.prototype.pushMultiroom = function (selfConnWebSocket) {
-	var self = this;
-	//console.log("pushMultiroom 2");
-	var volumiodiscovery = self.commandRouter.pluginManager.getPlugin('system_controller', 'volumiodiscovery');
-	if (volumiodiscovery) {
-	var response = volumiodiscovery.getDevices();
-	if(response != undefined){
-	selfConnWebSocket.emit('pushMultiRoomDevices', response);
-	}
-	}
+  var self = this;
+  //console.log("pushMultiroom 2");
+  var volumiodiscovery = self.commandRouter.pluginManager.getPlugin('system_controller', 'volumiodiscovery');
+  if (volumiodiscovery) {
+    var response = volumiodiscovery.getDevices();
+    if (response != undefined) {
+      selfConnWebSocket.emit('pushMultiRoomDevices', response);
+    }
+  }
 }
 
 
 // Receive player state updates from commandRouter and broadcast to all connected clients
 InterfaceWebUI.prototype.pushState = function (state, connWebSocket) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushState');
-	if (connWebSocket) {
-		self.pushMultiroom(connWebSocket);
-		return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushState', state);
+  var self = this;
+  self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'InterfaceWebUI::pushState');
+  if (connWebSocket) {
+    self.pushMultiroom(connWebSocket);
+    return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushState', state);
 
-	} else {
-		// Push the updated state to all clients
-		self.pushMultiroom(self.libSocketIO);
-		return libQ.fcall(self.libSocketIO.emit.bind(self.libSocketIO), 'pushState', state);
-	}
+  } else {
+    // Push the updated state to all clients
+    self.pushMultiroom(self.libSocketIO);
+    return libQ.fcall(self.libSocketIO.emit.bind(self.libSocketIO), 'pushState', state);
+  }
 };
 
 
 InterfaceWebUI.prototype.printToastMessage = function (type, title, message) {
-	var self = this;
+  var self = this;
 
-	// Push the message all clients
-	self.libSocketIO.emit('pushToastMessage', {
-		type: type,
-		title: title,
-		message: message
-	});
+  // Push the message all clients
+  self.libSocketIO.emit('pushToastMessage', {
+    type: type,
+    title: title,
+    message: message
+  });
 };
 
 InterfaceWebUI.prototype.broadcastToastMessage = function (type, title, message) {
-	var self = this;
+  var self = this;
 
-	// Push the message all clients
-	self.libSocketIO.sockets.emit('pushToastMessage', {
-		type: type,
-		title: title,
-		message: message
-	});
+  // Push the message all clients
+  self.libSocketIO.sockets.emit('pushToastMessage', {
+    type: type,
+    title: title,
+    message: message
+  });
 };
 
 InterfaceWebUI.prototype.pushMultiroomDevices = function (msg) {
-	this.libSocketIO.emit('pushMultiRoomDevices', msg);
+  this.libSocketIO.emit('pushMultiRoomDevices', msg);
 };
 
 InterfaceWebUI.prototype.logDone = function (timeStart) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + '------------------------------ ' + (Date.now() - timeStart) + 'ms');
-	return libQ.resolve();
+  var self = this;
+  self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + '------------------------------ ' + (Date.now() - timeStart) + 'ms');
+  return libQ.resolve();
 };
 
 InterfaceWebUI.prototype.logStart = function (sCommand) {
-	var self = this;
-	self.commandRouter.pushConsoleMessage('\n' + '[' + Date.now() + '] ' + '---------------------------- ' + sCommand);
-	return libQ.resolve();
+  var self = this;
+  self.commandRouter.pushConsoleMessage('\n' + '[' + Date.now() + '] ' + '---------------------------- ' + sCommand);
+  return libQ.resolve();
 };
 
 // Pass the error if we don't want to handle it
 InterfaceWebUI.prototype.pushError = function (error) {
-	if ((typeof error) === 'string') {
-		return this.commandRouter.pushConsoleMessage.call(this.commandRouter, 'Error: ' + error);
-	} else if ((typeof error) === 'object') {
-		return this.commandRouter.pushConsoleMessage.call(this.commandRouter, 'Error:\n' + error.stack);
-	}
-	// Return a resolved empty promise to represent completion
-	return libQ.resolve();
+  if ((typeof error) === 'string') {
+    return this.commandRouter.pushConsoleMessage.call(this.commandRouter, 'Error: ' + error);
+  } else if ((typeof error) === 'object') {
+    return this.commandRouter.pushConsoleMessage.call(this.commandRouter, 'Error:\n' + error.stack);
+  }
+  // Return a resolved empty promise to represent completion
+  return libQ.resolve();
 };
 
 InterfaceWebUI.prototype.pushAirplay = function (value) {
-	this.logger.debug("Pushing airplay mode: s" + value);
-	this.libSocketIO.sockets.emit('pushAirplay', value);
+  this.logger.debug("Pushing airplay mode: s" + value);
+  this.libSocketIO.sockets.emit('pushAirplay', value);
 };
 
 InterfaceWebUI.prototype.emitFavourites = function (value) {
-	var self = this;
+  var self = this;
 
-	self.logger.info("Pushing Favourites " + JSON.stringify(value));
-	self.libSocketIO.sockets.emit('urifavourites', value);
+  self.logger.info("Pushing Favourites " + JSON.stringify(value));
+  self.libSocketIO.sockets.emit('urifavourites', value);
 };
 
-InterfaceWebUI.prototype.broadcastMessage = function(emit,payload) {
-	if(emit.msg && emit.value) {
-		this.libSocketIO.sockets.emit(emit.msg,emit.value);
-	} else {
-		this.libSocketIO.sockets.emit(emit,payload);
-	}
+InterfaceWebUI.prototype.broadcastMessage = function (emit, payload) {
+  if (emit.msg && emit.value) {
+    this.libSocketIO.sockets.emit(emit.msg, emit.value);
+  } else {
+    this.libSocketIO.sockets.emit(emit, payload);
+  }
 };
 
 


### PR DESCRIPTION
Hi,

I have fixed the problem that you cannot add songs/videos from spotify or youtube to a playlist managed by volumio.

A music service plugin that wants to support this too only has to implement a method called ```getTrackInfo``` that accepts the uri to be added. It must then return detailed information about the song or playlist.

I have added support for this in the youtube plugin and will create a  PR for it accordingly in the plugins repo (**see referenced PRs!**)

I had to adapt the code for removing elements from a playlist (method ```commonRemoveFromPlaylist``` line 602 -> the for loop): there was a check that compared the calling service name with the service name of the song. But in case of youtube or spotify the service name of an element is not mpd at it was expected and so the element was never removed. I think that checking the URI for removing the item should be sufficient enough anyway. 

Take a look at the plugin. It already seem to work for spotify.


