### PR TITLE
Localization support for plugins

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -12,76 +12,76 @@ var vconf = require('v-conf');
 module.exports = CoreCommandRouter;
 function CoreCommandRouter(server) {
 
-	var logfile = '/var/log/volumio.log';
+  var logfile = '/var/log/volumio.log';
 
-	fs.ensureFileSync(logfile);
-	fs.watchFile(logfile, function () {
-		fs.stat(logfile, function (err, stats) {
-			if (stats.size > 15728640) {
-				var now = new Date();
-				console.log('******** LOG FILE REACHED 15MB IN SIZE, CLEANING IT ********');
-				fs.writeFile(logfile, '------------------- Log Cleaned at '+ now + ' -------------------', function(){
-					console.log('******** LOG FILE SUCCESSFULLY CLEANED ********');
-				})
-			}
-		});
-	});
-	this.logger = new (winston.Logger)({
-		transports: [
-			new (winston.transports.Console)(),
-			new (winston.transports.File)({
-				filename: logfile,
-				json: false
-			})
-		]
-	});
+  fs.ensureFileSync(logfile);
+  fs.watchFile(logfile, function () {
+    fs.stat(logfile, function (err, stats) {
+      if (stats.size > 15728640) {
+        var now = new Date();
+        console.log('******** LOG FILE REACHED 15MB IN SIZE, CLEANING IT ********');
+        fs.writeFile(logfile, '------------------- Log Cleaned at ' + now + ' -------------------', function () {
+          console.log('******** LOG FILE SUCCESSFULLY CLEANED ********');
+        })
+      }
+    });
+  });
+  this.logger = new (winston.Logger)({
+    transports: [
+      new (winston.transports.Console)(),
+      new (winston.transports.File)({
+        filename: logfile,
+        json: false
+      })
+    ]
+  });
 
-	this.callbacks = [];
-	this.sharedVars = new vconf();
-    this.sharedVars.registerCallback('language_code',this.loadI18nStrings.bind(this));
-    this.sharedVars.addConfigValue('selective_search','boolean',true);
+  this.callbacks = [];
+  this.sharedVars = new vconf();
+  this.sharedVars.registerCallback('language_code', this.loadI18nStrings.bind(this));
+  this.sharedVars.addConfigValue('selective_search', 'boolean', true);
 
-	this.logger.info("-------------------------------------------");
-	this.logger.info("-----            Volumio2              ----");
-	this.logger.info("-------------------------------------------");
-	this.logger.info("-----          System startup          ----");
-	this.logger.info("-------------------------------------------");
+  this.logger.info("-------------------------------------------");
+  this.logger.info("-----            Volumio2              ----");
+  this.logger.info("-------------------------------------------");
+  this.logger.info("-----          System startup          ----");
+  this.logger.info("-------------------------------------------");
 
-    //Checking for system updates
-    this.checkAndPerformSystemUpdates();
-    // Start the music library
-    this.musicLibrary = new (require('./musiclibrary.js'))(this);
+  //Checking for system updates
+  this.checkAndPerformSystemUpdates();
+  // Start the music library
+  this.musicLibrary = new (require('./musiclibrary.js'))(this);
 
-    // Start plugins
-    this.pluginManager = new (require(__dirname + '/pluginmanager.js'))(this, server);
-    this.pluginManager.checkIndex();
-    this.pluginManager.pluginFolderCleanup();
-    this.configManager=new(require(__dirname+'/configManager.js'))(this.logger);
-
-
-    this.pluginManager.loadPlugins();
-    this.pluginManager.startPlugins();
-
-    this.loadI18nStrings();
-    this.musicLibrary.updateBrowseSourcesLang();
-
-    // Start the state machine
-    this.stateMachine = new (require('./statemachine.js'))(this);
+  // Start plugins
+  this.pluginManager = new (require(__dirname + '/pluginmanager.js'))(this, server);
+  this.pluginManager.checkIndex();
+  this.pluginManager.pluginFolderCleanup();
+  this.configManager = new (require(__dirname + '/configManager.js'))(this.logger);
 
 
-    // Start the volume controller
-    this.volumeControl = new (require('./volumecontrol.js'))(this);
+  this.pluginManager.loadPlugins();
+  this.pluginManager.startPlugins();
 
-    // Start the playListManager.playPlaylistlist FS
-    //self.playlistFS = new (require('./playlistfs.js'))(self);
+  this.loadI18nStrings();
+  this.musicLibrary.updateBrowseSourcesLang();
 
-    this.playListManager = new (require('./playlistManager.js'))(this);
+  // Start the state machine
+  this.stateMachine = new (require('./statemachine.js'))(this);
 
-    this.platformspecific = new (require(__dirname + '/platformSpecific.js'))(this);
 
-    this.pushConsoleMessage('BOOT COMPLETED');
+  // Start the volume controller
+  this.volumeControl = new (require('./volumecontrol.js'))(this);
 
-    this.startupSound();
+  // Start the playListManager.playPlaylistlist FS
+  //self.playlistFS = new (require('./playlistfs.js'))(self);
+
+  this.playListManager = new (require('./playlistManager.js'))(this);
+
+  this.platformspecific = new (require(__dirname + '/platformSpecific.js'))(this);
+
+  this.pushConsoleMessage('BOOT COMPLETED');
+
+  this.startupSound();
 }
 
 // Methods usually called by the Client Interfaces ----------------------------------------------------------------------------
@@ -90,116 +90,116 @@ function CoreCommandRouter(server) {
 
 // Volumio Pause
 CoreCommandRouter.prototype.volumioPause = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPause');
-	return this.stateMachine.pause();
+  this.pushConsoleMessage('CoreCommandRouter::volumioPause');
+  return this.stateMachine.pause();
 };
 
 // Volumio Stop
 CoreCommandRouter.prototype.volumioStop = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioStop');
-	return this.stateMachine.stop();
+  this.pushConsoleMessage('CoreCommandRouter::volumioStop');
+  return this.stateMachine.stop();
 };
 
 // Volumio Previous
 CoreCommandRouter.prototype.volumioPrevious = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPrevious');
-	return this.stateMachine.previous();
+  this.pushConsoleMessage('CoreCommandRouter::volumioPrevious');
+  return this.stateMachine.previous();
 };
 
 // Volumio Next
 CoreCommandRouter.prototype.volumioNext = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioNext');
-	return this.stateMachine.next();
+  this.pushConsoleMessage('CoreCommandRouter::volumioNext');
+  return this.stateMachine.next();
 };
 
 // Volumio Get State
 CoreCommandRouter.prototype.volumioGetState = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetState');
-	return this.stateMachine.getState();
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetState');
+  return this.stateMachine.getState();
 };
 
 // Volumio Get Queue
 CoreCommandRouter.prototype.volumioGetQueue = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetQueue');
-	return this.stateMachine.getQueue();
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetQueue');
+  return this.stateMachine.getQueue();
 };
 
 // Volumio Remove Queue Item
 CoreCommandRouter.prototype.volumioRemoveQueueItem = function (nIndex) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioRemoveQueueItem');
-	return this.stateMachine.removeQueueItem(nIndex);
+  this.pushConsoleMessage('CoreCommandRouter::volumioRemoveQueueItem');
+  return this.stateMachine.removeQueueItem(nIndex);
 };
 
 // Volumio Clear Queue Item
 CoreCommandRouter.prototype.volumioClearQueue = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioClearQueue');
-	return this.stateMachine.clearQueue();
+  this.pushConsoleMessage('CoreCommandRouter::volumioClearQueue');
+  return this.stateMachine.clearQueue();
 };
 
 // Volumio Set Volume
 CoreCommandRouter.prototype.volumiosetvolume = function (VolumeInteger) {
-	this.callCallback("volumiosetvolume", VolumeInteger);
-	return this.volumeControl.alsavolume(VolumeInteger);
+  this.callCallback("volumiosetvolume", VolumeInteger);
+  return this.volumeControl.alsavolume(VolumeInteger);
 };
 
 // Volumio Update Volume
 CoreCommandRouter.prototype.volumioupdatevolume = function (vol) {
-	this.callCallback("volumioupdatevolume", vol);
-	return this.stateMachine.updateVolume(vol);
+  this.callCallback("volumioupdatevolume", vol);
+  return this.stateMachine.updateVolume(vol);
 };
 
 // Volumio Retrieve Volume
 CoreCommandRouter.prototype.volumioretrievevolume = function (vol) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioRetrievevolume');
-	return this.volumeControl.retrievevolume();
+  this.pushConsoleMessage('CoreCommandRouter::volumioRetrievevolume');
+  return this.volumeControl.retrievevolume();
 };
 
 
 CoreCommandRouter.prototype.volumioUpdateVolumeSettings = function (vol) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioUpdateVolumeSettings');
-	if (this.volumeControl){
-		return this.volumeControl.updateVolumeSettings(vol);
-	}
+  this.pushConsoleMessage('CoreCommandRouter::volumioUpdateVolumeSettings');
+  if (this.volumeControl) {
+    return this.volumeControl.updateVolumeSettings(vol);
+  }
 };
 
 CoreCommandRouter.prototype.updateVolumeScripts = function (data) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioUpdateVolumeScripts');
-    if (this.volumeControl){
-        return this.volumeControl.updateVolumeScript(data);
-    }
+  this.pushConsoleMessage('CoreCommandRouter::volumioUpdateVolumeScripts');
+  if (this.volumeControl) {
+    return this.volumeControl.updateVolumeScript(data);
+  }
 };
 
 CoreCommandRouter.prototype.addCallback = function (name, callback) {
-	if (this.callbacks[name] == undefined) {
-		this.callbacks[name] = [];
-	}
-	this.callbacks[name].push(callback);
-	//this.logger.debug("Total " + callbacks[name].length + " callbacks for " + name);
+  if (this.callbacks[name] == undefined) {
+    this.callbacks[name] = [];
+  }
+  this.callbacks[name].push(callback);
+  //this.logger.debug("Total " + callbacks[name].length + " callbacks for " + name);
 };
 
 CoreCommandRouter.prototype.callCallback = function (name, data) {
-	var self = this;
-	var calls = this.callbacks[name];
-	if (calls != undefined) {
-		var nCalls = calls.length;
-		for (var i = 0; i < nCalls; i++) {
-			var func = this.callbacks[name][i];
-			try {
-				func(data);
-			} catch (e) {
-				self.logger.error("Help! Some callbacks for " + name + " are crashing!");
-				self.logger.error(e);
-			}
-		}
-	} else {
-		self.logger.debug("No callbacks for " + name);
-	}
+  var self = this;
+  var calls = this.callbacks[name];
+  if (calls != undefined) {
+    var nCalls = calls.length;
+    for (var i = 0; i < nCalls; i++) {
+      var func = this.callbacks[name][i];
+      try {
+        func(data);
+      } catch (e) {
+        self.logger.error("Help! Some callbacks for " + name + " are crashing!");
+        self.logger.error(e);
+      }
+    }
+  } else {
+    self.logger.debug("No callbacks for " + name);
+  }
 };
 
 // Volumio Add Queue Uids
 CoreCommandRouter.prototype.volumioAddQueueUids = function (arrayUids) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioAddQueueUids');
-	return this.musicLibrary.addQueueUids(arrayUids);
+  this.pushConsoleMessage('CoreCommandRouter::volumioAddQueueUids');
+  return this.musicLibrary.addQueueUids(arrayUids);
 };
 /*
 
@@ -215,234 +215,233 @@ CoreCommandRouter.prototype.volumioAddQueueUids = function (arrayUids) {
  */
 // Volumio Rebuild Library
 CoreCommandRouter.prototype.volumioRebuildLibrary = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioRebuildLibrary');
-	return this.musicLibrary.buildLibrary();
+  this.pushConsoleMessage('CoreCommandRouter::volumioRebuildLibrary');
+  return this.musicLibrary.buildLibrary();
 };
 
 // Volumio Get Library Index
 CoreCommandRouter.prototype.volumioGetLibraryFilters = function (sUid) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetLibraryFilters');
-	return this.musicLibrary.getIndex(sUid);
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetLibraryFilters');
+  return this.musicLibrary.getIndex(sUid);
 };
 
 // Volumio Browse Library
 CoreCommandRouter.prototype.volumioGetLibraryListing = function (sUid, objOptions) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetLibraryListing');
-	return this.musicLibrary.getListing(sUid, objOptions);
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetLibraryListing');
+  return this.musicLibrary.getListing(sUid, objOptions);
 };
 
 // Volumio Browse Sources
 CoreCommandRouter.prototype.volumioGetBrowseSources = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetBrowseSources');
-	return this.musicLibrary.getBrowseSources();
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetBrowseSources');
+  return this.musicLibrary.getBrowseSources();
 };
 
 CoreCommandRouter.prototype.volumioAddToBrowseSources = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioAddToBrowseSources' + data);
-	return this.musicLibrary.addToBrowseSources(data);
+  this.pushConsoleMessage('CoreCommandRouter::volumioAddToBrowseSources' + data);
+  return this.musicLibrary.addToBrowseSources(data);
 };
 
 CoreCommandRouter.prototype.volumioRemoveToBrowseSources = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioRemoveToBrowseSources' + data);
-	return this.musicLibrary.removeBrowseSource(data);
+  this.pushConsoleMessage('CoreCommandRouter::volumioRemoveToBrowseSources' + data);
+  return this.musicLibrary.removeBrowseSource(data);
 };
 
-CoreCommandRouter.prototype.volumioUpdateToBrowseSources = function (name,data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioUpdateToBrowseSources' + data);
-	return this.musicLibrary.updateBrowseSources(name,data);
+CoreCommandRouter.prototype.volumioUpdateToBrowseSources = function (name, data) {
+  this.pushConsoleMessage('CoreCommandRouter::volumioUpdateToBrowseSources' + data);
+  return this.musicLibrary.updateBrowseSources(name, data);
 };
 
 CoreCommandRouter.prototype.setSourceActive = function (data) {
-    this.pushConsoleMessage('CoreCommandRouter::volumiosetSourceActive' + data);
-    return this.musicLibrary.setSourceActive(data);
+  this.pushConsoleMessage('CoreCommandRouter::volumiosetSourceActive' + data);
+  return this.musicLibrary.setSourceActive(data);
 };
 // Volumio Get Playlist Index
 CoreCommandRouter.prototype.volumioGetPlaylistIndex = function (sUid) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetPlaylistIndex');
-	return this.playlistFS.getIndex(sUid);
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetPlaylistIndex');
+  return this.playlistFS.getIndex(sUid);
 };
 
 // Service Update Tracklist
 CoreCommandRouter.prototype.serviceUpdateTracklist = function (sService) {
-	this.pushConsoleMessage('CoreCommandRouter::serviceUpdateTracklist');
-	var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
-	return thisPlugin.rebuildTracklist();
+  this.pushConsoleMessage('CoreCommandRouter::serviceUpdateTracklist');
+  var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  return thisPlugin.rebuildTracklist();
 };
 
 // Start WirelessScan
 CoreCommandRouter.prototype.volumiowirelessscan = function () {
-	this.pushConsoleMessage('CoreCommandRouter::StartWirelessScan');
-	var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
-	return thisPlugin.scanWirelessNetworks();
+  this.pushConsoleMessage('CoreCommandRouter::StartWirelessScan');
+  var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  return thisPlugin.scanWirelessNetworks();
 };
 
 // Push WirelessScan Results (TODO SEND VIA WS)
 CoreCommandRouter.prototype.volumiopushwirelessnetworks = function (results) {
-	this.pushConsoleMessage(results);
+  this.pushConsoleMessage(results);
 };
 
 // Volumio Import Playlists
 CoreCommandRouter.prototype.volumioImportServicePlaylists = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioImportServicePlaylists');
-	return this.playlistFS.importServicePlaylists();
+  this.pushConsoleMessage('CoreCommandRouter::volumioImportServicePlaylists');
+  return this.playlistFS.importServicePlaylists();
 };
 
 // Volumio Search
 CoreCommandRouter.prototype.volumioSearch = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::Search '+data);
-	var asd = this.musicLibrary.search(data);
+  this.pushConsoleMessage('CoreCommandRouter::Search ' + data);
+  var asd = this.musicLibrary.search(data);
 
-	return this.musicLibrary.search(data);
+  return this.musicLibrary.search(data);
 };
 
 // Methods usually called by the State Machine --------------------------------------------------------------------
 
 CoreCommandRouter.prototype.volumioPushState = function (state) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPushState');
-	this.executeOnPlugin('system_controller', 'volumiodiscovery', 'saveDeviceInfo', state);
-	// Announce new player state to each client interface
-	var self = this;
-	var res = libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushState === "function")
-				return thisInterface.pushState(state);
-		})
-	);
-	self.callCallback("volumioPushState", state);
-	return res;
+  this.pushConsoleMessage('CoreCommandRouter::volumioPushState');
+  this.executeOnPlugin('system_controller', 'volumiodiscovery', 'saveDeviceInfo', state);
+  // Announce new player state to each client interface
+  var self = this;
+  var res = libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushState === "function")
+        return thisInterface.pushState(state);
+    })
+  );
+  self.callCallback("volumioPushState", state);
+  return res;
 };
 
 CoreCommandRouter.prototype.volumioResetState = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioResetState');
-	return this.stateMachine.resetVolumioState();
+  this.pushConsoleMessage('CoreCommandRouter::volumioResetState');
+  return this.stateMachine.resetVolumioState();
 };
 
 CoreCommandRouter.prototype.volumioPushQueue = function (queue) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPushQueue');
+  this.pushConsoleMessage('CoreCommandRouter::volumioPushQueue');
 
-	// Announce new player queue to each client interface
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushQueue === "function")
-				return thisInterface.pushQueue(queue);
-		})
-	);
+  // Announce new player queue to each client interface
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushQueue === "function")
+        return thisInterface.pushQueue(queue);
+    })
+  );
 };
 
 // MPD Clear-Add-Play
 CoreCommandRouter.prototype.serviceClearAddPlayTracks = function (arrayTrackIds, sService) {
-	this.pushConsoleMessage('CoreCommandRouter::serviceClearAddPlayTracks');
-	var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
-	return thisPlugin.clearAddPlayTracks(arrayTrackIds);
+  this.pushConsoleMessage('CoreCommandRouter::serviceClearAddPlayTracks');
+  var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  return thisPlugin.clearAddPlayTracks(arrayTrackIds);
 };
 
 // MPD Stop
 CoreCommandRouter.prototype.serviceStop = function (sService) {
-	this.pushConsoleMessage('CoreCommandRouter::serviceStop');
-	var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
-	return thisPlugin.stop();
+  this.pushConsoleMessage('CoreCommandRouter::serviceStop');
+  var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  return thisPlugin.stop();
 };
 
 // MPD Pause
 CoreCommandRouter.prototype.servicePause = function (sService) {
-	this.pushConsoleMessage('CoreCommandRouter::servicePause');
+  this.pushConsoleMessage('CoreCommandRouter::servicePause');
 
-	var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
-	return thisPlugin.pause();
+  var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  return thisPlugin.pause();
 };
 
 // MPD Resume
 CoreCommandRouter.prototype.serviceResume = function (sService) {
-	this.pushConsoleMessage('CoreCommandRouter::serviceResume');
+  this.pushConsoleMessage('CoreCommandRouter::serviceResume');
 
-	var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
 
-	var state=this.stateMachine.getState();
+  var state = this.stateMachine.getState();
 
-	if(state==='stop')
-	{
-		thisPlugin.clearAddPlayTracks();
-	}
+  if (state === 'stop') {
+    thisPlugin.clearAddPlayTracks();
+  }
 
-	return thisPlugin.resume();
+  return thisPlugin.resume();
 };
 
 // Methods usually called by the service controllers --------------------------------------------------------------
 
 CoreCommandRouter.prototype.servicePushState = function (state, sService) {
-	this.pushConsoleMessage('CoreCommandRouter::servicePushState');
-	return this.stateMachine.syncState(state, sService);
+  this.pushConsoleMessage('CoreCommandRouter::servicePushState');
+  return this.stateMachine.syncState(state, sService);
 };
 
 // Methods usually called by the music library ---------------------------------------------------------------------
 
 // Get tracklists from all services and return them as an array
 CoreCommandRouter.prototype.getAllTracklists = function () {
-	this.pushConsoleMessage('CoreCommandRouter::getAllTracklists');
+  this.pushConsoleMessage('CoreCommandRouter::getAllTracklists');
 
-	// This is the synchronous way to get libraries, which waits for each controller to return its tracklist before continuing
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('music_service'), function (sService) {
-			var thisService = self.pluginManager.getPlugin('music_service', sService);
-			return thisService.getTracklist();
-		})
-	);
+  // This is the synchronous way to get libraries, which waits for each controller to return its tracklist before continuing
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('music_service'), function (sService) {
+      var thisService = self.pluginManager.getPlugin('music_service', sService);
+      return thisService.getTracklist();
+    })
+  );
 };
 
 // Volumio Add Queue Items
 CoreCommandRouter.prototype.addQueueItems = function (arrayItems) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioAddQueueItems');
+  this.pushConsoleMessage('CoreCommandRouter::volumioAddQueueItems');
 
 
-	return this.stateMachine.addQueueItems(arrayItems);
+  return this.stateMachine.addQueueItems(arrayItems);
 };
 CoreCommandRouter.prototype.replaceAndPlay = function (arrayItems) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioReplaceandPlayItems');
+  this.pushConsoleMessage('CoreCommandRouter::volumioReplaceandPlayItems');
 
-	this.stateMachine.clearQueue();
+  this.stateMachine.clearQueue();
 
-    if (arrayItems.uri != undefined && arrayItems.uri.indexOf('playlists/') >= 0) {
-        return this.playPlaylist(arrayItems.title)
-    } else  {
-        return this.stateMachine.addQueueItems(arrayItems);
-    }
+  if (arrayItems.uri != undefined && arrayItems.uri.indexOf('playlists/') >= 0) {
+    return this.playPlaylist(arrayItems.title)
+  } else {
+    return this.stateMachine.addQueueItems(arrayItems);
+  }
 };
 
 CoreCommandRouter.prototype.replaceAndPlayCue = function (arrayItems) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioReplaceandPlayItems');
-    this.stateMachine.clearQueue();
+  this.pushConsoleMessage('CoreCommandRouter::volumioReplaceandPlayItems');
+  this.stateMachine.clearQueue();
 
-    if (arrayItems.uri != undefined && arrayItems.uri.indexOf('playlists/') >= 0) {
-        return this.playPlaylist(arrayItems.title)
-    } else  {
-        return this.stateMachine.addQueueItems(arrayItems);
-    }
+  if (arrayItems.uri != undefined && arrayItems.uri.indexOf('playlists/') >= 0) {
+    return this.playPlaylist(arrayItems.title)
+  } else {
+    return this.stateMachine.addQueueItems(arrayItems);
+  }
 };
 
 
 
 // Volumio Check Favourites
 CoreCommandRouter.prototype.checkFavourites = function (data) {
-	var self = this;
-	//self.pushConsoleMessage('CoreCommandRouter::volumioAddQueueItems');
+  var self = this;
+  //self.pushConsoleMessage('CoreCommandRouter::volumioAddQueueItems');
 
-	return self.stateMachine.checkFavourites(data);
+  return self.stateMachine.checkFavourites(data);
 };
 
 // Volumio Emit Favourites
 CoreCommandRouter.prototype.emitFavourites = function (msg) {
-	var plugin = this.pluginManager.getPlugin('user_interface', 'websocket');
-	plugin.emitFavourites(msg);
+  var plugin = this.pluginManager.getPlugin('user_interface', 'websocket');
+  plugin.emitFavourites(msg);
 };
 
 // Volumio Play Playlist
 CoreCommandRouter.prototype.playPlaylist = function (data) {
-	var self = this;
-	return self.playListManager.playPlaylist(data);
+  var self = this;
+  return self.playListManager.playPlaylist(data);
 };
 
 // Utility functions ---------------------------------------------------------------------------------------------
@@ -452,17 +451,17 @@ CoreCommandRouter.prototype.playPlaylist = function (data) {
  * @returns {{name: *, uuid: *, time: string}}
  */
 CoreCommandRouter.prototype.getId = function () {
-	var self = this;
+  var self = this;
 
-	var file = fs.readJsonSync("data/configuration/system_controller/system/config.json");
+  var file = fs.readJsonSync("data/configuration/system_controller/system/config.json");
 
-	var name = file.playerName.value;
-	var uuid = file.uuid.value;
-	var date = new Date();
-	var time = date.getDate() + "/" + date.getMonth() + "/" + date.getFullYear() + " - " +
-			date.getHours() + ":" + date.getMinutes();
+  var name = file.playerName.value;
+  var uuid = file.uuid.value;
+  var date = new Date();
+  var time = date.getDate() + "/" + date.getMonth() + "/" + date.getFullYear() + " - " +
+    date.getHours() + ":" + date.getMinutes();
 
-	return {'name': name, 'uuid': uuid, 'time': time};
+  return { 'name': name, 'uuid': uuid, 'time': time };
 }
 
 /**
@@ -472,17 +471,17 @@ CoreCommandRouter.prototype.getId = function () {
  * @returns {*|string}
  */
 CoreCommandRouter.prototype.getPlugConf = function (category, plugin) {
-	var cName = category;
-	var name = plugin;
-	try{
-		var config = fs.readJsonSync(("/data/configuration/" + cName + "/" +
-			name + "/" + "config.json"), 'utf-8',
-			{throws: false});
-	}
-	catch(e) {
-		var config ="";
-	}
-	return config;
+  var cName = category;
+  var name = plugin;
+  try {
+    var config = fs.readJsonSync(("/data/configuration/" + cName + "/" +
+      name + "/" + "config.json"), 'utf-8',
+      { throws: false });
+  }
+  catch (e) {
+    var config = "";
+  }
+  return config;
 }
 
 /**
@@ -492,16 +491,16 @@ CoreCommandRouter.prototype.getPlugConf = function (category, plugin) {
  * @returns {Array}
  */
 CoreCommandRouter.prototype.catPluginsConf = function (category, array) {
-	var self = this;
-	var plugins = array;
-	var plugConf = [];
-	for (var j = 0; j < plugins.length; j++) {
-		var name = plugins[j].name;
-		var status = plugins[j].enabled;
-		var config = self.getPlugConf(category, name);
-		plugConf.push({name, status, config});
-	}
-	return plugConf;
+  var self = this;
+  var plugins = array;
+  var plugConf = [];
+  for (var j = 0; j < plugins.length; j++) {
+    var name = plugins[j].name;
+    var status = plugins[j].enabled;
+    var config = self.getPlugConf(category, name);
+    plugConf.push({ name, status, config });
+  }
+  return plugConf;
 }
 
 /**
@@ -509,30 +508,31 @@ CoreCommandRouter.prototype.catPluginsConf = function (category, array) {
  * @returns {Array}
  */
 CoreCommandRouter.prototype.getPluginsConf = function () {
-	var self = this;
-	var paths = self.pluginManager.getPluginsMatrix();
-	var confs = [];
-	for (var i = 0; i < paths.length; i++){
-		var cName = paths[i].cName;
-		var plugins = paths[i].catPlugin;
-		var plugConf = self.catPluginsConf(cName, plugins);
-		confs.push({cName, plugConf});
-	}
+  var self = this;
+  var paths = self.pluginManager.getPluginsMatrix();
+  var confs = [];
+  for (var i = 0; i < paths.length; i++) {
+    var cName = paths[i].cName;
+    var plugins = paths[i].catPlugin;
+    var plugConf = self.catPluginsConf(cName, plugins);
+    confs.push({ cName, plugConf });
+  }
 
-	var identification = self.getId();
-	return confs;
+  var identification = self.getId();
+  return confs;
 }
 
 /**
  * Writes the configuration of every plugin into a json file
  */
 CoreCommandRouter.prototype.writePluginsConf = function () {
-	var self = this;
-	var confs = self.getPluginsConf();
+  var self = this;
+  var confs = self.getPluginsConf();
 
-	var file = "/data/configuration/generalConfig";
-	fs.outputJson(file, confs, function (err) {
-		console.log(err)})
+  var file = "/data/configuration/generalConfig";
+  fs.outputJson(file, confs, function (err) {
+    console.log(err)
+  })
 }
 
 /**
@@ -541,28 +541,28 @@ CoreCommandRouter.prototype.writePluginsConf = function () {
  * @returns {*}
  */
 CoreCommandRouter.prototype.restorePluginsConf = function (request) {
-	var self = this;
+  var self = this;
 
-	var defer = libQ.defer();
-	var backup = request;
-	var current = self.pluginManager.getPluginsMatrix();
-	var usefulConfs = [];
+  var defer = libQ.defer();
+  var backup = request;
+  var current = self.pluginManager.getPluginsMatrix();
+  var usefulConfs = [];
 
-	for(var i = 0; i < current.length; i++){
-		var j = 0;
-		while(j < backup.length && current[i].cName != backup[j].cName){
-			j++;
-		}
-		if(j < backup.length) {
-			var availPlugins = current[i].catPlugin;
-			var backPlugins = backup[j];
-			usefulConfs.push(self.usefulBackupConfs(availPlugins, backPlugins));
-		}
-	}
+  for (var i = 0; i < current.length; i++) {
+    var j = 0;
+    while (j < backup.length && current[i].cName != backup[j].cName) {
+      j++;
+    }
+    if (j < backup.length) {
+      var availPlugins = current[i].catPlugin;
+      var backPlugins = backup[j];
+      usefulConfs.push(self.usefulBackupConfs(availPlugins, backPlugins));
+    }
+  }
 
-	defer.resolve(usefulConfs);
-	self.writeConfs(usefulConfs);
-	return defer.promise;
+  defer.resolve(usefulConfs);
+  self.writeConfs(usefulConfs);
+  return defer.promise;
 }
 
 /**
@@ -573,30 +573,30 @@ CoreCommandRouter.prototype.restorePluginsConf = function (request) {
  * @returns {{cName: *, plugConf: Array}}
  */
 CoreCommandRouter.prototype.usefulBackupConfs = function (currArray, backArray) {
-	var self = this;
-	var availPlugins = currArray;
-	var catName = backArray.cName;
-	var backPlugins = backArray.plugConf;
-	var backNum = backPlugins.length;
-	var i = 0;
+  var self = this;
+  var availPlugins = currArray;
+  var catName = backArray.cName;
+  var backPlugins = backArray.plugConf;
+  var backNum = backPlugins.length;
+  var i = 0;
 
-	var existingPlug = [];
-	while (i < availPlugins.length && backNum > 0) {
-		var j = 0;
-		while (j < backPlugins.length && availPlugins[i].name != backPlugins[j].name) {
-			j++;
-		}
-		if(j < backPlugins.length){
-			existingPlug.push(backPlugins[j]);
-			backNum--;
-			backPlugins.splice(j, 1);
-		}
-		i++;
-	}
-	if (backNum > 0){
-		self.installBackupPlugins(catName, backPlugins);
-	}
-	return {'cName': catName, 'plugConf': existingPlug};
+  var existingPlug = [];
+  while (i < availPlugins.length && backNum > 0) {
+    var j = 0;
+    while (j < backPlugins.length && availPlugins[i].name != backPlugins[j].name) {
+      j++;
+    }
+    if (j < backPlugins.length) {
+      existingPlug.push(backPlugins[j]);
+      backNum--;
+      backPlugins.splice(j, 1);
+    }
+    i++;
+  }
+  if (backNum > 0) {
+    self.installBackupPlugins(catName, backPlugins);
+  }
+  return { 'cName': catName, 'plugConf': existingPlug };
 }
 
 /**
@@ -604,18 +604,18 @@ CoreCommandRouter.prototype.usefulBackupConfs = function (currArray, backArray) 
  * @param data is a json with useful plugin's configuration files, sorted by category
  */
 CoreCommandRouter.prototype.writeConfs = function (data) {
-	var self = this;
+  var self = this;
 
-	var usefulConfs = data;
-	for(var i = 0; i < usefulConfs.length; i++){
-		for(var j = 0; j < usefulConfs[i].plugConf.length; j++){
-			if (usefulConfs[i].plugConf[j].config != "") {
-				var path = "/data/configuration/" + usefulConfs[i].cName + "/" +
-					usefulConfs[i].plugConf[j].name + "/config.json";
-				fs.outputJsonSync(path, usefulConfs[i].plugConf[j].config);
-			}
-		}
-	}
+  var usefulConfs = data;
+  for (var i = 0; i < usefulConfs.length; i++) {
+    for (var j = 0; j < usefulConfs[i].plugConf.length; j++) {
+      if (usefulConfs[i].plugConf[j].config != "") {
+        var path = "/data/configuration/" + usefulConfs[i].cName + "/" +
+          usefulConfs[i].plugConf[j].name + "/config.json";
+        fs.outputJsonSync(path, usefulConfs[i].plugConf[j].config);
+      }
+    }
+  }
 }
 
 /**
@@ -625,12 +625,12 @@ CoreCommandRouter.prototype.writeConfs = function (data) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.min = function (a, b) {
-	var self = this;
+  var self = this;
 
-	if (a < b)
-		return a;
-	else
-		return b;
+  if (a < b)
+    return a;
+  else
+    return b;
 }
 
 /**
@@ -639,34 +639,34 @@ CoreCommandRouter.prototype.min = function (a, b) {
  * @param array array of plugins
  */
 CoreCommandRouter.prototype.installBackupPlugins = function (name, array) {
-	var self = this;
+  var self = this;
 
-	var availablePlugins = self.pluginManager.getAvailablePlugins();
-	var cat = [];
-	availablePlugins.then(function (available) {
-		cat = available.categories;
-		var plug = [];
+  var availablePlugins = self.pluginManager.getAvailablePlugins();
+  var cat = [];
+  availablePlugins.then(function (available) {
+    cat = available.categories;
+    var plug = [];
 
-		for (var i = 0; i < cat.length; i++) {
-			if (cat[i].name == name) {
-				plug = cat[i].plugins;
-			}
-		}
+    for (var i = 0; i < cat.length; i++) {
+      if (cat[i].name == name) {
+        plug = cat[i].plugins;
+      }
+    }
 
-		if (plug.length > 0) {
-			for (var j = 0; j < array.length; j++) {
-				var k = 0;
-				while (k < plug.length && array[j].name != plug[k].name) {
-					k++;
-				}
-				if (k < plug.length) {
-					self.logger.info("Backup: installing plugin: " + plug[k].name);
-					self.pluginManager.installPlugin(plug[k].url);
-				}
-			}
-			self.writeConfs([{'cName': name, 'plugConf': array}]);
-		}
-	});
+    if (plug.length > 0) {
+      for (var j = 0; j < array.length; j++) {
+        var k = 0;
+        while (k < plug.length && array[j].name != plug[k].name) {
+          k++;
+        }
+        if (k < plug.length) {
+          self.logger.info("Backup: installing plugin: " + plug[k].name);
+          self.pluginManager.installPlugin(plug[k].url);
+        }
+      }
+      self.writeConfs([{ 'cName': name, 'plugConf': array }]);
+    }
+  });
 }
 
 /**
@@ -675,29 +675,29 @@ CoreCommandRouter.prototype.installBackupPlugins = function (name, array) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.loadBackup = function (request) {
-	var self = this;
+  var self = this;
 
-	var defer = libQ.defer();
+  var defer = libQ.defer();
 
-	var data = [];
+  var data = [];
 
-	self.logger.info("Backup: retrieving "+ request.type + " backup");
+  self.logger.info("Backup: retrieving " + request.type + " backup");
 
-	if(request.type == "playlist"){
-		var identification = self.getId();
-		data = {'id' : identification, 'backup': self.loadPlaylistsBackup()};
-		defer.resolve(data);
-	}else if (request.type == "radio-favourites" || request.type == "favourites"
-	|| request.type == "my-web-radio"){
-		var identification = self.getId();
-		data = {'id' : identification, 'backup': self.loadFavBackup(request.type)};
-		defer.resolve(data);
-	} else{
-		self.logger.info("Backup: request not accepted, unexisting category");
-		defer.resolve(undefined);
-	}
+  if (request.type == "playlist") {
+    var identification = self.getId();
+    data = { 'id': identification, 'backup': self.loadPlaylistsBackup() };
+    defer.resolve(data);
+  } else if (request.type == "radio-favourites" || request.type == "favourites"
+    || request.type == "my-web-radio") {
+    var identification = self.getId();
+    data = { 'id': identification, 'backup': self.loadFavBackup(request.type) };
+    defer.resolve(data);
+  } else {
+    self.logger.info("Backup: request not accepted, unexisting category");
+    defer.resolve(undefined);
+  }
 
-	return defer.promise;
+  return defer.promise;
 }
 
 /**
@@ -705,20 +705,20 @@ CoreCommandRouter.prototype.loadBackup = function (request) {
  * @returns {Array}
  */
 CoreCommandRouter.prototype.loadPlaylistsBackup = function () {
-	var self = this;
+  var self = this;
 
-	//data=[{"name": "", "content": []}]
-	var data = [];
-	var playlists = self.playListManager.retrievePlaylists();
+  //data=[{"name": "", "content": []}]
+  var data = [];
+  var playlists = self.playListManager.retrievePlaylists();
 
-	for (var i = 0; i < playlists.length; i++){
-		var name = playlists[i];
-		var path = self.playListManager.playlistFolder + name;
-		var songs = fs.readJsonSync(path, {throws: false});
-		data.push({"name": name, "content": songs});
-	}
+  for (var i = 0; i < playlists.length; i++) {
+    var name = playlists[i];
+    var path = self.playListManager.playlistFolder + name;
+    var songs = fs.readJsonSync(path, { throws: false });
+    data.push({ "name": name, "content": songs });
+  }
 
-	return data;
+  return data;
 }
 
 /**
@@ -727,60 +727,60 @@ CoreCommandRouter.prototype.loadPlaylistsBackup = function () {
  * @returns {Array}
  */
 CoreCommandRouter.prototype.loadFavBackup = function (type) {
-	var self = this;
+  var self = this;
 
-	var path = self.playListManager.favouritesPlaylistFolder;
-	var data = [];
+  var path = self.playListManager.favouritesPlaylistFolder;
+  var data = [];
 
-	try{
-		data = fs.readJsonSync(path + type, {throws: false});
-	}catch(e){
-		self.logger.info("No "+ type + " in favourites folder");
-	};
+  try {
+    data = fs.readJsonSync(path + type, { throws: false });
+  } catch (e) {
+    self.logger.info("No " + type + " in favourites folder");
+  };
 
-	return data;
+  return data;
 }
 
 /**
  * writes the playlists and their content in a json
  */
 CoreCommandRouter.prototype.writePlaylistsBackup = function () {
-	var self = this;
+  var self = this;
 
-	var data = self.loadPlaylistsBackup();
+  var data = self.loadPlaylistsBackup();
 
-	var file = "/data/configuration/playlists";
-	fs.outputJsonSync(file, data);
+  var file = "/data/configuration/playlists";
+  fs.outputJsonSync(file, data);
 }
 
 /**
  * writes radio and songs favourites in a json
  */
 CoreCommandRouter.prototype.writeFavouritesBackup = function () {
-	var self = this;
+  var self = this;
 
-	var data = self.loadFavBackup("favourites");
-	var radio = self.loadFavBackup("radio-favourites");
-	var myRadio = self.loadFavBackup("my-web-radio");
+  var data = self.loadFavBackup("favourites");
+  var radio = self.loadFavBackup("radio-favourites");
+  var myRadio = self.loadFavBackup("my-web-radio");
 
-	var favourites = {"songs": data, "radios": radio, "myRadios": myRadio};
+  var favourites = { "songs": data, "radios": radio, "myRadios": myRadio };
 
-	var file = "/data/configuration/favourites";
-	fs.outputJsonSync(file, favourites);
+  var file = "/data/configuration/favourites";
+  fs.outputJsonSync(file, favourites);
 }
 
 /**
  * Restores the playlist from the available local backup file
  */
 CoreCommandRouter.prototype.restorePlaylistBackup = function () {
-	var self = this;
-	var check = self.checkBackup("playlists");
-	var path = self.playListManager.playlistFolder;
-	var isbackup = check[0];
+  var self = this;
+  var check = self.checkBackup("playlists");
+  var path = self.playListManager.playlistFolder;
+  var isbackup = check[0];
 
-	if(isbackup){
-		self.restorePlaylist({'type': "playlist", 'backup': backup});
-	}
+  if (isbackup) {
+    self.restorePlaylist({ 'type': "playlist", 'backup': backup });
+  }
 }
 
 /**
@@ -788,18 +788,18 @@ CoreCommandRouter.prototype.restorePlaylistBackup = function () {
  * @param type
  */
 CoreCommandRouter.prototype.restoreFavouritesBackup = function (type) {
-	var self = this;
+  var self = this;
 
-	var backup = self.checkBackup("favourites");
-	var isbackup = backup[0];
-	var path = self.playListManager.favouritesPlaylistFolder;
+  var backup = self.checkBackup("favourites");
+  var isbackup = backup[0];
+  var path = self.playListManager.favouritesPlaylistFolder;
 
-	if(isbackup){
-		var kind = self.checkFavouritesType(type, backup[1]);
-		var file = kind[0];
-		var data = kind[1];
-		self.restorePlaylist({'type': type, 'path': file, 'backup': data});
-	}
+  if (isbackup) {
+    var kind = self.checkFavouritesType(type, backup[1]);
+    var file = kind[0];
+    var data = kind[1];
+    self.restorePlaylist({ 'type': type, 'path': file, 'backup': data });
+  }
 }
 
 /**
@@ -807,43 +807,43 @@ CoreCommandRouter.prototype.restoreFavouritesBackup = function (type) {
  * @param req
  */
 CoreCommandRouter.prototype.restorePlaylist = function (req) {
-	var self = this;
-	var path = "";
-	var backup = req.backup;
+  var self = this;
+  var path = "";
+  var backup = req.backup;
 
-	if (req.type == "playlist") {
-		path = self.playListManager.playlistFolder;
-		self.logger.info("Backup: restoring playlists");
-		for (var i = 0; i < backup.length; i++) {
-			var name = backup[i].name;
-			var songs = backup[i].content;
-			fs.outputJsonSync(path + name, songs);
-		}
-	}
-	else if(req.type == "favourites" || req.type == "radio-favourites" ||
-		req.type == "my-web-radio"){
-		path = self.playListManager.favouritesPlaylistFolder + req.type;
-		try{
-			var fav = fs.readJsonSync(path);
-			backup = self.mergePlaylists(backup, fav);
-		}catch(e){
-			self.logger.info("Backup: no existing playlist for selected category");
-		};
-		self.logger.info("Backup: restoring " + req.type + "!");
-		fs.outputJsonSync(path, backup);
-	}
-	else
-		self.logger.info("Backup: impossible to restore data");
+  if (req.type == "playlist") {
+    path = self.playListManager.playlistFolder;
+    self.logger.info("Backup: restoring playlists");
+    for (var i = 0; i < backup.length; i++) {
+      var name = backup[i].name;
+      var songs = backup[i].content;
+      fs.outputJsonSync(path + name, songs);
+    }
+  }
+  else if (req.type == "favourites" || req.type == "radio-favourites" ||
+    req.type == "my-web-radio") {
+    path = self.playListManager.favouritesPlaylistFolder + req.type;
+    try {
+      var fav = fs.readJsonSync(path);
+      backup = self.mergePlaylists(backup, fav);
+    } catch (e) {
+      self.logger.info("Backup: no existing playlist for selected category");
+    };
+    self.logger.info("Backup: restoring " + req.type + "!");
+    fs.outputJsonSync(path, backup);
+  }
+  else
+    self.logger.info("Backup: impossible to restore data");
 }
 
-CoreCommandRouter.prototype.getPath = function (type){
-	if(type == "songs")
-		return "favourites";
-	else if (type == "radios")
-		return "radio-favourites";
-	else if (type == "myRadios")
-		return "my-web-radio";
-	return "";
+CoreCommandRouter.prototype.getPath = function (type) {
+  if (type == "songs")
+    return "favourites";
+  else if (type == "radios")
+    return "radio-favourites";
+  else if (type == "myRadios")
+    return "my-web-radio";
+  return "";
 }
 
 /**
@@ -852,19 +852,19 @@ CoreCommandRouter.prototype.getPath = function (type){
  * @returns {*[]}
  */
 CoreCommandRouter.prototype.checkBackup = function (backup) {
-	var self = this;
-	var isbackup = false;
-	var file = [];
-	var path = "/data/configuration/" + backup;
+  var self = this;
+  var isbackup = false;
+  var file = [];
+  var path = "/data/configuration/" + backup;
 
-	try{
-		file = fs.readJsonSync(path);
-		isbackup = true;
-	}catch(e){
-		self.logger.info("Backup: no " + backup + " backup available");
-	};
+  try {
+    file = fs.readJsonSync(path);
+    isbackup = true;
+  } catch (e) {
+    self.logger.info("Backup: no " + backup + " backup available");
+  };
 
-	return [isbackup, file];
+  return [isbackup, file];
 }
 
 /**
@@ -875,26 +875,26 @@ CoreCommandRouter.prototype.checkBackup = function (backup) {
  * @returns {*[]}
  */
 CoreCommandRouter.prototype.checkFavouritesType = function (type, backup) {
-	var self = this;
-	var data = [];
-	var file = "";
+  var self = this;
+  var data = [];
+  var file = "";
 
-	if(type == "songs") {
-		data = backup.songs;
-		file = "favourites";
-	}
-	else if(type == "radios") {
-		data = backup.radios;
-		file = "radio-favourites";
-	}
-	else if(type == "myRadios") {
-		data = backup.myRadios;
-		file = "my-web-radio";
-	}
-	else
-		self.logger.info("Error: category non existent");
+  if (type == "songs") {
+    data = backup.songs;
+    file = "favourites";
+  }
+  else if (type == "radios") {
+    data = backup.radios;
+    file = "radio-favourites";
+  }
+  else if (type == "myRadios") {
+    data = backup.myRadios;
+    file = "my-web-radio";
+  }
+  else
+    self.logger.info("Error: category non existent");
 
-	return [file, data];
+  return [file, data];
 }
 
 /**
@@ -904,23 +904,23 @@ CoreCommandRouter.prototype.checkFavouritesType = function (type, backup) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.mergePlaylists = function (recent, old) {
-	var self = this;
-	var backup = recent;
-	var current = old;
+  var self = this;
+  var backup = recent;
+  var current = old;
 
-	for (var i = 0; i < current.length; i++){
-		var isthere = false;
-		for (var j = 0; j < backup.length; j++){
-			if (current[i].uri == backup[j].uri) {
-				isthere = true;
-			}
-		}
-		if (!isthere) {
-			backup.push(current[i]);
-		}
-	}
+  for (var i = 0; i < current.length; i++) {
+    var isthere = false;
+    for (var j = 0; j < backup.length; j++) {
+      if (current[i].uri == backup[j].uri) {
+        isthere = true;
+      }
+    }
+    if (!isthere) {
+      backup.push(current[i]);
+    }
+  }
 
-	return backup;
+  return backup;
 }
 
 /**
@@ -929,23 +929,23 @@ CoreCommandRouter.prototype.mergePlaylists = function (recent, old) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.managePlaylists = function (value) {
-	var self = this;
+  var self = this;
 
-	var defer = libQ.defer();
+  var defer = libQ.defer();
 
-	if (value == 0){
-		setTimeout(function () {
-			self.writePlaylistsBackup();
-			defer.resolve();
-		}, 10000);
-	}else{
-		setTimeout(function () {
-			self.restorePlaylistBackup();
-			defer.resolve();
-		}, 10000);
-	}
+  if (value == 0) {
+    setTimeout(function () {
+      self.writePlaylistsBackup();
+      defer.resolve();
+    }, 10000);
+  } else {
+    setTimeout(function () {
+      self.restorePlaylistBackup();
+      defer.resolve();
+    }, 10000);
+  }
 
-	return defer.promise;
+  return defer.promise;
 }
 
 /**
@@ -954,125 +954,123 @@ CoreCommandRouter.prototype.managePlaylists = function (value) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.manageFavourites = function (value) {
-	var self = this;
+  var self = this;
 
-	var defer = libQ.defer();
+  var defer = libQ.defer();
 
-	if (value == 0){
-		setTimeout(function () {
-			self.writeFavouritesBackup();
-			defer.resolve();
-		}, 10000);
-	}else{
-		setTimeout(function () {
-			self.restoreFavouritesBackup("songs");
-		}, 10000);
-		setTimeout(function () {
-			self.restoreFavouritesBackup("radios");
-		}, 10000);
-		setTimeout(function () {
-			self.restoreFavouritesBackup("myRadios");
-			defer.resolve();
-		}, 10000);
-	}
+  if (value == 0) {
+    setTimeout(function () {
+      self.writeFavouritesBackup();
+      defer.resolve();
+    }, 10000);
+  } else {
+    setTimeout(function () {
+      self.restoreFavouritesBackup("songs");
+    }, 10000);
+    setTimeout(function () {
+      self.restoreFavouritesBackup("radios");
+    }, 10000);
+    setTimeout(function () {
+      self.restoreFavouritesBackup("myRadios");
+      defer.resolve();
+    }, 10000);
+  }
 
-	return defer.promise;
+  return defer.promise;
 }
 
 CoreCommandRouter.prototype.executeOnPlugin = function (type, name, method, data) {
-	this.pushConsoleMessage('CoreCommandRouter::executeOnPlugin: ' + name + ' , ' + method);
+  this.pushConsoleMessage('CoreCommandRouter::executeOnPlugin: ' + name + ' , ' + method);
 
-	var thisPlugin = this.pluginManager.getPlugin(type, name);
+  var thisPlugin = this.pluginManager.getPlugin(type, name);
 
-	if (thisPlugin != undefined)
-		if (thisPlugin[method]) {
-			return thisPlugin[method](data);
-		} else {
-			this.pushConsoleMessage('Error : CoreCommandRouter::executeOnPlugin: No method [' + method + '] in plugin ' + name);
-		}
-	else return undefined;
+  if (thisPlugin != undefined)
+    if (thisPlugin[method]) {
+      return thisPlugin[method](data);
+    } else {
+      this.pushConsoleMessage('Error : CoreCommandRouter::executeOnPlugin: No method [' + method + '] in plugin ' + name);
+    }
+  else return undefined;
 };
 
 CoreCommandRouter.prototype.getUIConfigOnPlugin = function (type, name, data) {
-	var self=this
-    this.pushConsoleMessage('CoreCommandRouter::getUIConfigOnPlugin');
+  var self = this
+  this.pushConsoleMessage('CoreCommandRouter::getUIConfigOnPlugin');
 
-	var defer=libQ.defer()
+  var defer = libQ.defer()
 
-	var thisPlugin = this.pluginManager.getPlugin(type, name);
-    thisPlugin.getUIConfig(data)
-    .then(function(uiconf){
-        var filePath=__dirname + '/plugins/'+type+'/'+name+'/override.json'
+  var thisPlugin = this.pluginManager.getPlugin(type, name);
+  thisPlugin.getUIConfig(data)
+    .then(function (uiconf) {
+      var filePath = __dirname + '/plugins/' + type + '/' + name + '/override.json'
 
-        self.overrideUIConfig(uiconf,filePath)
-        .then(function(){
-            defer.resolve(uiconf)
+      self.overrideUIConfig(uiconf, filePath)
+        .then(function () {
+          defer.resolve(uiconf)
         })
-        .fail(function()
-        {
-            defer.reject(new Error());
+        .fail(function () {
+          defer.reject(new Error());
         })
     })
-    .fail(function()
-    {
-        defer.reject(new Error("Error retrieving UIConfig from plugin "+name))
+    .fail(function () {
+      defer.reject(new Error("Error retrieving UIConfig from plugin " + name))
     })
 
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.writePlayerControls = function (config) {
-	var self = this;
-	var pCtrlFile = '/data/playerstate/playback-controls.json';
+  var self = this;
+  var pCtrlFile = '/data/playerstate/playback-controls.json';
 
-	this.pushConsoleMessage('CoreCommandRouter::writePlayerControls');
+  this.pushConsoleMessage('CoreCommandRouter::writePlayerControls');
 
-	var state = self.stateMachine.getState();
+  var state = self.stateMachine.getState();
 
-	var data = Object.assign({
-		random: state.random,
-		repeat: state.repeat
-	}, config);
+  var data = Object.assign({
+    random: state.random,
+    repeat: state.repeat
+  }, config);
 
-	fs.writeFile(pCtrlFile, JSON.stringify(data, null, 4), function (err) {
-		if (err) self.pushConsoleMessage('Failed setting player state in CoreCommandRouter::initPlayerState');
-	});
+  fs.writeFile(pCtrlFile, JSON.stringify(data, null, 4), function (err) {
+    if (err) self.pushConsoleMessage('Failed setting player state in CoreCommandRouter::initPlayerState');
+  });
 };
 
 CoreCommandRouter.prototype.initPlayerControls = function () {
-	var pCtrlFile = '/data/playerstate/playback-controls.json';
-	var self = this;
+  var pCtrlFile = '/data/playerstate/playback-controls.json';
+  var self = this;
 
-	this.pushConsoleMessage('CoreCommandRouter::initPlayerControls');
+  this.pushConsoleMessage('CoreCommandRouter::initPlayerControls');
 
-	function handleError() {
-		self.pushConsoleMessage('Failed setting player state in CoreCommandRouter::initPlayerControls');
-	}
+  function handleError() {
+    self.pushConsoleMessage('Failed setting player state in CoreCommandRouter::initPlayerControls');
+  }
 
-	fs.ensureFile(pCtrlFile, function (err) {
-		if (err) handleError();
+  fs.ensureFile(pCtrlFile, function (err) {
+    if (err) handleError();
 
-		fs.readFile(pCtrlFile, function (err, data) {
-			if (err) handleError();
+    fs.readFile(pCtrlFile, function (err, data) {
+      if (err) handleError();
 
-			try {
-				var config = JSON.parse(data.toString());
-				self.stateMachine.setRepeat(config.repeat);
-				self.stateMachine.setRandom(config.random);
-			} catch(e) {
-				var state = self.stateMachine.getState();
-				var config = {
-					random: state.random,
-					repeat: state.repeat
-				};
+      try {
+        var config = JSON.parse(data.toString());
+        self.stateMachine.setRepeat(config.repeat);
+        self.stateMachine.setRandom(config.random);
+      } catch (e) {
+        var state = self.stateMachine.getState();
+        var config = {
+          random: state.random,
+          repeat: state.repeat
+        };
 
-				fs.writeFile(pCtrlFile, JSON.stringify(config, null, 4), function (err) {
-					if (err) handleError();
-				});
-			}
-		});
-	});
+        fs.writeFile(pCtrlFile, JSON.stringify(config, null, 4), function (err) {
+          if (err) handleError();
+        });
+      }
+    });
+  });
 };
 
 /* what is this?
@@ -1088,7 +1086,7 @@ CoreCommandRouter.prototype.initPlayerControls = function () {
  * @param sMessage The debug message to push
  */
 CoreCommandRouter.prototype.pushDebugConsoleMessage = function (sMessage) {
-    this.logger.info(sMessage);
+  this.logger.info(sMessage);
 };
 
 /**
@@ -1096,11 +1094,11 @@ CoreCommandRouter.prototype.pushDebugConsoleMessage = function (sMessage) {
  * @param sMessage The error message to push
  */
 CoreCommandRouter.prototype.pushErrorConsoleMessage = function (sMessage) {
-    this.logger.error(sMessage);
+  this.logger.error(sMessage);
 };
 
 CoreCommandRouter.prototype.pushConsoleMessage = function (sMessage) {
-	this.logger.info(sMessage);
+  this.logger.info(sMessage);
 	/*
 	 var self = this;
 	 return libQ.all(
@@ -1114,103 +1112,103 @@ CoreCommandRouter.prototype.pushConsoleMessage = function (sMessage) {
 };
 
 CoreCommandRouter.prototype.pushToastMessage = function (type, title, message) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.printToastMessage === "function")
-				return thisInterface.printToastMessage(type, title, message);
-		})
-	);
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.printToastMessage === "function")
+        return thisInterface.printToastMessage(type, title, message);
+    })
+  );
 };
 
 CoreCommandRouter.prototype.broadcastToastMessage = function (type, title, message) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.broadcastToastMessage === "function")
-				return thisInterface.broadcastToastMessage(type, title, message);
-		})
-	);
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.broadcastToastMessage === "function")
+        return thisInterface.broadcastToastMessage(type, title, message);
+    })
+  );
 };
 
 CoreCommandRouter.prototype.broadcastMessage = function (msg, value) {
-	var self = this;
-	this.pushConsoleMessage('CoreCommandRouter::BroadCastMessage '+msg);
+  var self = this;
+  this.pushConsoleMessage('CoreCommandRouter::BroadCastMessage ' + msg);
 
-	return libQ.all(
+  return libQ.all(
 
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var emit = {msg:msg,value:value};
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.broadcastMessage === "function")
-				return thisInterface.broadcastMessage(emit);
-		})
-	);
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var emit = { msg: msg, value: value };
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.broadcastMessage === "function")
+        return thisInterface.broadcastMessage(emit);
+    })
+  );
 };
 
 CoreCommandRouter.prototype.pushMultiroomDevices = function (data) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushMultiroomDevices === "function")
-				return thisInterface.pushMultiroomDevices(data);
-		})
-	);
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushMultiroomDevices === "function")
+        return thisInterface.pushMultiroomDevices(data);
+    })
+  );
 };
 
 CoreCommandRouter.prototype.pushMultiroom = function (data) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushMultiroom === "function")
-				return thisInterface.pushMultiroom(data);
-		})
-	);
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushMultiroom === "function")
+        return thisInterface.pushMultiroom(data);
+    })
+  );
 };
 
 
 CoreCommandRouter.prototype.pushAirplay = function (data) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushAirplay === "function")
-				return thisInterface.pushAirplay(data);
-		})
-	);
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushAirplay === "function")
+        return thisInterface.pushAirplay(data);
+    })
+  );
 };
 
 
 // Platform specific & Hardware related options, they can be found in platformSpecific.js
 // This allows to change system commands across different devices\environments
 CoreCommandRouter.prototype.shutdown = function () {
-	this.pluginManager.onVolumioShutdown();
-	this.platformspecific.shutdown();
+  this.pluginManager.onVolumioShutdown();
+  this.platformspecific.shutdown();
 };
 
 CoreCommandRouter.prototype.reboot = function () {
-	this.pluginManager.onVolumioReboot();
-	this.platformspecific.reboot();
+  this.pluginManager.onVolumioReboot();
+  this.platformspecific.reboot();
 };
 
 CoreCommandRouter.prototype.networkRestart = function () {
-	this.platformspecific.networkRestart();
+  this.platformspecific.networkRestart();
 };
 
 CoreCommandRouter.prototype.wirelessRestart = function () {
-	this.platformspecific.wirelessRestart();
+  this.platformspecific.wirelessRestart();
 };
 
 CoreCommandRouter.prototype.startupSound = function () {
-	this.platformspecific.startupSound();
+  this.platformspecific.startupSound();
 };
 
 CoreCommandRouter.prototype.fileUpdate = function (data) {
-	this.platformspecific.fileUpdate(data);
+  this.platformspecific.fileUpdate(data);
 }
 
 
@@ -1219,19 +1217,19 @@ CoreCommandRouter.prototype.fileUpdate = function (data) {
 //------------------------- Multiservice queue methods -----------------------------------
 
 CoreCommandRouter.prototype.explodeUriFromService = function (service, uri) {
-	this.logger.info("Exploding uri "+uri+" in service "+service);
+  this.logger.info("Exploding uri " + uri + " in service " + service);
 
-	var thisPlugin = this.pluginManager.getPlugin('music_service', service);
-	if(thisPlugin.explodeUri !=undefined)
-		return  thisPlugin.explodeUri(uri);
-	else {
-		var promise=libQ.defer();
-		promise.resolve({
-			uri: uri,
-			service: service
-		});
-		return promise.promise;
-	}
+  var thisPlugin = this.pluginManager.getPlugin('music_service', service);
+  if (thisPlugin.explodeUri != undefined)
+    return thisPlugin.explodeUri(uri);
+  else {
+    var promise = libQ.defer();
+    promise.resolve({
+      uri: uri,
+      service: service
+    });
+    return promise.promise;
+  }
 };
 
 
@@ -1244,231 +1242,223 @@ CoreCommandRouter.prototype.explodeUriFromService = function (service, uri) {
 
 // Volumio Play
 CoreCommandRouter.prototype.volumioPlay = function (N) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPlay');
+  this.pushConsoleMessage('CoreCommandRouter::volumioPlay');
 
-    this.stateMachine.unSetVolatile();
+  this.stateMachine.unSetVolatile();
 
-	if(N===undefined)
-		return this.stateMachine.play();
-	else
-	{
-		return this.stateMachine.play(N);
-	}
+  if (N === undefined)
+    return this.stateMachine.play();
+  else {
+    return this.stateMachine.play(N);
+  }
 };
 
 // Volumio Toggle
 CoreCommandRouter.prototype.volumioToggle = function () {
-    this.pushConsoleMessage('CoreCommandRouter::volumioToggle');
+  this.pushConsoleMessage('CoreCommandRouter::volumioToggle');
 
-    var state=this.stateMachine.getState();
+  var state = this.stateMachine.getState();
 
-	if (state.status != undefined) {
-		if(state.status==='stop' || state.status==='pause')
-		{
-			return this.stateMachine.play();
-		} else {
-			if(state.trackType == 'webradio') {
-				return this.stateMachine.stop();
-			} else {
-				return this.stateMachine.pause();
-			}
-		}
+  if (state.status != undefined) {
+    if (state.status === 'stop' || state.status === 'pause') {
+      return this.stateMachine.play();
+    } else {
+      if (state.trackType == 'webradio') {
+        return this.stateMachine.stop();
+      } else {
+        return this.stateMachine.pause();
+      }
     }
+  }
 };
 
 
 // Volumio Seek
 CoreCommandRouter.prototype.volumioSeek = function (position) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioSeek');
-	return this.stateMachine.seek(position);
+  this.pushConsoleMessage('CoreCommandRouter::volumioSeek');
+  return this.stateMachine.seek(position);
 };
 
 CoreCommandRouter.prototype.installPlugin = function (uri) {
-	var self=this;
-	var defer=libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-	this.pluginManager.installPlugin(uri).then(function()
-	{
-		defer.resolve();
-	}).fail(function(e){
-		self.logger.info("Error: "+e);
-		defer.reject(new Error('Cannot install plugin. Error: '+e));
-	});
+  this.pluginManager.installPlugin(uri).then(function () {
+    defer.resolve();
+  }).fail(function (e) {
+    self.logger.info("Error: " + e);
+    defer.reject(new Error('Cannot install plugin. Error: ' + e));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.updatePlugin = function (data) {
-	var self=this;
-	var defer=libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-	this.pluginManager.updatePlugin(data).then(function()
-	{
-		defer.resolve();
-	}).fail(function(e){
-		self.logger.info("Error: "+e);
-		self.logger.info("Error: "+e);
-		defer.reject(new Error('Cannot Update plugin. Error: '+e));
-	});
+  this.pluginManager.updatePlugin(data).then(function () {
+    defer.resolve();
+  }).fail(function (e) {
+    self.logger.info("Error: " + e);
+    self.logger.info("Error: " + e);
+    defer.reject(new Error('Cannot Update plugin. Error: ' + e));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.unInstallPlugin = function (data) {
-	var self = this;
-	var defer=libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-	self.logger.info('Starting Uninstall of plugin ' + data.category + ' - ' +data.name);
+  self.logger.info('Starting Uninstall of plugin ' + data.category + ' - ' + data.name);
 
-	this.pluginManager.unInstallPlugin(data.category,data.name).then(function()
-	{
-		defer.resolve();
-	}).fail(function(){
-		defer.reject(new Error('Cannot uninstall plugin'));
-	});
+  this.pluginManager.unInstallPlugin(data.category, data.name).then(function () {
+    defer.resolve();
+  }).fail(function () {
+    defer.reject(new Error('Cannot uninstall plugin'));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.enablePlugin = function (data) {
-	var defer=libQ.defer();
+  var defer = libQ.defer();
 
-	this.pluginManager.enablePlugin(data.category,data.plugin).then(function()
-	{
-		defer.resolve();
-	}).fail(function(){
-		defer.reject(new Error('Cannot enable plugin'));
-	});
+  this.pluginManager.enablePlugin(data.category, data.plugin).then(function () {
+    defer.resolve();
+  }).fail(function () {
+    defer.reject(new Error('Cannot enable plugin'));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.disablePlugin = function (data) {
-	var defer=libQ.defer();
+  var defer = libQ.defer();
 
-	this.pluginManager.disablePlugin(data.category,data.plugin).then(function()
-	{
-		defer.resolve();
-	}).fail(function(){
-		defer.reject(new Error('Cannot disable plugin'));
-	});
+  this.pluginManager.disablePlugin(data.category, data.plugin).then(function () {
+    defer.resolve();
+  }).fail(function () {
+    defer.reject(new Error('Cannot disable plugin'));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.modifyPluginStatus = function (data) {
-	var defer=libQ.defer();
+  var defer = libQ.defer();
 
-	this.pluginManager.modifyPluginStatus(data.category,data.plugin,data.status).then(function()
-	{
-		defer.resolve();
-	}).fail(function(){
-		defer.reject(new Error('Cannot update plugin status'));
-	});
+  this.pluginManager.modifyPluginStatus(data.category, data.plugin, data.status).then(function () {
+    defer.resolve();
+  }).fail(function () {
+    defer.reject(new Error('Cannot update plugin status'));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
-CoreCommandRouter.prototype.broadcastMessage = function (emit,payload) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.broadcastMessage === "function")
-				return thisInterface.broadcastMessage(emit,payload);
-		})
-	);
+CoreCommandRouter.prototype.broadcastMessage = function (emit, payload) {
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.broadcastMessage === "function")
+        return thisInterface.broadcastMessage(emit, payload);
+    })
+  );
 };
 
 CoreCommandRouter.prototype.getInstalledPlugins = function () {
-	return this.pluginManager.getInstalledPlugins();
+  return this.pluginManager.getInstalledPlugins();
 };
 
 CoreCommandRouter.prototype.getAvailablePlugins = function () {
-	return this.pluginManager.getAvailablePlugins();
+  return this.pluginManager.getAvailablePlugins();
 };
 
 CoreCommandRouter.prototype.getPluginDetails = function (data) {
-	return this.pluginManager.getPluginDetails(data);
+  return this.pluginManager.getPluginDetails(data);
 };
 
 
 
-CoreCommandRouter.prototype.enableAndStartPlugin = function (category,name) {
-	return this.pluginManager.enableAndStartPlugin(category,name);
+CoreCommandRouter.prototype.enableAndStartPlugin = function (category, name) {
+  return this.pluginManager.enableAndStartPlugin(category, name);
 };
 
 
-CoreCommandRouter.prototype.disableAndStopPlugin = function (category,name) {
-	return this.pluginManager.disableAndStopPlugin(category,name);
+CoreCommandRouter.prototype.disableAndStopPlugin = function (category, name) {
+  return this.pluginManager.disableAndStopPlugin(category, name);
 };
 
 
 CoreCommandRouter.prototype.volumioRandom = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioRandom');
+  this.pushConsoleMessage('CoreCommandRouter::volumioRandom');
 
-	this.writePlayerControls({
-		random: data
-	});
+  this.writePlayerControls({
+    random: data
+  });
 
-	return this.stateMachine.setRandom(data);
+  return this.stateMachine.setRandom(data);
 };
 
 
 
 
-CoreCommandRouter.prototype.randomToggle = function(){
-    var self = this;
+CoreCommandRouter.prototype.randomToggle = function () {
+  var self = this;
 
-    var state = self.stateMachine.getState();
+  var state = self.stateMachine.getState();
 
-    if(state.random){
-        var random = false;
-    }
-    else{
-        var random = true;
-    }
+  if (state.random) {
+    var random = false;
+  }
+  else {
+    var random = true;
+  }
 
-    this.writePlayerControls({
-        random: random
-	});
+  this.writePlayerControls({
+    random: random
+  });
 
-    return self.stateMachine.setRandom(random);
+  return self.stateMachine.setRandom(random);
 
 }
 
-CoreCommandRouter.prototype.volumioRepeat = function (repeat,repeatSingle) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioRandom');
+CoreCommandRouter.prototype.volumioRepeat = function (repeat, repeatSingle) {
+  this.pushConsoleMessage('CoreCommandRouter::volumioRandom');
 
-    this.writePlayerControls({
-        repeat: repeat
-    });
+  this.writePlayerControls({
+    repeat: repeat
+  });
 
-    return this.stateMachine.setRepeat(repeat,repeatSingle);
+  return this.stateMachine.setRepeat(repeat, repeatSingle);
 };
 
 CoreCommandRouter.prototype.repeatToggle = function () {
-    var self = this;
+  var self = this;
 
-    var state = self.stateMachine.getState();
+  var state = self.stateMachine.getState();
 
-    if(state.repeat){
-        var repeat = false;
-    }
-    else{
-        var repeat = true;
-    }
+  if (state.repeat) {
+    var repeat = false;
+  }
+  else {
+    var repeat = true;
+  }
 
-    this.writePlayerControls({
-        repeat: repeat
-    });
+  this.writePlayerControls({
+    repeat: repeat
+  });
 
-    return self.stateMachine.setRepeat(repeat, false);
+  return self.stateMachine.setRepeat(repeat, false);
 }
 
 CoreCommandRouter.prototype.volumioConsume = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioConsume');
-	return this.stateMachine.setConsume(data);
+  this.pushConsoleMessage('CoreCommandRouter::volumioConsume');
+  return this.stateMachine.setConsume(data);
 };
 
 /**
@@ -1476,9 +1466,9 @@ CoreCommandRouter.prototype.volumioConsume = function (data) {
  * Return a promise
  */
 CoreCommandRouter.prototype.volumioFFWDRew = function (millisecs) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioFFWDRew '+millisecs);
+  this.pushConsoleMessage('CoreCommandRouter::volumioFFWDRew ' + millisecs);
 
-    return this.stateMachine.ffwdRew(millisecs);
+  return this.stateMachine.ffwdRew(millisecs);
 };
 
 
@@ -1486,160 +1476,148 @@ CoreCommandRouter.prototype.volumioFFWDRew = function (millisecs) {
 
 
 CoreCommandRouter.prototype.volumioSaveQueueToPlaylist = function (name) {
-	var self=this;
-    this.pushConsoleMessage('CoreCommandRouter::volumioSaveQueueToPlaylist');
+  var self = this;
+  this.pushConsoleMessage('CoreCommandRouter::volumioSaveQueueToPlaylist');
 
-	var queueArray=this.stateMachine.getQueue();
-	var defer=this.playListManager.commonAddItemsToPlaylist(this.playListManager.playlistFolder,name,queueArray);
+  var queueArray = this.stateMachine.getQueue();
+  var defer = this.playListManager.commonAddItemsToPlaylist(this.playListManager.playlistFolder, name, queueArray);
 
-    defer.then(function()
-    {
-        self.pushToastMessage('success', self.getI18nString('COMMON.SAVE_QUEUE_SUCCESS') + name);
-    })
+  defer.then(function () {
+    self.pushToastMessage('success', self.getI18nString('COMMON.SAVE_QUEUE_SUCCESS') + name);
+  })
     .fail(function () {
-        self.pushToastMessage('success', self.getI18nString('COMMON.SAVE_QUEUE_ERROR')+name);
+      self.pushToastMessage('success', self.getI18nString('COMMON.SAVE_QUEUE_ERROR') + name);
     });
 
-    return defer;
+  return defer;
 };
 
 
-CoreCommandRouter.prototype.volumioMoveQueue = function (from,to) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioMoveQueue');
+CoreCommandRouter.prototype.volumioMoveQueue = function (from, to) {
+  this.pushConsoleMessage('CoreCommandRouter::volumioMoveQueue');
 
-	return this.stateMachine.moveQueueItem(from,to);
+  return this.stateMachine.moveQueueItem(from, to);
 };
 
 CoreCommandRouter.prototype.getI18nString = function (key) {
-    var splitted=key.split('.');
+  var splitted = key.split('.');
 
-	if(splitted.length==1)
-    {
-        if(this.i18nStrings[key]!==undefined)
-            return this.i18nStrings[key];
-        else return this.i18nStringsDefaults[key];
-    }
-    else {
-        if(this.i18nStrings[splitted[0]]!==undefined &&
-           this.i18nStrings[splitted[0]][splitted[1]]!==undefined)
-            return this.i18nStrings[splitted[0]][splitted[1]];
-        else return this.i18nStringsDefaults[splitted[0]][splitted[1]];
-    }
+  if (splitted.length == 1) {
+    if (this.i18nStrings[key] !== undefined)
+      return this.i18nStrings[key];
+    else return this.i18nStringsDefaults[key];
+  }
+  else {
+    if (this.i18nStrings[splitted[0]] !== undefined &&
+      this.i18nStrings[splitted[0]][splitted[1]] !== undefined)
+      return this.i18nStrings[splitted[0]][splitted[1]];
+    else return this.i18nStringsDefaults[splitted[0]][splitted[1]];
+  }
 };
 
 CoreCommandRouter.prototype.loadI18nStrings = function () {
-    var self=this;
-    var language_code=this.sharedVars.get('language_code');
+  var self = this;
+  var language_code = this.sharedVars.get('language_code');
 
-    this.logger.info("Loading i18n strings for locale "+language_code);
+  this.logger.info("Loading i18n strings for locale " + language_code);
 
-    this.i18nStrings=fs.readJsonSync(__dirname+'/i18n/strings_'+language_code+".json");
-    this.i18nStringsDefaults=fs.readJsonSync(__dirname+'/i18n/strings_en.json');
+  this.i18nStrings = fs.readJsonSync(__dirname + '/i18n/strings_' + language_code + ".json");
+  this.i18nStringsDefaults = fs.readJsonSync(__dirname + '/i18n/strings_en.json');
 
-    var categories=this.pluginManager.getPluginCategories();
-    for(var i in categories)
-    {
-        var category=categories[i];
-        var names=this.pluginManager.getPluginNames(category);
-        for(var j in names)
-        {
-            var name=names[j];
-            var instance=this.pluginManager.getPlugin(category,name);
+  var categories = this.pluginManager.getPluginCategories();
+  for (var i in categories) {
+    var category = categories[i];
+    var names = this.pluginManager.getPluginNames(category);
+    for (var j in names) {
+      var name = names[j];
+      var instance = this.pluginManager.getPlugin(category, name);
 
-            if(instance.loadI18NStrings)
-                instance.loadI18NStrings(language_code);
+      if (instance.loadI18NStrings)
+        instance.loadI18NStrings(language_code);
 
-        }
     }
+  }
 };
 
-CoreCommandRouter.prototype.i18nJson = function (dictionaryFile,defaultDictionaryFile,jsonFile) {
-    var self=this;
-    var methodDefer=libQ.defer();
-    var defers=[];
+CoreCommandRouter.prototype.i18nJson = function (dictionaryFile, defaultDictionaryFile, jsonFile) {
+  var self = this;
+  var methodDefer = libQ.defer();
+  var defers = [];
 
 
-	try {
-		fs.statSync(dictionaryFile);
-	} catch(e) {
-		dictionaryFile = defaultDictionaryFile;
-	}
+  try {
+    fs.statSync(dictionaryFile);
+  } catch (e) {
+    dictionaryFile = defaultDictionaryFile;
+  }
 
-    defers.push(libQ.nfcall(fs.readJson,dictionaryFile));
-    defers.push(libQ.nfcall(fs.readJson,defaultDictionaryFile));
-    defers.push(libQ.nfcall(fs.readJson,jsonFile));
+  defers.push(libQ.nfcall(fs.readJson, dictionaryFile));
+  defers.push(libQ.nfcall(fs.readJson, defaultDictionaryFile));
+  defers.push(libQ.nfcall(fs.readJson, jsonFile));
 
-    libQ.all(defers).
-            then(function(documents)
-    {
+  libQ.all(defers).
+    then(function (documents) {
 
-        var dictionary=documents[0];
-        var defaultDictionary=documents[1];
-        var jsonFile=documents[2];
+      var dictionary = documents[0];
+      var defaultDictionary = documents[1];
+      var jsonFile = documents[2];
 
-        self.translateKeys(jsonFile,dictionary,defaultDictionary);
+      self.translateKeys(jsonFile, dictionary, defaultDictionary);
 
-        methodDefer.resolve(jsonFile);
+      methodDefer.resolve(jsonFile);
     })
-    .fail(function(err){
-        self.logger.info("ERROR LOADING JSON "+err);
+    .fail(function (err) {
+      self.logger.info("ERROR LOADING JSON " + err);
 
-        methodDefer.reject(new Error());
+      methodDefer.reject(new Error());
     });
 
-    return methodDefer.promise;
+  return methodDefer.promise;
 
 };
 
-CoreCommandRouter.prototype.translateKeys = function (parent,dictionary,defaultDictionary) {
-    var self=this;
+CoreCommandRouter.prototype.translateKeys = function (parent, dictionary, defaultDictionary) {
+  var self = this;
 
-    var keys=Object.keys(parent);
+  var keys = Object.keys(parent);
 
-    for(var i in keys)
-    {
-        var obj=parent[keys[i]];
-        var type=typeof(obj);
+  for (var i in keys) {
+    var obj = parent[keys[i]];
+    var type = typeof (obj);
 
-        if(type==='object')
-        {
-           self.translateKeys(obj,dictionary,defaultDictionary);
-        }
-        else if(type==='string')
-        {
-            if(obj.startsWith("TRANSLATE."))
-            {
-                var replaceKey=obj.slice(10);
-
-                var dotIndex=replaceKey.indexOf('.');
-
-                if(dotIndex==-1)
-                {
-                    var value=dictionary[replaceKey];
-                    if(value===undefined)
-                    {
-                        value=defaultDictionary[replaceKey];
-                    }
-                    parent[keys[i]]=value;
-                }
-                else {
-                    var category=replaceKey.slice(0,dotIndex);
-                    var key=replaceKey.slice(dotIndex+1);
-
-                    var value=dictionary[category][key];
-                    if(value===undefined)
-                    {
-                        value=defaultDictionary[category][key];
-                    }
-                    parent[keys[i]]=value;
-                }
-
-
-
-            }
-
-        }
+    if (type === 'object') {
+      self.translateKeys(obj, dictionary, defaultDictionary);
     }
+    else if (type === 'string') {
+      if (obj.startsWith("TRANSLATE.")) {
+        var replaceKey = obj.slice(10);
+
+        var dotIndex = replaceKey.indexOf('.');
+
+        if (dotIndex == -1) {
+          var value = dictionary[replaceKey];
+          if (value === undefined) {
+            value = defaultDictionary[replaceKey];
+          }
+          parent[keys[i]] = value;
+        }
+        else {
+          var category = replaceKey.slice(0, dotIndex);
+          var key = replaceKey.slice(dotIndex + 1);
+
+          var value = dictionary[category][key];
+          if (value === undefined) {
+            value = defaultDictionary[category][key];
+          }
+          parent[keys[i]] = value;
+        }
+
+
+
+      }
+
+    }
+  }
 }
 
 /**
@@ -1658,62 +1636,57 @@ CoreCommandRouter.prototype.translateKeys = function (parent,dictionary,defaultD
  */
 
 CoreCommandRouter.prototype.overrideUIConfig = function (uiconfig, overrideFile) {
-    var self=this;
-    var methodDefer=libQ.defer();
+  var self = this;
+  var methodDefer = libQ.defer();
 
-    fs.readJson(overrideFile, function(err,override){
+  fs.readJson(overrideFile, function (err, override) {
 
-        if(err)
-        {
-            methodDefer.resolve()
-        }
-        else {
-            for(var i in override)
-            {
-                var attr=override[i]
+    if (err) {
+      methodDefer.resolve()
+    }
+    else {
+      for (var i in override) {
+        var attr = override[i]
 
-                var attribute_name=attr.attribute_name
-                var attribute_value=attr.value
-                var id=attr.id
+        var attribute_name = attr.attribute_name
+        var attribute_value = attr.value
+        var id = attr.id
 
-                self.overrideField(uiconfig,id,attribute_name,attribute_value)
-            }
+        self.overrideField(uiconfig, id, attribute_name, attribute_value)
+      }
 
-            methodDefer.resolve()
-        }
-    })
+      methodDefer.resolve()
+    }
+  })
 
-    return methodDefer.promise;
+  return methodDefer.promise;
 
 };
 
-CoreCommandRouter.prototype.overrideField = function (parent,id,attribute_name,attribute_value) {
-    var self=this;
+CoreCommandRouter.prototype.overrideField = function (parent, id, attribute_name, attribute_value) {
+  var self = this;
 
-    if(typeof(parent)==='object')
-    {
-        if(parent.id===id)
-        {
-            parent[attribute_name]=attribute_value
-        } else {
-            var keys=Object.keys(parent);
+  if (typeof (parent) === 'object') {
+    if (parent.id === id) {
+      parent[attribute_name] = attribute_value
+    } else {
+      var keys = Object.keys(parent);
 
-            for(var i in keys)
-            {
-                var obj=parent[keys[i]];
+      for (var i in keys) {
+        var obj = parent[keys[i]];
 
-                self.overrideField(obj,id,attribute_name,attribute_value);
-            }
+        self.overrideField(obj, id, attribute_name, attribute_value);
+      }
 
-        }
     }
+  }
 }
 
 
 CoreCommandRouter.prototype.updateBrowseSourcesLang = function () {
-	var self=this;
+  var self = this;
 
-	return this.musicLibrary.updateBrowseSourcesLang();
+  return this.musicLibrary.updateBrowseSourcesLang();
 }
 
 
@@ -1721,81 +1694,75 @@ CoreCommandRouter.prototype.updateBrowseSourcesLang = function () {
  * This function checks if update files are placed in the update folder
  */
 CoreCommandRouter.prototype.checkAndPerformSystemUpdates = function () {
-    //var defer=libQ.defer();
-    var self=this;
+  //var defer=libQ.defer();
+  var self = this;
 
-    var updateFolder='/volumio/update';
-	try {
-		var files = fs.readdirSync(updateFolder);
-	} catch (e)
-	{
-		//Nothing to do
-	}
+  var updateFolder = '/volumio/update';
+  try {
+    var files = fs.readdirSync(updateFolder);
+  } catch (e) {
+    //Nothing to do
+  }
 
-    if(files!==undefined && files.length>0)
-    {
-        self.logger.info("Updating system");
+  if (files !== undefined && files.length > 0) {
+    self.logger.info("Updating system");
 
-        try {
-            for(var i in files)
-            {
-                var file=files[i];
+    try {
+      for (var i in files) {
+        var file = files[i];
 
-                if(file.endsWith(".sh"))
-                {
-                    var output = execSync('sh '+updateFolder+'/'+file, { encoding: 'utf8' });
-                }
-
-
-            }
-
-            for(var i in files)
-            {
-                var file=files[i];
-
-                fs.unlinkSync(updateFolder+'/'+file);
-            }
-        }
-        catch(err)
-        {
-            self.logger.error("An error occurred when updating Volumio. Details: "+err);
-
-            //TODO: decide what to do in case of errors when updating
+        if (file.endsWith(".sh")) {
+          var output = execSync('sh ' + updateFolder + '/' + file, { encoding: 'utf8' });
         }
 
 
+      }
+
+      for (var i in files) {
+        var file = files[i];
+
+        fs.unlinkSync(updateFolder + '/' + file);
+      }
     }
+    catch (err) {
+      self.logger.error("An error occurred when updating Volumio. Details: " + err);
+
+      //TODO: decide what to do in case of errors when updating
+    }
+
+
+  }
 }
 
 CoreCommandRouter.prototype.safeRemoveDrive = function (data) {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    exec("/usr/bin/sudo /bin/umount /mnt/USB/"+data, function (error, stdout, stderr) {
+  exec("/usr/bin/sudo /bin/umount /mnt/USB/" + data, function (error, stdout, stderr) {
+    if (error !== null) {
+      self.pushConsoleMessage(error);
+      self.pushToastMessage('error', data,
+        self.getI18nString('SYSTEM.CANNOT_REMOVE_MEDIA') + ': ' + error);
+    } else {
+      self.pushToastMessage('success', self.getI18nString('SYSTEM.MEDIA_REMOVED_SUCCESSFULLY'),
+        self.getI18nString('SYSTEM.MEDIA_REMOVED_SUCCESSFULLY'));
+      self.executeOnPlugin('music_service', 'mpd', 'updateMpdDB', '/USB/');
+      execSync('/usr/bin/mpc update', { uid: 1000, gid: 1000, encoding: 'utf8' });
+      exec('/usr/bin/mpc idle update', { uid: 1000, gid: 1000, timeout: 10000 }, function (error, stdout, stderr) {
         if (error !== null) {
-            self.pushConsoleMessage(error);
-            self.pushToastMessage('error',data,
-                self.getI18nString('SYSTEM.CANNOT_REMOVE_MEDIA')+ ': ' +error);
         } else {
-            self.pushToastMessage('success',self.getI18nString('SYSTEM.MEDIA_REMOVED_SUCCESSFULLY'),
-                self.getI18nString('SYSTEM.MEDIA_REMOVED_SUCCESSFULLY'));
-            self.executeOnPlugin('music_service', 'mpd', 'updateMpdDB', '/USB/');
-            execSync('/usr/bin/mpc update', { uid:1000, gid:1000, encoding: 'utf8' });
-            exec('/usr/bin/mpc idle update', {uid:1000, gid:1000, timeout: 10000}, function (error, stdout, stderr) {
-                if (error !== null) {
-                } else {
-                    var response = self.musicLibrary.executeBrowseSource('music-library/USB');
-                    if (response != undefined) {
-                        response.then(function (result) {
-                            defer.resolve(result);
-                        })
-                            .fail(function () {
-                                defer.reject();
-                            });
-                    }
-				}
-            });
+          var response = self.musicLibrary.executeBrowseSource('music-library/USB');
+          if (response != undefined) {
+            response.then(function (result) {
+              defer.resolve(result);
+            })
+              .fail(function () {
+                defer.reject();
+              });
+          }
         }
-    });
-    return defer.promise;
+      });
+    }
+  });
+  return defer.promise;
 }

--- a/app/index.js
+++ b/app/index.js
@@ -1532,9 +1532,22 @@ CoreCommandRouter.prototype.loadI18nStrings = function () {
       var name = names[j];
       var instance = this.pluginManager.getPlugin(category, name);
 
-      if (instance.loadI18NStrings)
-        instance.loadI18NStrings(language_code);
+      if (instance.getI18nFile) {
+        var pluginI18NFile = instance.getI18nFile(language_code);
+        if (pluginI18NFile && fs.pathExistsSync(pluginI18NFile)) {
+          var pluginI18nStrings = fs.readJSONSync(pluginI18NFile);
 
+          for (var locale in pluginI18nStrings) {
+            // check if locale does not already exist to avoid that volumio
+            // strings get overwritten
+            if (!this.i18nStrings[locale]) {
+              this.i18nStrings[locale] = pluginI18nStrings[locale];
+            } else {
+              this.logger.info("Plugin " + name + " has duplicated i18n key " + locale + ". It is ignored.");
+            }
+          }
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
Currently the plugins have to implement localization support by their own. The ```CoreCommandRouter ``` called the method ```loadI18NStrings``` on each plugin if the method exists. But this was not documented at all so the method is not used so far.

I have replaced this method by a new method called ```getI18nFile```. The idea is that each plugin returns the i18n filename that should be loaded into volumio on startup.  Then volumio reads that file and merges the locales into the variable ```i18nStrings```. Now the plugins can call ```self.commandRouter.getI18nString('MY_LOCALE_KEY')``` and they get the localized string for it. 

With this feature we can now provide localized toast messages in the spotify, qobuz and youtube plugin.

When you accept the PR I will update the docs accordingly where we also have to setup some guidelines so that we have no merge issues. My code already takes aware of duplicated keys and only adds new keys to ```i18nStrings```.

The implementation of ```getI18nFile``` could look like this and could be part of the example plugin too:

```javascript
Youtube.prototype.getI18nFile = function (lang_code) {
  var supportedLanguages = ['en', 'it', 'de'];

  if (supportedLanguages.includes(lang_code)) {
    return path.join(__dirname, 'i18n', 'strings_' + lang_code + '.json');
  }

  // return default i18n file
  return path.join(__dirname, 'i18n', 'strings_en.json')
}
```