### PR TITLE
Make 'volumio vstop' work

### DIFF
--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -33,9 +33,9 @@ clear
 
 [[VOLUMIO SERVICE CONTROL]]
 
-start                               Starts Volumio Service
+vstart                              Starts Volumio Service
 vstop                               Stops Volumio Service
-restart                             Restarts Volumio Service
+vrestart                            Restarts Volumio Service
 
 [[VOLUMIO DEVELOPMENT]]
 
@@ -55,7 +55,7 @@ plugin update                      updates the plugin
 
 #VOLUMIO SERVICE CONTROLS
 
-start() {
+vstart() {
 echo volumio | sudo -S systemctl start volumio.service
 }
 
@@ -127,20 +127,20 @@ case "$1" in
         stopairplay)
            /usr/bin/curl "http://127.0.0.1:3000/api/v1/commands/?cmd=stopAirplay"
         ;;
-        start)
-            start
+        vstart)
+            vstart
             ;;
-        start)
-            start
+        vstart)
+            vstart
             ;;
 
         vstop)
             vstop
             ;;
 
-        restart)
+        vrestart)
             vstop
-            start
+            vstart
             ;;
 
         status)

--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -135,11 +135,11 @@ case "$1" in
             ;;
 
         vstop)
-            stop
+            vstop
             ;;
 
         restart)
-            stop
+            vstop
             start
             ;;
 


### PR DESCRIPTION
While we're there, name the other commands controlling the volumio service consistently.
I couldn't find any internal commands using these but perhaps this is an API break.

Fixes #1427. Not tested beyond making sure 'volumio vstop' doesn't fail with 'command not found'.
