### PR TITLE
Sleep timer disables once triggered, returns 00:00 via getSleep when …

### DIFF
--- a/app/plugins/miscellanea/alarm-clock/index.js
+++ b/app/plugins/miscellanea/alarm-clock/index.js
@@ -251,8 +251,14 @@ AlarmClock.prototype.getSleep = function()
 	thisMoment.add(sleep_minute,"m");
 	var diff = moment.duration(thisMoment.diff(now));
 
-	sleep_hour =  diff.get("hours");
-	sleep_minute = diff.get("minutes");
+	// only return actual time if sleep timer is active
+	if (self.sleep.sleep_enabled == true) {
+    sleep_hour =  diff.get("hours");
+    sleep_minute = diff.get("minutes");
+	} else {
+		sleep_hour = 0;
+		sleep_minute = 0;
+	}
 
 	defer.resolve({
 		enabled:sleepTask.sleep_enabled,
@@ -319,12 +325,14 @@ AlarmClock.prototype.setSleep = function(data)
 			self.haltSchedule.cancel();
 			delete self.haltSchedule;
 
-			console.log("System is shutting down....");
 			setTimeout(function()
 			{
 				if (data.action == 'stop'){
+          self.commandRouter.pushConsoleMessage("Sleep timer expired.");
 					self.commandRouter.volumioStop();
-				} else {
+          self.getSleepConf().sleep_enabled = false;
+        } else {
+          console.log("System is shutting down....");
 				self.commandRouter.shutdown();
 				}
 			},5000);


### PR DESCRIPTION
Fix for https://github.com/volumio/Volumio2/issues/1434

Set sleep_enabled flag to false when sleep timer is triggered, plus return 00:00 as the sleep time unless the sleep timer is actually active.

Indentation is a bit weird in some of these files, I didn't attempt to fix it.