### PR TITLE
Save logsubmit logs locally

### DIFF
--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -453,7 +453,6 @@ ControllerSystem.prototype.sendBugReport = function (message) {
 	if (message == undefined || message.text == undefined || message.text.length < 1 ) {
 		message.text = 'No info available';
 	}
-	fs.appendFileSync('/tmp/logfields', 'Description="' + message.text + '"\r\n');
 	// Must single-quote the message or the shell may interpret it and crash.
 	// single-quotes already within the message need to be escaped.
 	// The resulting string always starts and ends with single quotes.

--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 LOGDUMP="/var/tmp/logondemand"
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 
 doc() {

--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+LOGDUMP="/var/tmp/logondemand"
 
 
 doc() {
@@ -50,6 +51,7 @@ plugin package                     compresses the plugin
 plugin publish                     publishes the plugin on git
 plugin install                     installs the plugin locally
 plugin update                      updates the plugin
+logdump <description>              dump logs to $LOGDUMP instead of uploading
 "
 
 }
@@ -167,6 +169,9 @@ case "$1" in
             ;;
 	    kernelsource)
 	        kernelsource
+            ;;
+	    logdump)
+	        /usr/local/bin/node /volumio/logsubmit.js "$2" nosubmit
             ;;
         plugin)
             if [ "$2" != "" ]; then

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -51,6 +51,11 @@ try {
 for (var itemN in commandArray) {
     var item = commandArray[itemN];
     var itemWithoutput = item + " >>" + logFile + " 2>&1"
+    try {
+        fs.appendFileSync(logFile, '\n# ' + item + ' ---------------' + '\n');
+    } catch(e) {
+        console.log(e);
+    }
     execSync(itemWithoutput);
 }
 

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -48,8 +48,6 @@ try {
     console.log(e);
 }
 
-execSync("cat /tmp/logfields >> " + logFile);
-
 for (var itemN in commandArray) {
     var item = commandArray[itemN];
     var itemWithoutput = item + " >>" + logFile + " 2>&1"
@@ -100,7 +98,6 @@ exec(command , {uid: 1000, gid: 1000, encoding: 'utf8'}, function (error, stdout
     console.log('Saving as: ' + storedLogFile);
     execSync("mv -f " + logFile + " " + storedLogFile);
 }
-execSync("rm /tmp/logfields");
 
 function randomIntInc (low, high) {
     return Math.floor(Math.random() * (high - low + 1) + low);

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -12,11 +12,6 @@ var commandArray = [
     "sudo journalctl -p 7"
 ];
 
-var logFile = "/tmp/logondemand";
-
-// Let's start fresh!
-execSync("date >" + logFile);
-
 var args = process.argv.slice(2);
 var description;
 if ( args[0] == undefined ) {
@@ -31,6 +26,11 @@ if ( args[0] == undefined ) {
         if (i < (n-1)) description = description + "\\'";
     }
 }
+
+var logFile = "/tmp/logondemand";
+
+// Let's start fresh!
+execSync("date >" + logFile);
 
 try {
     //If description is supplied, add it

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -3,8 +3,8 @@ var exec = require('child_process').exec;
 var fs = require('fs');
 
 var commandArray = [
-	"cat /proc/version",
-	"cat /etc/os-release",
+    "cat /proc/version",
+    "cat /etc/os-release",
     "ifconfig",
     "iwconfig",
 	"aplay -l",

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -12,6 +12,9 @@ var commandArray = [
     "sudo journalctl -p 7"
 ];
 
+// Up to two arguments may be given:
+// - a description, which is inserted in the output file
+// - an optional flag indicating the log should be saved locally, not uploaded
 var args = process.argv.slice(2);
 var description;
 if ( args[0] == undefined ) {
@@ -25,6 +28,11 @@ if ( args[0] == undefined ) {
         description = description + "'" + pieces[i] + "'";
         if (i < (n-1)) description = description + "\\'";
     }
+}
+
+var submit = 'yes';
+if ( args.length > 1 ) {
+    submit = 'no';
 }
 
 var logFile = "/tmp/logondemand";
@@ -77,6 +85,7 @@ var command = "/usr/bin/curl -X POST -H 'Content-Type: multipart/form-data'"
             + " -F 'variant=" + variant + "'"
             + " 'http://logs.volumio.org:7171/logs/v1'";
 
+if ( submit === 'yes' ) {
 exec(command , {uid: 1000, gid: 1000, encoding: 'utf8'}, function (error, stdout, stderr) {
     if (error !== null) {
         console.log('Cannot send bug report: ' + error);
@@ -86,9 +95,12 @@ exec(command , {uid: 1000, gid: 1000, encoding: 'utf8'}, function (error, stdout
         console.log(stdout)
         execSync("rm " + logFile);
     }
-    execSync("rm /tmp/logfields");
 });
-
+} else {
+    console.log('Saving as: ' + storedLogFile);
+    execSync("mv -f " + logFile + " " + storedLogFile);
+}
+execSync("rm /tmp/logfields");
 
 function randomIntInc (low, high) {
     return Math.floor(Math.random() * (high - low + 1) + low);

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -7,7 +7,7 @@ var commandArray = [
     "cat /etc/os-release",
     "ifconfig",
     "iwconfig",
-	"aplay -l",
+    "aplay -l",
     "ps -ef",
     "sudo journalctl -p 7"
 ];

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -28,6 +28,7 @@ if ( args[0] == undefined ) {
 }
 
 var logFile = "/tmp/logondemand";
+var storedLogFile = "/var/tmp/logondemand";
 
 // Let's start fresh!
 execSync("date >" + logFile);
@@ -79,10 +80,12 @@ var command = "/usr/bin/curl -X POST -H 'Content-Type: multipart/form-data'"
 exec(command , {uid: 1000, gid: 1000, encoding: 'utf8'}, function (error, stdout, stderr) {
     if (error !== null) {
         console.log('Cannot send bug report: ' + error);
+        console.log('Saving as: ' + storedLogFile);
+        execSync("mv -f " + logFile + " " + storedLogFile);
     } else {
         console.log(stdout)
+        execSync("rm " + logFile);
     }
-    execSync("rm " + logFile);
     execSync("rm /tmp/logfields");
 });
 

--- a/logsubmit.js
+++ b/logsubmit.js
@@ -43,7 +43,7 @@ execSync("date >" + logFile);
 
 try {
     //If description is supplied, add it
-    execSync("echo " + description + " >>" + logFile);
+    fs.appendFileSync(logFile, 'Description="' + description + '"\n');
 } catch (e) {
     console.log(e);
 }


### PR DESCRIPTION
This adds support for
```
$ volumio logdump
```
which will save a logsubmit.js report to local storage, for the times when networking is broken.
Also, save the log when the upload fails, so it can be transmitted by other means.

Getting this to work required setting PATH in volumio.sh, for reasons explained in 'Make the PATH that is in use unambiguous'.

Tested on 2.346.