### PR TITLE
Utilise `currentSeek` to track Seek in consume mode

### DIFF
--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -423,7 +423,7 @@ CoreStateMachine.prototype.increasePlaybackTimer = function () {
 
 	var now=Date.now();
 	this.currentSeek+=(now-this.playbackStart);
-	this.isConsume?  this.consumeState.seek = this.currentSeek : null;
+	this.isVolatile?  this.volatileState.seek = this.currentSeek : null;
 	if(this.runPlaybackTimer==true)
 	{
 		this.playbackStart=Date.now();

--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -417,13 +417,13 @@ CoreStateMachine.prototype.getNextIndex = function () {
 };
 
 
-// Stop playback timer
+// Increase playback timer
 CoreStateMachine.prototype.increasePlaybackTimer = function () {
 	var self=this;
 
 	var now=Date.now();
 	this.currentSeek+=(now-this.playbackStart);
-
+	this.isConsume?  this.consumeState.seek = this.currentSeek : null;
 	if(this.runPlaybackTimer==true)
 	{
 		this.playbackStart=Date.now();


### PR DESCRIPTION
When in consume mode, while the UI displays the timer correctly, state information is rest to the original `consume.state` when `pushState` is called from the state machine's internal functions, such as `updateVolume` for example.

This is a quick and dirty fix for that, by piggy backing the already present `currentSeek` value.
I realise that isn't ideal, but ideas welcome, will implement! :-)


Fixes #1510 
and solves the issue from my old question on the forum https://volumio.org/forum/pushing-playback-state-info-volumio-t7641-10.html back from volspotconnect days :-)

