### PR TITLE
pluginhelper: Use shallow clone

### DIFF
--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -29,7 +29,7 @@ function init() {
             console.log("cloning repo:\ngit clone https://github.com/" + name +
                 "/volumio-plugins.git");
             try {
-                execSync("/usr/bin/git clone https://github.com/" + name +
+                execSync("/usr/bin/git clone --depth 5 --no-single-branch https://github.com/" + name +
                     "/volumio-plugins.git /home/volumio/volumio-plugins");
                 console.log("Done, please run command again");
                 process.exit(1);
@@ -357,7 +357,7 @@ function zip(){
                 console.log("Error installing node modules: " + e);
                 process.exit(1);
             }
-        }        
+        }
         var package = fs.readJsonSync("package.json");
         execSync("IFS=$'\\n'; /usr/bin/minizip -o -9 " + package.name +
             ".zip $(find -type f -not -name " + package.name + ".zip -printf '%P\\n')",
@@ -413,9 +413,9 @@ function publish() {
             catch (e){
                 console.log("Nothing to commit");
             }
-            
+
             zip();
-            
+
             execSync("/bin/mv " + package.name + ".zip /tmp/");
             process.chdir("../../../");
             execSync("/usr/bin/git checkout gh-pages");


### PR DESCRIPTION
Save some SD card space, especially given the growing number of plugins! 
I doubt everyone need the entire commit history on their Volumio instance ;-)


#### Before -- 159.75 MiB
```bash
git clone https://github.com/volumio/volumio-plugins.git
Cloning into 'volumio-plugins'...
remote: Counting objects: 12279, done.
remote: Compressing objects: 100% (114/114), done.
remote: Total 12279 (delta 24), reused 128 (delta 20), pack-reused 12139
Receiving objects: 100% (12279/12279), 159.75 MiB | 5.22 MiB/s, done.
Resolving deltas: 100% (4671/4671), done.
Checking connectivity... done.
Checking out files: 100% (4625/4625), done.
```

#### After -- 32.96 MiB
```bash
$ git clone https://github.com/volumio/volumio-plugins.git --depth 5 --no-single-branch
Cloning into 'volumio-plugins'...
remote: Counting objects: 4075, done.
remote: Compressing objects: 100% (2976/2976), done.
remote: Total 4075 (delta 1117), reused 3247 (delta 800), pack-reused 0
Receiving objects: 100% (4075/4075), 32.96 MiB | 5.39 MiB/s, done.
Resolving deltas: 100% (1117/1117), done.
Checking connectivity... done.
Checking out files: 100% (4625/4625), done.
```