### PR TITLE
Don't create a websocket inconditionally at startup

### DIFF
--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -3,7 +3,6 @@ var exec = require('child_process').exec;
 var execSync = require('child_process').execSync;
 var inquirer = require('inquirer');
 var websocket = require('socket.io-client')
-var socket = websocket.connect('http://127.0.0.1:3000', {reconnect: true})
 
 // ============================== CREATE PLUGIN ===============================
 
@@ -32,10 +31,9 @@ function init() {
                 execSync("/usr/bin/git clone --depth 5 --no-single-branch https://github.com/" + name +
                     "/volumio-plugins.git /home/volumio/volumio-plugins");
                 console.log("Done, please run command again");
-                process.exit(1);
             }catch(e){
                 console.log("Unable to find repo, are you sure you forked it?")
-                process.exit(1);
+                process.exitCode = 1;
             }
         });
     }
@@ -44,20 +42,23 @@ function init() {
         exec("git config --get remote.origin.url", function (error, stdout, stderr) {
             if (error) {
                 console.error('exec error: ${error}');
-                process.exit(1);
+                process.exitCode = 1;
+                return;
             }
             var url = stdout;
             if (url == "https://github.com/volumio/volumio-plugins.git\n") {
                 exec("git config user.name", function (error, stdout, stderr) {
                     if (error) {
                         console.error('exec error: ${error}');
-                        process.exit(1);
+                        process.exitCode = 1;
+                        return;
                     }
                     var user = stdout;
                     if (user != 'volumio\n'){
                         console.log("Error, your repo is the original one, please " +
                             "fork it as suggested in the documentation!");
-                        process.exit(1);
+                        process.exitCode = 1;
+                        return;
                     }
                     else{
                         ask_category();
@@ -355,7 +356,8 @@ function zip(){
             }
             catch (e){
                 console.log("Error installing node modules: " + e);
-                process.exit(1);
+                process.exitCode = 1;
+                return;
             }
         }
         var package = fs.readJsonSync("package.json");
@@ -366,6 +368,7 @@ function zip(){
     }
     catch (e){
         console.log("Error compressing plugin: " + e);
+        process.exitCode = 1;
     }
 }
 
@@ -656,13 +659,13 @@ function commit(package, arch) {
     execSync("/usr/bin/git push origin gh-pages");
     console.log("Congratulations, your package has been correctly uploaded and" +
         "is ready for merging!")
-    process.exit(1)
 }
 
 // =============================== INSTALL ====================================
 
 function install(){
     if(fs.existsSync("package.json")){
+        let socket = websocket.connect('http://127.0.0.1:3000', {reconnect: true});
         var package = fs.readJsonSync("package.json");
         zip();
         if(!fs.existsSync("/tmp/plugins")) {
@@ -675,13 +678,13 @@ function install(){
             console.log("Progress: " + data.progress + "\nStatus :" + data.message)
             if(data.message == "Plugin Successfully Installed"){
                 console.log("Done!");
-                process.exit(1)
+                socket.close()
             }
         })
     }
     else {
         console.log("No package found")
-        process.exit(1)
+        process.exitCode = 1;
     }
 }
 
@@ -689,6 +692,7 @@ function install(){
 
 function update() {
     if(fs.existsSync("package.json")){
+        let socket = websocket.connect('http://127.0.0.1:3000', {reconnect: true});
         var package = fs.readJsonSync("package.json");
         zip();
         if(!fs.existsSync("/tmp/plugins")) {
@@ -701,13 +705,13 @@ function update() {
             console.log("Progress: " + data.progress + "\nStatus :" + data.message)
             if(data.message == "Plugin Successfully Installed"){
                 console.log("Done!");
-                process.exit(1)
+                socket.close()
             }
         })
     }
     else {
         console.log("No package found")
-        process.exit(1)
+        process.exitCode = 1;
     }
 }
 


### PR DESCRIPTION
Instead of creating the websocket connection at startup for each
invokation, do it only within the 2 methods that currently require
one: `install` and `update`.

This has the nice side effect of not preventing the script to exit
properly when calling any of the other commands, like `refresh`.

Additionally, the use of `process.exit()` is discouraged, and it's better
to just set an `exitCode` so that any unprocessed event in the event loop
will be handled before exiting.

See here https://nodejs.org/api/process.html#process_process_exit_code
for more details.