### PR TITLE
Fix edge case of playerName with uppercase letters

### DIFF
--- a/app/plugins/system_controller/volumiodiscovery/index.js
+++ b/app/plugins/system_controller/volumiodiscovery/index.js
@@ -113,7 +113,7 @@ ControllerVolumioDiscovery.prototype.startAdvertisement=function()
 	console.log("Discovery: StartAdv! " + forceRename);
 	try {
 		var systemController = self.commandRouter.pluginManager.getPlugin('system_controller', 'system');
-		var name = systemController.getConf('playerName');
+		var name = systemController.getConf('playerName').toLowerCase();
 		var uuid = systemController.getConf('uuid');
 		var serviceName = config.get('service');
 		var servicePort = config.get('port');


### PR DESCRIPTION
Fixes the renaming of device back to default (for the edge case that I had of a playerName in camelCase ).

It would seem that my issues were nothing related to `mdns` and node v8 ;-)