### PR TITLE
Remove redundant `nodetools` package dependency

### DIFF
--- a/app/plugins/miscellanea/albumart/albumart.js
+++ b/app/plugins/miscellanea/albumart/albumart.js
@@ -6,7 +6,6 @@ var download = require('file-download');
 var S = require('string');
 var fs = require('fs-extra');
 var uuid = require('node-uuid');
-var nodetools = require('nodetools');
 var exec = require('child_process').exec;
 var diskCache = true;
 
@@ -117,9 +116,9 @@ var searchOnline = function (defer, web) {
     if (infoJson[resolution] == undefined) {
 
         try {
-            var decodedArtist=nodetools.urlDecode(artist);
-            var decodedAlbum=nodetools.urlDecode(album);
-            var decodedResolution=nodetools.urlDecode(resolution);
+            var decodedArtist = decodeURIComponent(artist);
+            var decodedAlbum = decodeURIComponent(album);
+            var decodedResolution = decodeURIComponent(resolution);
         } catch(e) {
            //console.log("ERROR getting albumart info from JSON file: " + e);
             defer.reject(new Error(err));
@@ -326,9 +325,9 @@ var processRequest = function (web, path, meta) {
 	}
 
 	if (path != undefined) {
-        path=nodetools.urlDecode(path);
+        path = decodeURIComponent(path);
 
-        path=sanitizeUri(path);
+        path = sanitizeUri(path);
 
         if(path.startsWith('/')){
         	if (path.startsWith('/tmp/')){

--- a/app/plugins/miscellanea/albumart/index.js
+++ b/app/plugins/miscellanea/albumart/index.js
@@ -2,7 +2,6 @@
 
 var exec = require('child_process').exec;
 var libQ = require('kew');
-var nodetools = require('nodetools');
 var enableweb = true;
 var defaultwebsize = 'large';
 var cacheid = '';
@@ -102,11 +101,11 @@ AlbumArt.prototype.getAlbumArt = function (data, path,icon) {
     if (data != undefined && data.artist != undefined && enableweb) {
         //performing decode since we cannot assume client will pass decoded strings
 
-        artist = nodetools.urlDecode(data.artist);
+        artist = decodeURIComponent(data.artist);
 
         if(data.album)
         {
-            album = nodetools.urlDecode(data.album);
+            album = decodeURIComponent(data.album);
         }
         else
         {
@@ -119,7 +118,7 @@ AlbumArt.prototype.getAlbumArt = function (data, path,icon) {
 			size=defaultwebsize;
 		}
 
-        web = '&web=' + nodetools.urlEncode(artist) + '/' + nodetools.urlEncode(album) + '/'+size;
+        web = '&web=' + encodeURIComponent(artist) + '/' + encodeURIComponent(album) + '/'+size;
     }
 	} catch (e) {
 	console.log('Cannot compose Albumart path')
@@ -132,7 +131,7 @@ AlbumArt.prototype.getAlbumArt = function (data, path,icon) {
     }
 
     if (path != undefined) {
-        url = url + '&path=' + nodetools.urlEncode(path);
+        url = url + '&path=' + encodeURIComponent(path);
     }
 
     if(icon!==undefined) {

--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -7,7 +7,6 @@ var libQ = require('kew');
 var libFast = require('fast.js');
 var libFsExtra = require('fs-extra');
 var exec = require('child_process').exec;
-var nodetools = require('nodetools');
 var convert = require('convert-seconds');
 var pidof = require('pidof');
 var parser = require('cue-parser');
@@ -647,7 +646,7 @@ ControllerMpd.prototype.mpdEstablish = function () {
             self.listAlbums();
         }
     })
-	
+
 	// Catch and log errors
 	self.clientMpd.on('error', function (err) {
 		self.logger.error('MPD error: ' + err);
@@ -1016,11 +1015,11 @@ ControllerMpd.prototype.createMPDFile = function (callback) {
 			} else {
                 var conf12 = conf11.replace('"${ffmpeg}"', " ");
             }
-            
+
             for(var callback of self.registeredCallbacks)
             {
                var data = self.commandRouter.executeOnPlugin(callback.type, callback.plugin, callback.data);
-               conf12 += data;  
+               conf12 += data;
             }
 
             fs.writeFile("/etc/mpd.conf", conf12, 'utf8', function (err) {
@@ -2219,7 +2218,7 @@ ControllerMpd.prototype.explodeUri = function(uri) {
     }
     else if(uri.endsWith('.iso')) {
         var uriPath = '/mnt/' + self.sanitizeUri(uri);
-       
+
         var uris = self.scanFolder(uriPath);
         var response = [];
 
@@ -2870,7 +2869,7 @@ ControllerMpd.prototype.handleBrowseUri = function (curUri, previous) {
     self.logger.info("CURURI: "+curUri);
 	var splitted=curUri.split('/');
 
-//music-library	
+//music-library
     if (curUri.startsWith('music-library')) {
         response = self.lsInfo(curUri);
     }
@@ -2910,7 +2909,7 @@ ControllerMpd.prototype.handleBrowseUri = function (curUri, previous) {
         else
         {
             if(splitted.length==3) {  //No album name
-                response = self.listArtist(curUri,2,'artists://','artists://');  //Pass back to listArtist 
+                response = self.listArtist(curUri,2,'artists://','artists://');  //Pass back to listArtist
 			}
             else {  //Has album name
 				response = self.listAlbumSongs(curUri,3,'artists://'+ splitted[2]);  //Pass to listAlbumSongs with artist and album name
@@ -3744,7 +3743,7 @@ ControllerMpd.prototype.prefetch = function (trackBlock) {
 }
 
 ControllerMpd.prototype.goto=function(data){
-	
+
     if (data.type=='artist') {
         return this.listArtist('artists://'+encodeURIComponent(data.value),2,'', 'albums://'+encodeURIComponent(data.value)+'/')
 	} else if (data.type=='album'){
@@ -3847,7 +3846,7 @@ ControllerMpd.prototype.saveMusicLibraryOptions=function(data){
 
 ControllerMpd.prototype.dsdVolume=function(){
 	var self = this;
-	
+
 	if (dsd_autovolume) {
 		self.logger.info('Setting Volume to 100 automatically for DSD')
         self.commandRouter.volumiosetvolume(100);
@@ -3867,4 +3866,3 @@ ControllerMpd.prototype.registerConfigCallback = function(callback){
     self.logger.info('register callback: ' + JSON.stringify(callback,null,4));
     self.registeredCallbacks.push(callback);
 }
-

--- a/app/plugins/music_service/upnp_browser/index.js
+++ b/app/plugins/music_service/upnp_browser/index.js
@@ -6,7 +6,6 @@ var libxmljs = require("libxmljs");
 var unirest = require('unirest');
 var cachemanager=require('cache-manager');
 var memoryCache = cachemanager.caching({store: 'memory', max: 100, ttl: 10*60/*seconds*/});
-var nodetools=require('nodetools');
 var mm = require('musicmetadata');
 var Client = require('node-ssdp').Client;
 var xml2js = require('xml2js');

--- a/app/plugins/music_service/webradio/index.js
+++ b/app/plugins/music_service/webradio/index.js
@@ -7,7 +7,6 @@ var pidof = require('pidof');
 var cachemanager=require('cache-manager');
 var memoryCache = cachemanager.caching({store: 'memory', max: 100, ttl: 10*60/*seconds*/});
 var libMpd = require('mpd');
-var nodetools=require('nodetools');
 var variant = '';
 var selection = {};
 var retry = 0;
@@ -508,7 +507,7 @@ ControllerWebradio.prototype.seek = function(position) {
 
 ControllerWebradio.prototype.explodeUri = function(uri) {
     var self = this;
-    
+
     var defer=libQ.defer();
 
     defer.resolve({
@@ -806,7 +805,7 @@ ControllerWebradio.prototype.search = function (data) {
     };
 
     var search = data.value.toLowerCase();
-    //var uri='http://api.shoutcast.com/legacy/stationsearch?k=vKgHQrwysboWzMwH&search='+nodetools.urlEncode(query.value)+'&limit=20';
+    //var uri='http://api.shoutcast.com/legacy/stationsearch?k=vKgHQrwysboWzMwH&search='+encodeURIComponent(query.value)+'&limit=20';
     var uri = 'http://api.dirble.com/v2/search?token=8d27f1f258b01bd71ad2be7dfaf1cce9d3074ee2';
 
     unirest.post(uri)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "node-schedule": "^1.2.3",
     "node-ssdp": "^3.2.5",
     "node-uuid": "^1.4.8",
-    "nodetools": "^1.0.0",
     "onoff": "^1.1.2",
     "pidof": "^1.0.2",
     "pullr": "^0.3.2",


### PR DESCRIPTION
Further to my [nodev8 upgrade findings](https://github.com/volumio/Build/issues/315) , I see that even the [prebuild node `v8.11.0` modules from the repo](http://repo.volumio.org/Volumio2/node_modules_arm-8.11.0.tar.gz) throws up :
```shell
$ npm list --depth=0
+-- nodetools@0.0.1 invalid
npm ERR! invalid: nodetools@0.0.1 /volumio/node_modules/nodetools
```
There are some fs-extra issues as well, but that is for another day ;=)

`nodetools` package - do we really need it? 
Current usage: 
```shell
$ git grep nodetools
app/plugins/miscellanea/albumart/albumart.js:var nodetools = require('nodetools');
app/plugins/miscellanea/albumart/albumart.js:            var decodedArtist=nodetools.urlDecode(artist);
app/plugins/miscellanea/albumart/albumart.js:            var decodedAlbum=nodetools.urlDecode(album);
app/plugins/miscellanea/albumart/albumart.js:            var decodedResolution=nodetools.urlDecode(resolution);
app/plugins/miscellanea/albumart/albumart.js:        path=nodetools.urlDecode(path);
app/plugins/miscellanea/albumart/index.js:var nodetools = require('nodetools');
app/plugins/miscellanea/albumart/index.js:        artist = nodetools.urlDecode(data.artist);
app/plugins/miscellanea/albumart/index.js:            album = nodetools.urlDecode(data.album);
app/plugins/miscellanea/albumart/index.js:        web = '&web=' + nodetools.urlEncode(artist) + '/' + nodetools.urlEncode(album) + '/'+size;
app/plugins/miscellanea/albumart/index.js:        url = url + '&path=' + nodetools.urlEncode(path);
app/plugins/music_service/mpd/index.js:var nodetools = require('nodetools');
app/plugins/music_service/upnp_browser/index.js:var nodetools=require('nodetools');
app/plugins/music_service/webradio/index.js:var nodetools=require('nodetools');
app/plugins/music_service/webradio/index.js:    //var uri='http://api.shoutcast.com/legacy/stationsearch?k=vKgHQrwysboWzMwH&search='+nodetools.urlEncode(query.value)+'&limit=20';
package.json:    "nodetools": "^1.0.0",
```
Given that `urlEncode()` and `urlDecode()` are the only methods we use of `nodetools`,  and 
`encodeURIComponent()` and `decodeURIComponent()` provides the functionality out of the box, can't we just drop it?

