### PR TITLE
First Intel Atom Baytrail/ Cherrytrail sound support

### DIFF
--- a/app/plugins/audio_interface/alsa_controller/cards.json
+++ b/app/plugins/audio_interface/alsa_controller/cards.json
@@ -25,6 +25,8 @@
     {"name": "rockchip", "multidevice": false, "prettyname": "Generic I2S", "defaultmixer": "","type":"integrated"},
     {"name": "snd-sun8i-i2s-dac", "multidevice": false, "prettyname": "I2S", "defaultmixer": "","type":"integrated"},
     {"name": "H3 Audio Codec", "multidevice": false, "prettyname": "Onboard Audio", "defaultmixer": "DAC","type":"integrated"},
-    {"name": "HDA Intel PCH", "multidevice": true, "devices":[{"number":0, "prettyname": "Analog Out", "defaultmixer": ""},{"number":3, "prettyname": "HDMI", "defaultmixer": ""}]}
+    {"name": "HDA Intel PCH", "multidevice": true, "devices":[{"number":0, "prettyname": "Analog Out", "defaultmixer": ""},{"number":3, "prettyname": "HDMI", "defaultmixer": ""}]},
+    {"name": "bytcr-rt5651", "multidevice": false, "prettyname": "Headphone Jack", "defaultmixer": "HP","type":"integrated"},
+    {"name": "Intel HDMI/DP LPE Audio", "multidevice": true, "devices":[{"number":2, "prettyname": "HDMI", "defaultmixer": ""}],"type":"integrated"}
   ]
 }


### PR DESCRIPTION
Currently experimental only.
The Intel SST and HDMI/DP LPE Audio devices need to be treated a little different.
bytcr-rt5651 needs a default mixer and HDMI is on hw:2,0, currently not clear what hw:0,0 and hw:1,0 are meant for (Analogue out and Display Port)?