### PR TITLE
Enforce leading / on NFS path supplied by user

### DIFF
--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -379,6 +379,15 @@ ControllerNetworkfs.prototype.addShare = function (data) {
 		path = path.replace(/\/+/g,'/');
 		path = path.replace(/^\//,'');
 	}
+	if (fstype == 'nfs') {
+		/* NFS mounts require an absolute path for the exported directory -
+		 * enforce a leading / on the path.
+		 */
+		path = path.replace(/^\s+/,'');
+		if ( ! path.startsWith('/') ) {
+			path = '/' + path;
+		}
+	}
 
 	var uuid = self.getShare(name, ip, path);
 	var response;

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -379,7 +379,7 @@ ControllerNetworkfs.prototype.addShare = function (data) {
 		path = path.replace(/\/+/g,'/');
 		path = path.replace(/^\//,'');
 	}
-	if (fstype == 'nfs') {
+	if (fstype === 'nfs') {
 		/* NFS mounts require an absolute path for the exported directory -
 		 * enforce a leading / on the path.
 		 */


### PR DESCRIPTION
NFS mounts require an absolute path to the exported directory on the server.
The volumio UI does not encourage this, as the default is mouting via CIFS.
To avoid troubling the user with these details, fix up the path before the
configuration is used or saved to disk.

Motivation: volumio/Volumio2-UI#511.