### PR TITLE
Avoid crashing if locale strings file is missing

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1579,7 +1579,11 @@ CoreCommandRouter.prototype.loadI18nStrings = function () {
 
         language_code = 'en';
         i18nFile = __dirname + '/i18n/strings_' + language_code + '.json';
-        this.i18nStrings = fs.readJsonSync(i18nFile);
+        try {
+            this.i18nStrings = fs.readJsonSync(i18nFile);
+        } catch( e ) {
+            this.logger.error('File ' + i18nFile + ' not accessible, no fallback available');
+        }
     }
 
     var categories=this.pluginManager.getPluginCategories();

--- a/app/index.js
+++ b/app/index.js
@@ -1581,6 +1581,10 @@ CoreCommandRouter.prototype.loadI18nStrings = function () {
         i18nFile = __dirname + '/i18n/strings_' + language_code + '.json';
         try {
             this.i18nStrings = fs.readJsonSync(i18nFile);
+            // Flag the fallback to 'en' in the UI, to reduce confusion.
+            // NB we can't use the getI18nString method yet;
+            //    we must display untranslated strings.
+            this.pushToastMessage('warning', 'Language File Missing', 'Falling back to English' + ' ' + error.message);
         } catch( e ) {
             this.logger.error('File ' + i18nFile + ' not accessible, no fallback available');
         }

--- a/app/index.js
+++ b/app/index.js
@@ -1603,7 +1603,7 @@ CoreCommandRouter.prototype.loadI18nStrings = function () {
             if (instance && instance.getI18nFile) {
               var pluginI18NFile = instance.getI18nFile(language_code);
               if (pluginI18NFile && fs.pathExistsSync(pluginI18NFile)) {
-                var pluginI18nStrings = fs.readJSONSync(pluginI18NFile);
+                var pluginI18nStrings = fs.readJsonSync(pluginI18NFile);
       
                 for (var locale in pluginI18nStrings) {
                   // check if locale does not already exist to avoid that volumio

--- a/app/index.js
+++ b/app/index.js
@@ -1575,6 +1575,7 @@ CoreCommandRouter.prototype.loadI18nStrings = function () {
         this.i18nStrings = fs.readJsonSync(i18nFile);
     } catch( error ) {
         if (error.code === 'ENOENT') {
+            var i18nDefaultFile = __dirname + '/i18n/strings_' + 'en' + '.json';
             this.logger.info('Warning: file '+i18nFile+' not found, defaulting to '+i18nDefaultFile);
             language_code = 'en';
             i18nFile = __dirname + '/i18n/strings_' + language_code + '.json';

--- a/app/index.js
+++ b/app/index.js
@@ -1574,15 +1574,12 @@ CoreCommandRouter.prototype.loadI18nStrings = function () {
     try {
         this.i18nStrings = fs.readJsonSync(i18nFile);
     } catch( error ) {
-        if (error.code === 'ENOENT') {
-            var i18nDefaultFile = __dirname + '/i18n/strings_' + 'en' + '.json';
-            this.logger.info('Warning: file '+i18nFile+' not found, defaulting to '+i18nDefaultFile);
-            language_code = 'en';
-            i18nFile = __dirname + '/i18n/strings_' + language_code + '.json';
-            this.i18nStrings = fs.readJsonSync(i18nFile);
-        } else {
-            throw error;
-        }
+        var i18nDefaultFile = __dirname + '/i18n/strings_' + 'en' + '.json';
+        this.logger.warn('File ' + i18nFile + ' not accessible, defaulting to ' + i18nDefaultFile);
+
+        language_code = 'en';
+        i18nFile = __dirname + '/i18n/strings_' + language_code + '.json';
+        this.i18nStrings = fs.readJsonSync(i18nFile);
     }
 
     var categories=this.pluginManager.getPluginCategories();

--- a/app/index.js
+++ b/app/index.js
@@ -1562,10 +1562,27 @@ CoreCommandRouter.prototype.loadI18nStrings = function () {
     var self=this;
     var language_code=this.sharedVars.get('language_code');
 
+    if (typeof language_code === 'undefined') {
+        this.logger.info("Warning: sharedVars language_code undefined. Forcing to 'en'");
+        language_code = 'en';
+    }
+
+    var i18nFile = __dirname + '/i18n/strings_' + language_code + '.json';
+
     this.logger.info("Loading i18n strings for locale "+language_code);
 
-    this.i18nStrings=fs.readJsonSync(__dirname+'/i18n/strings_'+language_code+".json");
-    this.i18nStringsDefaults=fs.readJsonSync(__dirname+'/i18n/strings_en.json');
+    try {
+        this.i18nStrings = fs.readJsonSync(i18nFile);
+    } catch( error ) {
+        if (error.code === 'ENOENT') {
+            this.logger.info('Warning: file '+i18nFile+' not found, defaulting to '+i18nDefaultFile);
+            language_code = 'en';
+            i18nFile = __dirname + '/i18n/strings_' + language_code + '.json';
+            this.i18nStrings = fs.readJsonSync(i18nFile);
+        } else {
+            throw error;
+        }
+    }
 
     var categories=this.pluginManager.getPluginCategories();
     for(var i in categories)


### PR DESCRIPTION
Issue #1548 presented a case where the sharedVars language_code
was an unexpected value and caused the system to crash.
This patch handles the simple cases - language_code undefined
and/or missing strings_<foo>.json file. Other kinds of errors could
still cause a crash.

Tested by setting language to French and renaming the app/i18n/strings_fr.json so file so it can't be found.