### PR TITLE
Extend play command in websocket API.

### DIFF
--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -209,11 +209,12 @@ function InterfaceWebUI(context) {
 			});
 
 			connWebSocket.on('play', function (N) {
+                                var num = parseInt(N);
 
-				if (N == null) {
-					return self.commandRouter.volumioPlay();
-				} else if (N.value != undefined) {
-                   return self.commandRouter.volumioPlay(N.value);
+                                if (N == null || isNaN(num) ) {
+                                        return self.commandRouter.volumioPlay();
+                                } else {
+                                        return self.commandRouter.volumioPlay(num);
 				}
 			});
 


### PR DESCRIPTION
Hi,

I hit the problem to select a radio stream from the playlist in volumio. Therefore I had to add the possibilty to address a specific item via websocket. As I couldn't see which Object you usally use, that has ` .value` property, I converted the recieved message into a primitive number.

This works for me. See if it works for the main project as well, as I don't in what other ways the API is used.

I appreciate any comment on this :)

morphZ