### PR TITLE
Fix timer overrun bug & prefetchDone not reset bug

### DIFF
--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -368,6 +368,7 @@ CoreStateMachine.prototype.startPlaybackTimer = function (nStartTime) {
 
 		this.askedForPrefetch=false;
 		this.simulateStopStartDone=false;
+		this.prefetchDone=false;
 
 		setTimeout(this.increasePlaybackTimer.bind(this),250);
 	}
@@ -431,7 +432,7 @@ CoreStateMachine.prototype.increasePlaybackTimer = function () {
 
 
 		var remainingTime=this.currentSongDuration-this.currentSeek;
-		if(remainingTime<5000 && this.askedForPrefetch==false)
+		if(remainingTime>=0 && remainingTime<5000 && this.askedForPrefetch==false)
 		{
 			this.askedForPrefetch=true;
 
@@ -453,7 +454,7 @@ CoreStateMachine.prototype.increasePlaybackTimer = function () {
 			}
 		}
 
-		if(remainingTime<=500 && this.prefetchDone==true && this.simulateStopStartDone==false)
+		if(remainingTime>=0 && remainingTime<=500 && this.prefetchDone==true && this.simulateStopStartDone==false)
 		{
 
 			this.simulateStopStartDone=true;


### PR DESCRIPTION
Fixes prefetching too many times due timer overrunning when buffering track & makes sure prefetchDone variable is always reset when the timer is reset to prevent unwanted behavior when queue has 2 consecutive tracks from different music services.

Full explanation in forum: https://volumio.org/forum/bugs-statemachine-increaseplaybacktimer-method-t10340.html