### PR TITLE
[codestyle] Disable git-hooks until full repo is linted

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,8 @@
     "preinstall": "",
     "start": "nodejs ./index.js",
     "lint" : "semistandard \"./**/*.js\" --fix",
+    "lint-staged" : "lint-staged",
     "test": "npm install fs-extra && npm install --only=dev && ./node_modules/.bin/mocha --reporter spec"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Given that we are using just the formatting function for now.
Once format_fix is merged, and everyone is on board, we can enable it again, gently nudging people to actually fix the lint errors ;-) 

So workflow for the interim would be:
```shell
git add <file0.js> <file1.js>
npm run lint-staged
git commit -m 'Formatted files ready with my new commit'
```
