### PR TITLE
Update the url when the plugin is updated

### DIFF
--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -511,6 +511,11 @@ function update_plugins(package, arch) {
                             today.getDate() + "-" + (today.getMonth()+1) +
                             "-" + today.getFullYear();
                         plugins.categories[i].plugins[j].version = package.version;
+                        // Make sure url points to the zip file
+                        plugins.categories[i].plugins[j].url = "http://volumio.github.io/volumio-plugins/" +
+                            "plugins/volumio/" + arch + "/" +
+                            package.volumio_info.plugin_type + "/" +
+                            package.name + "/" + package.name + ".zip";
                         update_desc_details(package, plugins, i, j, arch);
                         plugFound = true;
                         catFound = true;


### PR DESCRIPTION
Added an extra line so the plugin url in plugins.json gets updated when the plugin is updated.
This is only really an issue if the plugin is moved like here:

https://github.com/volumio/volumio-plugins/pull/249

Most of the time the url doesn't change. 