### PR TITLE
Use the right node version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-- '6.1.0'
+- '8.11.1'
 
 install: true


### PR DESCRIPTION
Travis is still using Node 6.1.0 to run tests (or actually, the only
test we have so far).
Bump the version to make sure it matches the one used in the live system.