### PR TITLE
Pass all the arguments to pull.sh

### DIFF
--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -81,7 +81,7 @@ pull() {
 cd /
 echo "Stopping Volumio"
 sudo systemctl stop volumio.service
-sudo /bin/sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/pull.sh
+sudo /bin/sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/pull.sh $@
 
 echo "Pull completed, restarting Volumio"
 sudo systemctl start volumio.service


### PR DESCRIPTION
The pull command is supposed to support the ability to pull a
specific branch, either from the official Volumio repo or from a
custom repo.
Is seems like this was either not working or a regression has been
introduced at some point.
This commit fixes the behaviour by passing to the pull.sh script
all the parameters passed to the pull() funciton in volumio.sh.