### PR TITLE
There is no readJSONSync() function

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1609,7 +1609,7 @@ CoreCommandRouter.prototype.loadI18nStrings = function () {
             if (instance && instance.getI18nFile) {
               var pluginI18NFile = instance.getI18nFile(language_code);
               if (pluginI18NFile && fs.pathExistsSync(pluginI18NFile)) {
-                var pluginI18nStrings = fs.readJSONSync(pluginI18NFile);
+                var pluginI18nStrings = fs.readJsonSync(pluginI18NFile);
       
                 for (var locale in pluginI18nStrings) {
                   // check if locale does not already exist to avoid that volumio


### PR DESCRIPTION
Not sure if this matters but it's inconsistent which just wastes mental bandwidth. Every other call is readJsonSync().

Tested(?) on 2.513 by switching language to DE.