### PR TITLE
fix: exclude hidden folders from directory browsing

### DIFF
--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -1271,13 +1271,17 @@ ControllerMpd.prototype.lsInfo = function (uri) {
                             }
 
                             name = namearr.pop();
-                            list.push({
-                                type: dirtype,
-                                title: name,
-                                service:'mpd',
-                                albumart: albumart,
-                                uri: s0 + path
-                            });
+
+                            // exclude hidden folders (eg. ".Trashes")
+                            if (!name.startsWith('.')) {
+                                list.push({
+                                    type: dirtype,
+                                    title: name,
+                                    service:'mpd',
+                                    albumart: albumart,
+                                    uri: s0 + path
+                                });
+                            }
                         }
                         else if (line.indexOf('playlist:') === 0) {
                             path = line.slice(10);

--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -1243,6 +1243,12 @@ ControllerMpd.prototype.lsInfo = function (uri) {
                             var diricon = 'fa fa-folder-open-o';
                             path = line.slice(11);
                             var namearr = path.split('/');
+                            name = namearr[namearr.length - 1];
+
+                            // early out to exclude hidden folders (eg. ".Trashes")
+                            if (name.startsWith('.')) {
+                                continue;
+                            }
 
                             if (uri === 'music-library') {
                                 switch(path) {
@@ -1266,22 +1272,17 @@ ControllerMpd.prototype.lsInfo = function (uri) {
                                 diricon = 'fa fa-usb';
                             } else if (uri.indexOf('music-library/INTERNAL') >= 0) {
                                 dirtype = 'internal-folder';
-							} else {
+                            } else {
                                 dirtype = 'folder';
                             }
-
-                            name = namearr.pop();
-
-                            // exclude hidden folders (eg. ".Trashes")
-                            if (!name.startsWith('.')) {
-                                list.push({
-                                    type: dirtype,
-                                    title: name,
-                                    service:'mpd',
-                                    albumart: albumart,
-                                    uri: s0 + path
-                                });
-                            }
+                            
+                            list.push({
+                                type: dirtype,
+                                title: name,
+                                service:'mpd',
+                                albumart: albumart,
+                                uri: s0 + path
+                            });
                         }
                         else if (line.indexOf('playlist:') === 0) {
                             path = line.slice(10);


### PR DESCRIPTION
## What

- When a `browseLibrary` request is received, exclude folders beginning with `.` from the array that's returned to the client.

## Why

- Folders hidden with `.` are hidden system folders and are normally not available to the user. These include directories like `.Trashes` that can easily be included on the user's media drive without them being aware of it. It's very strange to see these displayed to the user. Here's an example:

![volumio-library-hidden-folders](https://user-images.githubusercontent.com/5931636/51561876-4b54b300-1e80-11e9-9c08-eaa28b512a8a.png)

## Solution

- The solution is crude and inelegant, but the surrounding code in `mpd/index.js` is not the easiest to work with, so I went with something very simple that won't require any refactoring to implement.