### PR TITLE
Pass a reference to config file to MyVolumio

### DIFF
--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -76,9 +76,8 @@ function PluginManager(ccommand, server) {
 	var myVolumioPMPath = '/myvolumio/app/myvolumio-pluginmanager';
     if (fs.existsSync(myVolumioPMPath)) {
     	this.logger.info('MYVOLUMIO Environment detected');
-        self.myVolumioPluginManager = new (require(myVolumioPMPath))(self.coreCommand, self.websocketServer, self.configManager);
+        self.myVolumioPluginManager = new (require(myVolumioPMPath))(self.coreCommand, self.websocketServer, self.configManager, self.config);
     }
-
 }
 
 PluginManager.prototype.startPlugins = function () {


### PR DESCRIPTION
Some plugins in MyVolumio will require access to the main config
file for plugins. Pass it over to MyVolumioPluginManager when
creating a new instance.