### PR TITLE
Fix track title display in music browser when tracknumber metadata doesn't exist

### DIFF
--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -1278,7 +1278,7 @@ ControllerMpd.prototype.lsInfo = function (uri) {
                             } else {
                                 dirtype = 'folder';
                             }
-                            
+
                             list.push({
                                 type: dirtype,
                                 title: name,
@@ -1340,7 +1340,11 @@ ControllerMpd.prototype.lsInfo = function (uri) {
                             else {
                                 var title1 = self.searchFor(lines, i + 1, 'Title:');
                                 var track = self.searchFor(lines, i + 1, 'Track:');
-                                var title = track + " - " + title1;
+                                if(track && title1) {
+                                    var title = track + " - " + title1;
+                                } else {
+                                    var title = title1;
+                                }
                             }
                             var year,albumart,tracknumber,duration,composer,genre;
                             if(self.commandRouter.sharedVars.get('extendedMetas'))
@@ -1445,7 +1449,11 @@ ControllerMpd.prototype.listallFolder = function (uri) {
                         else {
                             var title1 = self.searchFor(lines, i + 1, 'Title:');
                             var track = self.searchFor(lines, i + 1, 'Track:');
-                            var title = track + " - " + title1;
+                            if(track && title1) {
+                                var title = track + " - " + title1;
+                            } else {
+                                var title = title1;
+                            }
                         }
                         var albumart = self.getAlbumArt({artist: albumartist, album: album},self.getParentFolder('/mnt/' + path),'fa-tags');
 
@@ -1595,7 +1603,11 @@ ControllerMpd.prototype.search = function (query) {
 						else {
 							var title1 = self.searchFor(lines, i + 1, 'Title:');
 							var track = self.searchFor(lines, i + 1, 'Track:');
-							var title = track + " - " + title1;
+                            if(track && title1) {
+                                var title = track + " - " + title1;
+                            } else {
+                                var title = title1;
+                            }
 						}
                         if (title == undefined) {
                             title = name[count - 1];
@@ -1965,7 +1977,11 @@ ControllerMpd.prototype.explodeUri = function(uri) {
 								else {
 									var title1 = self.searchFor(lines, i + 1, 'Title:');
 									var track = self.searchFor(lines, i + 1, 'Track:');
-									var title = track + " - " + title1 + "HERE";
+                                    if(track && title1) {
+                                        var title = track + " - " + title1;
+                                    } else {
+                                        var title = title1;
+                                    }
 								}
                                 var time = parseInt(self.searchFor(lines, i + 1, 'Time:'));
 
@@ -2029,7 +2045,11 @@ ControllerMpd.prototype.explodeUri = function(uri) {
 								else {
 									var title1 = self.searchFor(lines, i + 1, 'Title:');
 									var track = self.searchFor(lines, i + 1, 'Track:');
-									var title = track + " - " + title1 + "HERE";
+                                    if(track && title1) {
+                                        var title = track + " - " + title1;
+                                    } else {
+                                        var title = title1;
+                                    }
 								}
 								var time = parseInt(self.searchFor(lines, i + 1, 'Time:'));
 
@@ -2105,7 +2125,11 @@ ControllerMpd.prototype.explodeUri = function(uri) {
 						else {
 							var title1 = self.searchFor(lines, i + 1, 'Title:');
 							var track = self.searchFor(lines, i + 1, 'Track:');
-							var title = track + " - " + title1;
+                            if(track && title1) {
+                                var title = track + " - " + title1;
+                            } else {
+                                var title = title1;
+                            }
 						}
                         var albumart=self.getAlbumArt({artist: artist, album: album,icon:'dot-circle-o'}, self.getParentFolder('/mnt/'+path));
                         var time = parseInt(self.searchFor(lines, i + 1, 'Time:'));
@@ -2213,7 +2237,11 @@ ControllerMpd.prototype.explodeUri = function(uri) {
 						else {
 							var title1 = self.searchFor(lines, i + 1, 'Title:');
 							var track = self.searchFor(lines, i + 1, 'Track:');
-							var title = track + " - " + title1;
+                            if(track && title1) {
+                                var title = track + " - " + title1;
+                            } else {
+                                var title = title1;
+                            }
 						}
                         var albumart=self.getAlbumArt({artist: artist, album: album}, self.getParentFolder('/mnt/'+path));
                         var time = parseInt(self.searchFor(lines, i + 1, 'Time:'));
@@ -2401,7 +2429,11 @@ ControllerMpd.prototype.exploderArtist=function(err,msg,defer) {
 				else {
 					var title1 = self.searchFor(lines, i + 1, 'Title:');
 					var track = self.searchFor(lines, i + 1, 'Track:');
-					var title = track + " - " + title1;
+                    if(track && title1) {
+                        var title = track + " - " + title1;
+                    } else {
+                        var title = title1;
+                    }
 				}
                 var albumart=self.getAlbumArt({artist: artist, album: album}, self.getParentFolder('/mnt/'+path));
                 var time = parseInt(self.searchFor(lines, i + 1, 'Time:'));
@@ -2544,7 +2576,11 @@ ControllerMpd.prototype.scanFolder=function(uri)
 								else {
 									var title1 = self.searchFor(lines, i + 1, 'Title:');
 									var track = self.searchFor(lines, i + 1, 'Track:');
-									var title = track + " - " + title1;
+                                    if(track && title1) {
+                                        var title = track + " - " + title1;
+                                    } else {
+                                        var title = title1;
+                                    }
 								}
                                 var time = parseInt(self.searchFor(lines, i + 1, 'Time:'));
 
@@ -2636,7 +2672,11 @@ ControllerMpd.prototype.explodeISOFile = function (uri) {
                         else {
                             var title1 = self.searchFor(lines, i + 1, 'Title:');
                             var track = self.searchFor(lines, i + 1, 'Track:');
-                            var title = track + " - " + title1;
+                            if(track && title1) {
+                                var title = track + " - " + title1;
+                            } else {
+                                var title = title1;
+                            }
                         }
                         var time = parseInt(self.searchFor(lines, i + 1, 'Time:'));
 
@@ -3181,7 +3221,11 @@ ControllerMpd.prototype.listAlbumSongs = function (uri,index,previous) {
 					else {
 						var title1 = self.searchFor(lines, i + 1, 'Title:');
 						var track = self.searchFor(lines, i + 1, 'Track:');
-						var title = track + " - " + title1;
+                        if(track && title1) {
+                            var title = track + " - " + title1;
+                        } else {
+                            var title = title1;
+                        }
 					}
                     var albumart=self.getAlbumArt({artist: artist, album: album}, self.getParentFolder(path),'dot-circle-o');
                     var time = parseInt(self.searchFor(lines, i + 1, 'Time:'));
@@ -3441,7 +3485,11 @@ ControllerMpd.prototype.parseListAlbum= function(err,msg,defer,response,uriBegin
 				else {
 					var title1 = self.searchFor(lines, i + 1, 'Title:');
 					var track = self.searchFor(lines, i + 1, 'Track:');
-					var title = track + " - " + title1;
+                    if(track && title1) {
+                        var title = track + " - " + title1;
+                    } else {
+                        var title = title1;
+                    }
 				}
                 var albumart=self.getAlbumArt({artist: artist, album: album}, self.getParentFolder(path),'dot-circle-o');
 
@@ -3638,14 +3686,18 @@ ControllerMpd.prototype.listGenre = function (curUri) {
                             var artist = self.searchFor(lines, i + 1, 'Artist:');
 							var albumartist = self.searchFor(lines, i + 1, 'AlbumArtist:');
                             var album = self.searchFor(lines, i + 1, 'Album:');
-					//Include track number if tracknumber variable is set to 'true'
+					        //Include track number if tracknumber variable is set to 'true'
 							if (!tracknumbers) {
 								var title = self.searchFor(lines, i + 1, 'Title:');
 							}
 							else {
 								var title1 = self.searchFor(lines, i + 1, 'Title:');
 								var track = self.searchFor(lines, i + 1, 'Track:');
-								var title = track + " - " + title1;
+                                if(track && title1 ) {
+                                    var title = track + " - " + title1;
+                                } else {
+                                    var title = title1;
+                                }
 							}
                             var albumart = self.getAlbumArt({artist: albumartist, album: album}, self.getParentFolder(path),'dot-circle-o');;
 
@@ -3889,7 +3941,7 @@ ControllerMpd.prototype.saveMusicLibraryOptions=function(data){
 
 ControllerMpd.prototype.dsdVolume=function(){
 	var self = this;
-	
+
 	if (dsd_autovolume) {
 		self.logger.info('Setting Volume to 100 automatically for DSD')
         self.commandRouter.volumiosetvolume(100);


### PR DESCRIPTION
**Scenario**: 
In Music Library Settings: _Show Track Numbers_ is **enabled** and a file doesn't have tracknumber metadata. The resulting entry in the music browser displays as a single hyphen "-". The filename does come through correctly when _Show Track Numbers_ is off.

The crux of the code is this snippet, which is laced through several of the MPD music service methods:

```
if (!tracknumbers) {
    var title = self.searchFor(lines, i + 1, 'Title:');
}
else {
    var title1 = self.searchFor(lines, i + 1, 'Title:');
    var track = self.searchFor(lines, i + 1, 'Track:');
    var title = track + " - " + title1;
}
... // a few lines later...
// Subsequently the title will be either the composite title from above, or 'name' which is the filename.
if (title) {
    title = title;
} else {
    title = name;
}
```

The change I suggest is to revise to:
```
if (!tracknumbers) {
    var title = self.searchFor(lines, i + 1, 'Title:');
}
else {
    var title1 = self.searchFor(lines, i + 1, 'Title:');
    var track = self.searchFor(lines, i + 1, 'Track:');
    if( track && title1 ) {
        var title = track + " - " + title1;
    } else {
        var title = title1;
    }
}
```

This results in the title being set correctly, to the filename, when the tracknumber or title meta data does not exist.