### PR TITLE
Encapsulate all the logic for MyVolumio plugins in the PluginManager

### DIFF
--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -628,6 +628,22 @@ PluginManager.prototype.getPlugin = function (category, name) {
 	}
 };
 
+PluginManager.prototype.getPluginsMyMusicConfig = function () {
+	let self = this;
+	let defer = libQ.defer()
+
+	// So far this capability is only exposed to MyVolumio plugins. We might consider enabling it for core plugins as well in the future.
+	if (this.myVolumioPluginManager !== undefined) {
+		let pluginsMyMysicConfig = self.myVolumioPluginManager.getPluginsMyMusicConfig();
+		pluginsMyMysicConfig.then(function (conf) {
+			defer.resolve(conf);
+		}).fail(function () {
+			defer.resolve(false);
+		});
+		return defer.promise;
+	}
+};
+
 /**
  * Returns path for a specific configuration file for a plugin (identified by its context)
  * @param context

--- a/app/plugins/miscellanea/my_music/index.js
+++ b/app/plugins/miscellanea/my_music/index.js
@@ -58,8 +58,8 @@ ControllerMyMusic.prototype.getUIConfig = function () {
 
 	var defer=libQ.defer();
 
-    var streamingConf = self.getStreamingConf();
-    streamingConf.then(function(sconf) {
+    var additionalConf = self.getAdditionalPluginsConf();
+    additionalConf.then(function(aconf) {
         self.commandRouter.i18nJson(__dirname+'/../../../i18n/strings_'+lang_code+'.json',
             __dirname+'/../../../i18n/strings_en.json',
             __dirname + '/UIConfig.json')
@@ -126,10 +126,10 @@ ControllerMyMusic.prototype.getUIConfig = function () {
                     uiconf.sections[5].hidden = true;
                 }
 
-                if (sconf) {
+                if (aconf) {
                     var insertInto = 3;
-                    for (var i in sconf.sections) {
-                        var streamingSection = sconf.sections[i];
+                    for (var i in aconf.sections) {
+                        var streamingSection = aconf.sections[i];
                         uiconf.sections.splice(insertInto, 0, streamingSection);
                         insertInto++
                     }
@@ -147,28 +147,19 @@ ControllerMyMusic.prototype.getUIConfig = function () {
 	return defer.promise;
 };
 
-ControllerMyMusic.prototype.getStreamingConf = function () {
-    var self = this;
-    var  defer = libQ.defer();
+ControllerMyMusic.prototype.getAdditionalPluginsConf = function() {
+    let self = this;
+    let defer = libQ.defer();
 
-    var streamingPlugin = self.context.coreCommand.pluginManager.getPlugin('music_service', 'streaming_services');
-	if (streamingPlugin) {
-        var streamingConf = self.commandRouter.getUIConfigOnPlugin('music_service', 'streaming_services', '');
-        streamingConf.then(function(conf) {
-            defer.resolve(conf);
-        })
-            .fail(function()
-            {
-                defer.resolve(false);
-            })
-	} else {
+    let pluginsMyMysicConfig = self.context.coreCommand.pluginManager.getPluginsMyMusicConfig();
+    pluginsMyMysicConfig.then(function(conf) {
+        defer.resolve(conf);
+    }).fail(function() {
         defer.resolve(false);
-	}
+    });
 
     return defer.promise;
 };
-
-
 
 ControllerMyMusic.prototype.setUIConfig = function (data) {
 	var self = this;


### PR DESCRIPTION
Instead of relying on any core plugin, in this case the `my_music` plugin, to know which plugins / services in MyVolumio require a special treatment, delegate the possibility to pull in additional UIConfig elements to the PluginManager code, which in turns will delegate it to MyVolumio's own PluginManager.