### PR TITLE
Check 'uri' field is defined before using

### DIFF
--- a/app/playqueue.js
+++ b/app/playqueue.js
@@ -140,7 +140,7 @@ CorePlayQueue.prototype.addQueueItems = function (arrayItems) {
         {
             service=item.service;
 
-            if(item.uri != undefined && item.uri.startsWith('cdda:'))
+            if( item.uri.startsWith('cdda:'))
             {
                 item.name=item.title;
                 if (!item.albumart) {

--- a/app/playqueue.js
+++ b/app/playqueue.js
@@ -132,35 +132,34 @@ CorePlayQueue.prototype.addQueueItems = function (arrayItems) {
         if (item.uri != undefined) {
             self.commandRouter.logger.info("Adding Item to queue: " + item.uri);
 
+            var service='mpd';
 
-        var service='mpd';
-
-        if(item.service)
-        {
-            service=item.service;
-
-            if( item.uri.startsWith('cdda:'))
+            if(item.service)
             {
-                item.name=item.title;
-                if (!item.albumart) {
-                    item.albumart="/albumart";
+                service=item.service;
+
+                if( item.uri.startsWith('cdda:'))
+                {
+                    item.name=item.title;
+                    if (!item.albumart) {
+                        item.albumart="/albumart";
+                    }
+                    promiseArray.push(libQ.resolve(item));
+                } else if (service==='webradio') {
+                    promiseArray.push(this.commandRouter.executeOnPlugin('music_service', 'webradio', 'explodeUri', item));
+                } else  {
+                    promiseArray.push(this.commandRouter.explodeUriFromService(service,item.uri));
                 }
-                promiseArray.push(libQ.resolve(item));
-            } else if (service==='webradio') {
-                promiseArray.push(this.commandRouter.executeOnPlugin('music_service', 'webradio', 'explodeUri', item));
-            } else  {
+            } else {
+
+                //backward compatibility with SPOP plugin
+                if(item.uri.startsWith('spotify:'))
+                {
+                    service='spop';
+                }
+
                 promiseArray.push(this.commandRouter.explodeUriFromService(service,item.uri));
             }
-        } else {
-
-            //backward compatibility with SPOP plugin
-            if(item.uri.startsWith('spotify:'))
-            {
-                service='spop';
-            }
-
-            promiseArray.push(this.commandRouter.explodeUriFromService(service,item.uri));
-        }
 
         }
     }

--- a/app/playqueue.js
+++ b/app/playqueue.js
@@ -155,7 +155,7 @@ CorePlayQueue.prototype.addQueueItems = function (arrayItems) {
         } else {
 
             //backward compatibility with SPOP plugin
-            if(item.uri.startsWith('spotify:'))
+            if(item.uri != undefined && item.uri.startsWith('spotify:'))
             {
                 service='spop';
             }

--- a/app/playqueue.js
+++ b/app/playqueue.js
@@ -140,7 +140,7 @@ CorePlayQueue.prototype.addQueueItems = function (arrayItems) {
         {
             service=item.service;
 
-            if( item.uri.startsWith('cdda:'))
+            if(item.uri != undefined && item.uri.startsWith('cdda:'))
             {
                 item.name=item.title;
                 if (!item.albumart) {

--- a/app/playqueue.js
+++ b/app/playqueue.js
@@ -131,7 +131,6 @@ CorePlayQueue.prototype.addQueueItems = function (arrayItems) {
 
         if (item.uri != undefined) {
             self.commandRouter.logger.info("Adding Item to queue: " + item.uri);
-        }
 
 
         var service='mpd';
@@ -161,6 +160,8 @@ CorePlayQueue.prototype.addQueueItems = function (arrayItems) {
             }
 
             promiseArray.push(this.commandRouter.explodeUriFromService(service,item.uri));
+        }
+
         }
     }
 

--- a/app/playqueue.js
+++ b/app/playqueue.js
@@ -155,7 +155,7 @@ CorePlayQueue.prototype.addQueueItems = function (arrayItems) {
         } else {
 
             //backward compatibility with SPOP plugin
-            if(item.uri != undefined && item.uri.startsWith('spotify:'))
+            if(item.uri.startsWith('spotify:'))
             {
                 service='spop';
             }


### PR DESCRIPTION
It seems at least possible some data can be fed to this function that doesn't contain the 'uri' field.
Otherwise, why the check when calling ```self.commandRouter.logger.info``` ?
