### PR TITLE
Add getPlaylistContent to websockets

### DIFF
--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -490,6 +490,15 @@ function InterfaceWebUI(context) {
 
 
 			// PLAYLIST MANAGEMENT
+                       connWebSocket.on('getPlaylistContent', function (data) {
+                            var selfConnWebSocket = this;
+
+                            var returnedData=self.commandRouter.playListManager.getPlaylistContent(data.name);
+                            returnedData.then(function (retData) {
+                              selfConnWebSocket.emit('pushPlaylistContent', {name:data.name,lists:[retData]});
+                            });
+                        });
+
 			connWebSocket.on('createPlaylist', function (data) {
 				var selfConnWebSocket = this;
 


### PR DESCRIPTION
Create new getPlaylistContent API for websocket. Used as:
`io.emit('getPlaylistContent', {name:"Playlist Name"});`
Returns:

```
pushPlaylistContent:{
  name: 'playlist name',
  lists: [
    [ { ... }, { ... } ]
  ]
}
```
