### PR TITLE
Allow addPlay to specify index

### DIFF
--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -104,12 +104,18 @@ function InterfaceWebUI(context) {
 
             });
 		
-			connWebSocket.on('addPlay', function (data) {
+            connWebSocket.on('addPlay', function (data) {
+                var tracks=data;
+                var index=0;
+                if (data.list != undefined) {
+                  tracks=data.list;
+                  if (data.index != undefined)
+                    index=data.index;
+                }
+                self.commandRouter.addQueueItems(tracks)
+                        return self.commandRouter.volumioPlay(e.firstItemIndex+index);
+            });
 
-                self.commandRouter.addQueueItems(data)
-                    .then(function(e){
-                        return self.commandRouter.volumioPlay(e.firstItemIndex);
-                    });
 			});
 
 			connWebSocket.on('addPlayCue', function (data) {

--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -108,12 +108,13 @@ function InterfaceWebUI(context) {
                 var tracks=data;
                 var index=0;
                 if (data.list != undefined) {
-                  tracks=data.list;
-                  if (data.index != undefined)
-                    index=data.index;
+                    tracks=data.list;
+                    if (data.index != undefined) {
+                        index=data.index;
+                    }
                 }
-                self.commandRouter.addQueueItems(tracks)
-                        return self.commandRouter.volumioPlay(e.firstItemIndex+index);
+                self.commandRouter.addQueueItems(tracks);
+                return self.commandRouter.volumioPlay(e.firstItemIndex+index);
             });
 
 			});


### PR DESCRIPTION
Enhance addPlay to allow the selection of a track index. Used as:

`io.emit('addPlay ', { list: [ { "uri" : "..." }, { "uri" : "..." } ], index: 1 });

Would add two tracks to the queue and play the second track.