### PR TITLE
Fix undefined when adding a playlist of radios to the queue

### DIFF
--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -176,7 +176,7 @@ PlaylistManager.prototype.enqueue = function (name) {
                         var item = {
                             service: data[i].service,
                             uri: data[i].uri,
-                            name: data[i].title,
+                            title: data[i].title,
                             artist: data[i].artist,
                             album: data[i].album,
                             albumart: data[i].albumart
@@ -740,7 +740,7 @@ PlaylistManager.prototype.commonPlayPlaylist = function (folder, name) {
 				else {
 					self.commandRouter.volumioClearQueue();
 
-					var uris = [];
+          var array = [];
 					for (var i in data) {
 						var uri;
 						var fullUri = S(data[i].uri);
@@ -758,10 +758,19 @@ PlaylistManager.prototype.commonPlayPlaylist = function (folder, name) {
                             service='mpd';
                         else service=data[i].service;
 
-						uris.push({uri:uri,service:service});
+                        var item = {
+                          service: service,
+                          uri: uri,
+                          title: data[i].title,
+                          artist: data[i].artist,
+                          album: data[i].album,
+                          albumart: data[i].albumart
+                        }
+
+                        array.push(item);
 					}
 
-                    self.commandRouter.addQueueItems(uris)
+          self.commandRouter.addQueueItems(array)
                         .then(function()
                         {
                             self.commandRouter.volumioPlay(0);

--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -170,7 +170,7 @@ PlaylistManager.prototype.enqueue = function (name) {
                     var promises = [];
                     var promise;
 
-                    var array = [];
+                    var playlist = [];
 
                     for (var i in data) {
                         var item = {
@@ -182,10 +182,10 @@ PlaylistManager.prototype.enqueue = function (name) {
                             albumart: data[i].albumart
                         }
 
-                        array.push(item);
+                        playlist.push(item);
                     }
 
-                    self.commandRouter.addQueueItems(array);
+                    self.commandRouter.addQueueItems(playlist);
 
                     defer.resolve();
                 }
@@ -740,7 +740,7 @@ PlaylistManager.prototype.commonPlayPlaylist = function (folder, name) {
 				else {
 					self.commandRouter.volumioClearQueue();
 
-          var array = [];
+          var playlist = [];
 					for (var i in data) {
 						var uri;
 						var fullUri = S(data[i].uri);
@@ -767,10 +767,10 @@ PlaylistManager.prototype.commonPlayPlaylist = function (folder, name) {
                           albumart: data[i].albumart
                         }
 
-                        array.push(item);
+            playlist.push(item);
 					}
 
-          self.commandRouter.addQueueItems(array)
+          self.commandRouter.addQueueItems(playlist)
                         .then(function()
                         {
                             self.commandRouter.volumioPlay(0);


### PR DESCRIPTION
When adding a playlist of radios to a queue using the options "Play" or "Add to queue", their name appear in the queue as undefined instead of keeping the original name:

![undefined](https://user-images.githubusercontent.com/25210729/67040398-b8e9f300-f123-11e9-8e0e-0574637dd9d0.jpg)

This commit fixes the issue.
