### PR TITLE
Check before overwriting .name field of a queue item.

### DIFF
--- a/app/plugins/music_service/webradio/index.js
+++ b/app/plugins/music_service/webradio/index.js
@@ -611,7 +611,7 @@ ControllerWebradio.prototype.explodeUri = function(data) {
             });
 
     } else {
-        data.name=data.title;
+        if (data.title) data.name=data.title;
         if (!data.albumart) {
             data.albumart="/albumart";
         }


### PR DESCRIPTION
Play queue items contain a valid .name field but not necessarily
a valid .title field. One instance where this happens when a webradio
is saved to a playlist and the playlist is added to the play queue.
Check .title is defined before overwriting the .name field.
Otherwise, the item will be shown in the queue with a name of "undefined".

This is an alternative fix to the approach in #1816.
Tested on 2.657 for these cases:
 - webradio saved as a playlist and playlist added to queue (shows as 'undefined' in playqueue before patch)
 - webradio from 'my web radios' added to the playqueue
 - webradio from 'volumio selection' added to the playqueue
 - single track from an album in music library added to the playqueue