### PR TITLE
Selfish

### DIFF
--- a/app/plugins/miscellanea/my_music/index.js
+++ b/app/plugins/miscellanea/my_music/index.js
@@ -53,7 +53,6 @@ ControllerMyMusic.prototype.onRestart = function () {
 ControllerMyMusic.prototype.getUIConfig = function () {
 	var self = this;
 
-	var self = this;
 	var lang_code = self.commandRouter.sharedVars.get('language_code');
 
 	var defer=libQ.defer();

--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -50,6 +50,7 @@ ControllerMpd.prototype.play = function (N) {
 
 //MPD Add
 ControllerMpd.prototype.add = function (data) {
+    var self = this;
 	this.commandRouter.pushToastMessage('success', data + self.commandRouter.getI18nString('COMMON.ADD_QUEUE_TEXT_1'));
 	return this.sendMpdCommand('add', [data]);
 };
@@ -83,6 +84,7 @@ ControllerMpd.prototype.seek = function (timepos) {
 
 //MPD Random
 ControllerMpd.prototype.random = function (randomcmd) {
+    var self = this;
 	var string = randomcmd ? 1 : 0;
 	this.commandRouter.pushToastMessage('success', "Random", string === 1 ? self.commandRouter.getI18nString('COMMON.ON') : self.commandRouter.getI18nString('COMMON.OFF'));
 	return this.sendMpdCommand('random', [string])
@@ -90,6 +92,7 @@ ControllerMpd.prototype.random = function (randomcmd) {
 
 //MPD Repeat
 ControllerMpd.prototype.repeat = function (repeatcmd) {
+    var self = this;
 	var string = repeatcmd ? 1 : 0;
 	this.commandRouter.pushToastMessage('success', "Repeat", string === 1 ? self.commandRouter.getI18nString('COMMON.ON') : self.commandRouter.getI18nString('COMMON.ON'));
 	return this.sendMpdCommand('repeat', [string]);

--- a/app/plugins/system_controller/networkfs/index.js
+++ b/app/plugins/system_controller/networkfs/index.js
@@ -79,7 +79,6 @@ ControllerNetworkfs.prototype.onUninstall = function () {
 ControllerNetworkfs.prototype.getUIConfig = function () {
     var self = this;
 
-    var self = this;
     var lang_code = self.commandRouter.sharedVars.get('language_code');
 
     var defer=libQ.defer();

--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -518,6 +518,7 @@ CoreStateMachine.prototype.updateVolume = function (Volume) {
 
 //Gets current Volume and Mute Status
 CoreStateMachine.prototype.getcurrentVolume = function () {
+    var self = this;
 	this.commandRouter.pushConsoleMessage('CoreStateMachine::getcurrentVolume');
 	this.commandRouter.volumioretrievevolume().then((volumeData)=>{
     	self.currentVolume = volumeData.vol;


### PR DESCRIPTION
This isn't ready for merging, I need some input.

After helping out with PR #1827 I made a scan of the tree looking for missing definitions of 'self'.
I found a few but in all cases it's unclear to me if the fix is
```
var self = this;
```
or to just use ```this.<foo>``` instead of ```self.<foo>```. The main one is in statemachine.js:
https://github.com/volumio/Volumio2/blob/0b9279fa6125327588395bccaddba81cda50df4b/app/statemachine.js#L520-L528
where I'm not really clear why ```this``` is used at line 526. I guess it is returning dynamic data...