### PR TITLE
Add Waveshare WM8960 Audio HAT

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -46,6 +46,7 @@
     {"id":"terraberry-dac2","name":"Terra-Berry DAC 2","overlay":"hifiberry-dac","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"es90x8q2m-dac","name":"Volumio ESS 9028QM","overlay":"es90x8q2m-dac","alsanum":"1","mixer":"Digital","modules":"","script":"","i2c_address":"48","needsreboot":"no"}
   ]},
+    {"id":"wm8960-audio-hat","name":"WM8960 Audio HAT","overlay":"wm8960-soundcard","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"no"},
   {"name":"Odroid C1+","data":[
     {"id":"odroid-hifi-shield","name":"HiFi Shield","overlay":"","alsanum":"2","mixer":"","modules":"","script":""}
   ]},


### PR DESCRIPTION
Hi,
I have bought a really nice Hi-Fi soundcard hat from Waveshare which is not (yet) recognised by Volumio. Would you mind updating the dacs.json file in order to be able to enjoy Volumio on my Raspberry Pi Zero W with the WM8960-Audio-HAT?

Thanks a lot!
