### PR TITLE
Capitalizing name in shariport-sync config

### DIFF
--- a/app/plugins/music_service/airplay_emulation/index.js
+++ b/app/plugins/music_service/airplay_emulation/index.js
@@ -143,7 +143,7 @@ AirPlayInterface.prototype.startShairportSync = function () {
         }
 
         var conf = data;
-        conf = conf.replace("${name}", name);
+        conf = conf.replace("${name}", name.charAt(0).toUpperCase() + name.slice(1));
         conf = conf.replace("${device}", outdev);
         if (buffer_size_line && buffer_size_line.length) {
             conf = conf.replace("${buffer_size_line}", buffer_size_line);


### PR DESCRIPTION
Causes the name of the airplay device to be the capitalized version of the volumio player name. Fixes the Issue for me where my after 2 reboots the name of my volumio player becomes lowercase in airplay menus.