### PR TITLE
Changed sources headline and added translation string

### DIFF
--- a/app/i18n/strings_de.json
+++ b/app/i18n/strings_de.json
@@ -210,7 +210,8 @@
     "LOGIN_FAIL":"Login fehlgeschlagen",
     "LOGGING_OUT":"Ausloggen",
     "LOGOUT_SUCCESS":"Erfolgreich ausgeloggt",
-    "OR":"oder"
+    "OR":"oder",
+    "SOURCES":"Quellen"
   },
   "APPEARANCE":{
     "APPEARANCE":"Aussehen",

--- a/app/i18n/strings_en.json
+++ b/app/i18n/strings_en.json
@@ -210,7 +210,8 @@
     "LOGIN_FAIL":"failed to log in",
     "LOGGING_OUT":"Logging out",
     "LOGOUT_SUCCESS":"Successfully logged out",
-    "OR":"or"
+    "OR":"or",
+    "SOURCES":"Sources"
   },
   "APPEARANCE":{
     "APPEARANCE":"Appearance",

--- a/app/plugins/miscellanea/my_music/UIConfig.json
+++ b/app/plugins/miscellanea/my_music/UIConfig.json
@@ -1,6 +1,6 @@
 {
   "page": {
-    "label": "TRANSLATE.COMMON.MY_MUSIC"
+    "label": "TRANSLATE.COMMON.SOURCES"
   },
   "sections": [
     {"coreSection":"my-music"},


### PR DESCRIPTION
Headline for Sources has been changed from "MY_MUSIC" to "SOURCES". A translation string has been added accordingly for english and german.