### PR TITLE
volumio_command_line_client: add initrd edit

### DIFF
--- a/app/plugins/system_controller/volumio_command_line_client/commands/init-edit.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/commands/init-edit.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+TMPWORK="/home/volumio/tmpwork"
+HELP() {
+  echo "
+
+Basic usage: volumio init-editor <initramfs filename>
+
+Example: volumio init-editor uIinitrd
+
+Notes:
+The script will determine how the initrd has been compressed and unpack/ repack accordingly
+
+"
+  exit 1
+}
+
+EXISTS=`which nano`
+if [ "x" = "x$EXISTS" ]; then
+    echo "This script requires text editor 'nano'"
+    echo "Please install 'nano'"
+    exit 1
+fi
+
+NUMARGS=$#
+if [ "$NUMARGS" -eq 0 ]; then
+  HELP
+fi
+
+while getopts d:f: FLAG; do
+  case $FLAG in
+    f)
+      INITRDNAME="/boot/$OPTARG"
+      ;;
+
+    h)  #show help
+      HELP
+      ;;
+    /?) #unrecognized option - show help
+      echo -e \\n"Option -${BOLD}$OPTARG${NORM} not allowed."
+      HELP
+      ;;
+  esac
+done
+
+if [ -z $INITRDNAME ]; then
+	echo ""
+	echo "$0: missing argument(s)"
+	HELP
+	exit 1
+fi
+
+if [ ! -f $INITRDNAME ]; then
+	echo ""
+	echo "$0: $INITRDNAME does not exist"
+	HELP
+	exit 1
+fi
+
+if [ -d $TMPWORK ]; then
+	echo "Workarea exists, cleaning it..." 
+	rm -r $TMPWORK/* > /dev/null 2>&1 
+else
+	mkdir $TMPWORK
+fi
+
+
+echo "Making $INITRDNAME backup copy..."
+cp $INITRDNAME $INITRDNAME".bak"
+FORMAT=`file $INITRDNAME | grep -o "RAMDisk Image"`
+cd $TMPWORK
+if [ "x$FORMAT" = "xRAMDisk Image" ]; then
+	echo "Unpacking RAMDisk image $INITRDNAME..."
+	dd if=$INITRDNAME bs=64 skip=1 | gzip -dc | cpio -div
+	nano init
+	echo "Creating a new $INITRDNAME, please wait..."
+	find . -print0 | cpio --quiet -o -0 --format=newc | gzip -9 > $INITRDNAME.new
+	mkimage -A arm64 -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d $INITRDNAME.new $INITRDNAME
+	rm $INITRDNAME.new
+else
+	echo "Unpacking gzip compressed $INITRDNAME..."
+	zcat $INITRDNAME | cpio -idmv > /dev/null 2>&1
+	nano init
+	echo "Creating a new $INITRDNAME, please wait..."
+	find . -print0 | cpio --quiet -o -0 --format=newc | gzip -9 > $INITRDNAME
+fi
+
+echo "Done."
+sync
+popd > /dev/null 2>&1
+
+rm -r $TMPWORK
+

--- a/app/plugins/system_controller/volumio_command_line_client/volumio.sh
+++ b/app/plugins/system_controller/volumio_command_line_client/volumio.sh
@@ -55,6 +55,8 @@ plugin publish                     publishes the plugin on git
 plugin install                     installs the plugin locally
 plugin update                      updates the plugin
 logdump <description>              dump logs to $LOGDUMP instead of uploading
+init-edit <initramfs filename>     unpacks the initramfs, feeds nano with the init script and upon nano exit, rebuilds initramfs
+
 
 [[VOLUMIO UPDATER]]
 updater forceupdate                Updates to latest version
@@ -96,6 +98,10 @@ sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/d
 
 kernelsource() {
 sudo /bin/sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/kernelsource.sh
+}
+
+init-edit() {
+sudo /bin/sh /volumio/app/plugins/system_controller/volumio_command_line_client/commands/init-edit.sh -f $1
 }
 
 case "$1" in
@@ -141,11 +147,17 @@ case "$1" in
                /usr/bin/curl "http://127.0.0.1:3000/api/v1/commands/?cmd=random"
             fi
             ;;
-        startairplay)
-           /usr/bin/curl "http://127.0.0.1:3000/api/v1/commands/?cmd=startAirplay"
+        startairplayplayback)
+           /usr/bin/curl "http://127.0.0.1:3000/api/v1/commands/?cmd=startAirplayPlayback"
         ;;
-        stopairplay)
-           /usr/bin/curl "http://127.0.0.1:3000/api/v1/commands/?cmd=stopAirplay"
+        stopairplayplayback)
+           /usr/bin/curl "http://127.0.0.1:3000/api/v1/commands/?cmd=stopAirplayPlayback"
+        ;;
+        airplayactive)
+           /usr/bin/curl "http://127.0.0.1:3000/api/v1/commands/?cmd=airplayActive"
+        ;;
+        airplayinactive)
+           /usr/bin/curl "http://127.0.0.1:3000/api/v1/commands/?cmd=airplayInactive"
         ;;
         usbattach)
            /usr/bin/curl "http://127.0.0.1:3000/api/v1/commands/?cmd=usbAudioAttach"
@@ -194,7 +206,10 @@ case "$1" in
 	    logdump)
 	        /usr/local/bin/node /volumio/logsubmit.js "$2" nosubmit
             ;;
-        plugin)
+	    init-edit)
+		init-edit $2
+	    ;;
+	    plugin)
             if [ "$2" != "" ]; then
                 if [ "$2" == "init" ]; then
                     echo ""


### PR DESCRIPTION
This adds an option to edit the init script in an initramfs.
It will decompress the initrd and open nano as the editor.
After nano has exited, the initrd will be rebuilt.
Works for both known volumio initrd formats: volumio.initrd as built by the mkinitramfs-custom script and the imaged uInitrd version of it.
 