### PR TITLE
Make error message distinct

### DIFF
--- a/app/plugins/music_service/webradio/index.js
+++ b/app/plugins/music_service/webradio/index.js
@@ -825,7 +825,7 @@ ControllerWebradio.prototype.listMyWebRadio = function (uri) {
 
     })
         .fail(function () {
-            defer.reject(new Error("Cannot list Favourites"));
+            defer.reject(new Error("Cannot list MyWebRadios"));
         });
 
     return defer.promise;

--- a/app/plugins/music_service/webradio/index.js
+++ b/app/plugins/music_service/webradio/index.js
@@ -607,7 +607,7 @@ ControllerWebradio.prototype.explodeUri = function(data) {
         })
             .catch(function(err) {
                 self.logger.error(err);
-                defer.reject(new Error('Cannot retrieve details for stram ' + uri + ': ' + err));
+                defer.reject(new Error('Cannot retrieve details for stream ' + uri + ': ' + err));
             });
 
     } else {


### PR DESCRIPTION
Another function, listRadioFavourites(), uses the same message
("Cannot list Favourites") which makes it difficult to distinguish
the source of an error if one occurs.