### PR TITLE
Filepath

### DIFF
--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -793,7 +793,7 @@ PlaylistManager.prototype.commonGetPlaylistContent = function (folder, name) {
 		else {
 			fs.readJson(filePath, function (err, data) {
 				if (err)
-					defer.reject(new Error("Error reading playlist from" + filePath));
+					defer.reject(new Error("Error reading playlist from " + filePath));
 				else {
 					defer.resolve(data);
 				}

--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -793,7 +793,7 @@ PlaylistManager.prototype.commonGetPlaylistContent = function (folder, name) {
 		else {
 			fs.readJson(filePath, function (err, data) {
 				if (err)
-					defer.reject(new Error("Error reading playlist"));
+					defer.reject(new Error("Error reading playlist from" + filePath));
 				else {
 					defer.resolve(data);
 				}


### PR DESCRIPTION
It seems useful to include the path to the file that the function
failed to read in the error that is returned.

Untested, will test when I get a chance.