### PR TITLE
Select track during addPlay

### DIFF
--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -104,13 +104,20 @@ function InterfaceWebUI(context) {
 
             });
 		
-			connWebSocket.on('addPlay', function (data) {
-
-                self.commandRouter.addQueueItems(data)
-                    .then(function(e){
-                        return self.commandRouter.volumioPlay(e.firstItemIndex);
-                    });
-			});
+            connWebSocket.on('addPlay', function (data) {
+                var tracks=data;
+                var index=0;
+                if (data.list != undefined) {
+                    tracks=data.list;
+                    if (data.index != undefined) {
+                        index=data.index;
+                    }
+                }
+                self.commandRouter.addQueueItems(tracks)
+                .then(function(e){
+                  return self.commandRouter.volumioPlay(e.firstItemIndex+index);
+                });
+            });
 
 			connWebSocket.on('addPlayCue', function (data) {
 				if (data.service == undefined || data.service == 'mpd') {


### PR DESCRIPTION
**Note:** Update of #1814

Enhance addPlay to allow the selection of a track index. Used as:

```
io.emit('addPlay ', { list: [ { "uri" : "..." }, { "uri" : "..." } ], index: 1 });
```

Would add two tracks to the queue and play the second track.