### PR TITLE
Ensure checkValidMixer actually gets called

### DIFF
--- a/app/plugins/audio_interface/alsa_controller/index.js
+++ b/app/plugins/audio_interface/alsa_controller/index.js
@@ -970,6 +970,8 @@ ControllerAlsa.prototype.getAplayInfo = function () {
 }
 
 ControllerAlsa.prototype.getMixerControls  = function (device) {
+    var self = this;
+
 	var mixers = [];
 	var outdev = this.config.get('outputdevice');
 	if (outdev == 'softvolume'){


### PR DESCRIPTION
With 'self' not defined, the self.checkValidMixer condition is always false
and no mixers get added to the mixers array.

Fixes: #1832

Tested on a rpi with no Dac, no explosions.
Testing on an rpi with a Dac should be done soon - done, seems to fix the issue.