### PR TITLE
Fix: Add missing attribute of the alsa section in order to specify th…

### DIFF
--- a/app/plugins/music_service/airplay_emulation/shairport-sync.conf.tmpl
+++ b/app/plugins/music_service/airplay_emulation/shairport-sync.conf.tmpl
@@ -11,6 +11,7 @@ diagnostics =
 alsa =
 {
   output_device = "${device}";
+  mixer_control_name = "${mixer}";
   ${buffer_size_line}
 };
 


### PR DESCRIPTION
- Fix: Add the missing attribute of the alsa section within the template of the shairport-sync template file  in order to specify the mixer to be used when the default is not used (e.g PCM)
- See : https://github.com/volumio/Volumio2/issues/1712