### PR TITLE
Fix next / prev functions while playing webradio (2/2)

### DIFF
--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -1267,7 +1267,7 @@ CoreStateMachine.prototype.next = function (promisedResponse) {
         }
 	} else {
 		//self.setConsumeUpdateService(undefined);
-		if (this.isConsume && this.consumeState.service != undefined) {
+		if (this.isConsume && this.consumeState.service != undefined && this.consumeState.service !== 'webradio') { 
 			var thisPlugin = this.commandRouter.pluginManager.getPlugin('music_service', this.consumeState.service);
             if (typeof thisPlugin.next === "function") {
                 thisPlugin.next();
@@ -1427,7 +1427,7 @@ CoreStateMachine.prototype.previous = function (promisedResponse) {
 			}
 
 		} else if (this.currentStatus === 'play') {
-			if (this.isConsume && this.consumeState.service != undefined) {
+			if (this.isConsume && this.consumeState.service != undefined && this.consumeState.service !== 'webradio') { 
                 var thisPlugin = this.commandRouter.getMusicPlugin(this.consumeState.service);
                 if (!this.previousTrackonPrev && typeof thisPlugin.seek === "function") {
                     thisPlugin.seek(0);


### PR DESCRIPTION
This PR fix next / prev functions while playing webradio !

I tested the modifications suggested in this post below and the next / prev functions work correctly!
https://github.com/volumio/Volumio2/issues/1122

To fix the problem a first modification is necessary in 
Volumio2-UI/src/app/services/player.service.js

```
@@ -69,15 +69,11 @@ class PlayerService {
  }

  prev() {
-    if (this.state.trackType !== 'webradio') {
      this.socketService.emit('prev');
-    }
  }

  next() {
-   if (this.state.trackType !== 'webradio') {
      this.socketService.emit('next');
-    }
  }

  skipBackwards() {
```

Changes must be coupled with another from main volumio2-UI in 
Volumio2-UI/src/app/services/player.service.js

PR link : [volumio/Volumio2-UI/pull/711]

hoping it will be useful !