### PR TITLE
Configure samba server-side file permissions

### DIFF
--- a/app/plugins/system_controller/networkfs/smb.conf.tmpl
+++ b/app/plugins/system_controller/networkfs/smb.conf.tmpl
@@ -9,6 +9,10 @@ wins support = yes
 local master = no
 preferred master = no
 os level = 30
+create mask = 0664
+directory mask = 2755
+force create mode = 0644
+force directory mode = 2755
 
 [Internal Storage]
         comment = {NAME} Internal Music Folder


### PR DESCRIPTION
### Problem
The current volumio Samba configuration and setup has a number of issues.
* When mounted with cifs on a client, written files and directories show up with ownership nouser/nogroup on volumio
* Files and directories on an attached USB drive must be world-readable/-writeable to be readable/writeable from a samba client. The volumio user ownership should be sufficient.

### Root cause
* The volumio `smb.conf` does not set up any file/directory permissions for created files/dirs
* The volumio system does not set up any samba users at all ( `sudo pdbedit -L -v` returns no results on a vanilla volumio). Because guest access is allowed in `smb.conf`, all logins fall back to guest rights.

### Fix
* Amend `smb.conf` to contain file/directory creation permissions
* Setup a volumio user and password for samba

### Work in Progress
I've fixed the `smb.conf.tmpl` to use "sane" standard permissions (open for discussion). On my volumio, I set up the volumio user/password interactively and verified that it works.
For this PR. I've put the necessary command into the system controller plugin post-install hook, but I'm not clear whether this is the right spot in the first place, and uncertain about how to test this.

Let me know what you think.