### PR TITLE
Fix syntax error in `dacs.json`

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -20,7 +20,7 @@
     {"id":"hifiberry-digi-pro","name":"HiFiBerry Digi+ Pro","overlay":"hifiberry-digi-pro","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"no"},
     {"id":"hifibox-dac","name":"HiFiBox DAC","overlay":"hifiberry-dacplus","alsanum":"1","mixer":"Digital","modules":"","script":"","eeprom_name":["HiFiBox DAC HAT","HiFiBox DAC HAT V1","HiFiBox DAC HAT V 10"],"needsreboot":"no"},
     {"id":"iqaudio-dacplus","name":"IQaudIO DAC Plus","overlay":"iqaudio-dacplus,unmute_amp ","alsanum":"1","mixer":"Digital","modules":"","script":"iqamp-unmute.sh","i2c_address":"4c","needsreboot":"no"},
-    {"id":"iqaudio-digiplus","name":"IQaudIO Pi-Digi+","overlay":"iqaudio-digi-wm8804-audio","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"},	  
+    {"id":"iqaudio-digiplus","name":"IQaudIO Pi-Digi+","overlay":"iqaudio-digi-wm8804-audio","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"iqaudio-amp","name":"IQaudIO Pi-DigiAMP+","overlay":"iqaudio-dacplus,unmute_amp ","alsanum":"1","mixer":"Digital","modules":"","script":"iqamp-unmute.sh","needsreboot":"yes"},
     {"id":"justboom-amp","name":"JustBoom Amp Boards","overlay":"justboom-dac","alsanum":"1","mixer":"Digital","modules":"","script":"","eeprom_name":["JustBoom DAC HAT","JustBoom DAC HAT v1.1"],"needsreboot":"yes"},
     {"id":"justboom-dac","name":"JustBoom DAC Boards","overlay":"justboom-dac","alsanum":"1","mixer":"Digital","modules":"","script":"","eeprom_name":["JustBoom DAC HAT","JustBoom DAC HAT v1.1"],"needsreboot":"yes"},
@@ -37,7 +37,7 @@
     {"id":"picade-hat","name":"Picade HAT","overlay":"hifiberry-dac","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes","eeprom_name":["Picade HAT"]},
     {"id":"pisound","name":"pisound","overlay":"pisound","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"no"},
     {"id":"raspiaudio","name":"raspiaudio","overlay":"googlevoicehat-soundcard","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"} ,
-	  {"id":"raspidacv3","name":"RaspiDACv3","overlay":"raspidac3","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
+    {"id":"raspidacv3","name":"RaspiDACv3","overlay":"raspidac3","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"rpi-dac","name":"R-PI DAC","overlay":"rpi-dac","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"soekris-dac","name":"Soekris dam 1021","overlay":"hifiberry-dac","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"speaker-phat","name":"Speaker pHAT","overlay":"hifiberry-dac","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"},
@@ -50,16 +50,15 @@
     {"id":"odroid-hifi-shield","name":"HiFi Shield","overlay":"","alsanum":"2","mixer":"","modules":"","script":""}
   ]},
   {"name":"Sparky","data":[
-	{"id":"piano-dac","name":"Allo Piano","overlay":"","alsanum":"1","mixer":"Digital","modules":["snd-soc-allo-piano-dac"],"script":"","needsreboot":"yes"},
-	{"id":"piano-dac-plus","name":"Allo Piano 2.1","overlay":"","alsanum":"1","mixer":"Digital","modules":["snd-soc-allo-piano-dac-plus"],"script":"","needsreboot":"yes"}
+    {"id":"piano-dac","name":"Allo Piano","overlay":"","alsanum":"1","mixer":"Digital","modules":["snd-soc-allo-piano-dac"],"script":"","needsreboot":"yes"},
+    {"id":"piano-dac-plus","name":"Allo Piano 2.1","overlay":"","alsanum":"1","mixer":"Digital","modules":["snd-soc-allo-piano-dac-plus"],"script":"","needsreboot":"yes"}
   ]},
   {"name":"Tinkerboard","data":[
     {"id":"hifiberry-amp","name":"HiFiBerry Amp","overlay":"hifiberry-amp","alsanum":"1","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
     {"id":"hifiberry-dac","name":"HiFiBerry DAC","overlay":"hifiberry-dac","alsanum":"1","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"hifiberry-dacplus","name":"HiFiBerry DAC Plus","overlay":"hifiberry-dacplus","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"iqaudio-dacplus","name":"IQaudIO DAC Plus","overlay":"iqaudio-dacplus","alsanum":"1","mixer":"Digital","modules":"","script":"iqamp-unmute.sh","needsreboot":"yes"},
-	{"id":"rpi-dac","name":"R-PI DAC","overlay":"rpi-dac","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
-    {"id":"audiophonics-es9028q2m-dac","name":"Audiophonics I-Sabre ES9028Q2M","overlay":"i-sabre-q2m","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
+    {"id":"rpi-dac","name":"R-PI DAC","overlay":"rpi-dac","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
+    {"id":"audiophonics-es9028q2m-dac","name":"Audiophonics I-Sabre ES9028Q2M","overlay":"i-sabre-q2m","alsanum":"1","mixer":"Digital","modules":"","script":"","needsreboot":"yes"}
   ]}
-  ]}
-
+]}


### PR DESCRIPTION
There is syntax error in `i2s_dacs/dacs.json` that will prevent the Volumio service from starting..
771710b (#1888) Introduces a syntax error (one pesky comma!)..
```
/volumio/node_modules/fs-extra/node_modules/jsonfile/index.js:73
      throw err
      ^
SyntaxError: /volumio/app/plugins/system_controller/i2s_dacs/dacs.json: Unexpected token ] in JSON at position 9071
    at JSON.parse (<anonymous>)
    at Object.readFileSync (/volumio/node_modules/fs-extra/node_modules/jsonfile/index.js:69:17)
    at ControllerI2s.eepromDetect (/volumio/app/plugins/system_controller/i2s_dacs/index.js:176:19)
    at ControllerI2s.i2sDetect (/volumio/app/plugins/system_controller/i2s_dacs/index.js:146:24)
```
Took the opportunity to fix other minor whitespace issues as well..
