### PR TITLE
Refactor `getSystemVersion()` to be easily extendable

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -7,520 +7,504 @@ var execSync = require('child_process').execSync;
 var winston = require('winston');
 var vconf = require('v-conf');
 
-
 // Define the CoreCommandRouter class
 module.exports = CoreCommandRouter;
-function CoreCommandRouter(server) {
 
-	var logfile = '/var/log/volumio.log';
+function CoreCommandRouter (server) {
+  var logfile = '/var/log/volumio.log';
 
-	fs.ensureFileSync(logfile);
-	this.logger = new (winston.Logger)({
-		transports: [
-			new (winston.transports.Console)(),
-			new (winston.transports.File)({
-				filename: logfile,
-				json: false
-			})
-		]
-	});
+  fs.ensureFileSync(logfile);
+  this.logger = new (winston.Logger)({
+    transports: [
+      new (winston.transports.Console)(),
+      new (winston.transports.File)({
+        filename: logfile,
+        json: false
+      })
+    ]
+  });
 
-	this.callbacks = [];
-	this.pluginsRestEndpoints = [];
-	this.sharedVars = new vconf();
-    this.sharedVars.registerCallback('language_code',this.loadI18nStrings.bind(this));
-    this.sharedVars.addConfigValue('selective_search','boolean',true);
+  this.callbacks = [];
+  this.pluginsRestEndpoints = [];
+  this.sharedVars = new vconf();
+  this.sharedVars.registerCallback('language_code', this.loadI18nStrings.bind(this));
+  this.sharedVars.addConfigValue('selective_search', 'boolean', true);
 
-	this.logger.info("-------------------------------------------");
-	this.logger.info("-----            Volumio2              ----");
-	this.logger.info("-------------------------------------------");
-	this.logger.info("-----          System startup          ----");
-	this.logger.info("-------------------------------------------");
+  this.logger.info('-------------------------------------------');
+  this.logger.info('-----            Volumio2              ----');
+  this.logger.info('-------------------------------------------');
+  this.logger.info('-----          System startup          ----');
+  this.logger.info('-------------------------------------------');
 
-    //Checking for system updates
-    this.checkAndPerformSystemUpdates();
-    // Start the music library
-    this.musicLibrary = new (require('./musiclibrary.js'))(this);
+  // Checking for system updates
+  this.checkAndPerformSystemUpdates();
+  // Start the music library
+  this.musicLibrary = new (require('./musiclibrary.js'))(this);
 
-    // Start plugins
-    this.pluginManager = new (require(__dirname + '/pluginmanager.js'))(this, server);
-    this.pluginManager.checkIndex();
-    this.pluginManager.pluginFolderCleanup();
-    this.configManager=new(require(__dirname+'/configManager.js'))(this.logger);
+  // Start plugins
+  this.pluginManager = new (require(__dirname + '/pluginmanager.js'))(this, server);
+  this.pluginManager.checkIndex();
+  this.pluginManager.pluginFolderCleanup();
+  this.configManager = new (require(__dirname + '/configManager.js'))(this.logger);
 
-    this.pluginManager.startPlugins();
+  this.pluginManager.startPlugins();
 
-    this.loadI18nStrings();
-    this.musicLibrary.updateBrowseSourcesLang();
+  this.loadI18nStrings();
+  this.musicLibrary.updateBrowseSourcesLang();
 
-    // Start the state machine
-    this.stateMachine = new (require('./statemachine.js'))(this);
+  // Start the state machine
+  this.stateMachine = new (require('./statemachine.js'))(this);
 
+  // Start the volume controller
+  this.volumeControl = new (require('./volumecontrol.js'))(this);
 
-    // Start the volume controller
-    this.volumeControl = new (require('./volumecontrol.js'))(this);
+  // Start the playListManager.playPlaylistlist FS
+  // self.playlistFS = new (require('./playlistfs.js'))(self);
 
-    // Start the playListManager.playPlaylistlist FS
-    //self.playlistFS = new (require('./playlistfs.js'))(self);
+  this.playListManager = new (require('./playlistManager.js'))(this);
 
-    this.playListManager = new (require('./playlistManager.js'))(this);
+  this.platformspecific = new (require(__dirname + '/platformSpecific.js'))(this);
 
-    this.platformspecific = new (require(__dirname + '/platformSpecific.js'))(this);
+  this.pushConsoleMessage('BOOT COMPLETED');
 
-    this.pushConsoleMessage('BOOT COMPLETED');
-
-    this.startupSound();
-	this.closeModals();
-
+  this.startupSound();
+  this.closeModals();
 }
 
 // Methods usually called by the Client Interfaces ----------------------------------------------------------------------------
 
-
-
 // Volumio Pause
 CoreCommandRouter.prototype.volumioPause = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPause');
-	return this.stateMachine.pause();
+  this.pushConsoleMessage('CoreCommandRouter::volumioPause');
+  return this.stateMachine.pause();
 };
 
 // Volumio Stop
 CoreCommandRouter.prototype.volumioStop = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioStop');
-	return this.stateMachine.stop();
+  this.pushConsoleMessage('CoreCommandRouter::volumioStop');
+  return this.stateMachine.stop();
 };
 
 // Volumio Previous
 CoreCommandRouter.prototype.volumioPrevious = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPrevious');
-	return this.stateMachine.previous();
+  this.pushConsoleMessage('CoreCommandRouter::volumioPrevious');
+  return this.stateMachine.previous();
 };
 
 // Volumio Next
 CoreCommandRouter.prototype.volumioNext = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioNext');
-	return this.stateMachine.next();
+  this.pushConsoleMessage('CoreCommandRouter::volumioNext');
+  return this.stateMachine.next();
 };
 
 // Volumio Get State
 CoreCommandRouter.prototype.volumioGetState = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetState');
-	return this.stateMachine.getState();
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetState');
+  return this.stateMachine.getState();
 };
 
 // Volumio Get Queue
 CoreCommandRouter.prototype.volumioGetQueue = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetQueue');
-	return this.stateMachine.getQueue();
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetQueue');
+  return this.stateMachine.getQueue();
 };
 
 // Volumio Remove Queue Item
 CoreCommandRouter.prototype.volumioRemoveQueueItem = function (nIndex) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioRemoveQueueItem');
-	return this.stateMachine.removeQueueItem(nIndex);
+  this.pushConsoleMessage('CoreCommandRouter::volumioRemoveQueueItem');
+  return this.stateMachine.removeQueueItem(nIndex);
 };
 
 // Volumio Clear Queue Item
 CoreCommandRouter.prototype.volumioClearQueue = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioClearQueue');
-	return this.stateMachine.clearQueue();
+  this.pushConsoleMessage('CoreCommandRouter::volumioClearQueue');
+  return this.stateMachine.clearQueue();
 };
 
 // Volumio Set Volume
 CoreCommandRouter.prototype.volumiosetvolume = function (VolumeInteger) {
-	var self = this;
-	this.callCallback("volumiosetvolume", VolumeInteger);
+  var self = this;
+  this.callCallback('volumiosetvolume', VolumeInteger);
 
-	var volSet = this.volumeControl.alsavolume(VolumeInteger);
-    volSet.then(function (result) {
-		 return self.volumioupdatevolume(result);
-    })
+  var volSet = this.volumeControl.alsavolume(VolumeInteger);
+  volSet.then(function (result) {
+    return self.volumioupdatevolume(result);
+  });
 };
 
 // Volumio Update Volume
 CoreCommandRouter.prototype.volumioupdatevolume = function (vol) {
-	this.callCallback("volumioupdatevolume", vol);
-	this.writeVolumeStatusFiles(vol);
-	return this.stateMachine.updateVolume(vol);
+  this.callCallback('volumioupdatevolume', vol);
+  this.writeVolumeStatusFiles(vol);
+  return this.stateMachine.updateVolume(vol);
 };
 
 // Volumio Retrieve Volume
 CoreCommandRouter.prototype.volumioretrievevolume = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioRetrievevolume');
-	return this.volumeControl.retrievevolume();
+  this.pushConsoleMessage('CoreCommandRouter::volumioRetrievevolume');
+  return this.volumeControl.retrievevolume();
 };
 
-
 CoreCommandRouter.prototype.volumioUpdateVolumeSettings = function (vol) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioUpdateVolumeSettings');
-	if (this.volumeControl){
-		return this.volumeControl.updateVolumeSettings(vol);
-	}
+  this.pushConsoleMessage('CoreCommandRouter::volumioUpdateVolumeSettings');
+  if (this.volumeControl) {
+    return this.volumeControl.updateVolumeSettings(vol);
+  }
 };
 
 CoreCommandRouter.prototype.updateVolumeScripts = function (data) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioUpdateVolumeScripts');
-    if (this.volumeControl){
-        return this.volumeControl.updateVolumeScript(data);
-    }
+  this.pushConsoleMessage('CoreCommandRouter::volumioUpdateVolumeScripts');
+  if (this.volumeControl) {
+    return this.volumeControl.updateVolumeScript(data);
+  }
 };
 
 CoreCommandRouter.prototype.retrieveVolumeLevels = function () {
-    this.pushConsoleMessage('CoreCommandRouter::volumioRetrieveVolumeLevels');
-    return this.stateMachine.getcurrentVolume();
+  this.pushConsoleMessage('CoreCommandRouter::volumioRetrieveVolumeLevels');
+  return this.stateMachine.getcurrentVolume();
 };
 
 CoreCommandRouter.prototype.setStartupVolume = function () {
-    this.pushConsoleMessage('CoreCommandRouter::volumiosetStartupVolume');
-    if (this.volumeControl){
-        return this.volumeControl.setStartupVolume();
-    }
+  this.pushConsoleMessage('CoreCommandRouter::volumiosetStartupVolume');
+  if (this.volumeControl) {
+    return this.volumeControl.setStartupVolume();
+  }
 };
 
 CoreCommandRouter.prototype.writeVolumeStatusFiles = function (vol) {
-
-	if (vol.mute !== undefined && vol.mute === true) {
-		this.executeWriteVolumeStatusFiles(0);
-	} else if (vol && vol.vol && typeof vol.vol == 'number') {
-        this.executeWriteVolumeStatusFiles(vol.vol);
-	} else {
-        this.executeWriteVolumeStatusFiles(100);
-	}
+  if (vol.mute !== undefined && vol.mute === true) {
+    this.executeWriteVolumeStatusFiles(0);
+  } else if (vol && vol.vol && typeof vol.vol === 'number') {
+    this.executeWriteVolumeStatusFiles(vol.vol);
+  } else {
+    this.executeWriteVolumeStatusFiles(100);
+  }
 };
 
 CoreCommandRouter.prototype.executeWriteVolumeStatusFiles = function (value) {
-    fs.writeFile('/tmp/volume', value, function (err) {
-        if (err) {
-        	this.logger.error('Could not save Volume value to status file: ' + err);
-		}
-    });
+  fs.writeFile('/tmp/volume', value, function (err) {
+    if (err) {
+      this.logger.error('Could not save Volume value to status file: ' + err);
+    }
+  });
 };
 
-
 CoreCommandRouter.prototype.addCallback = function (name, callback) {
-	if (this.callbacks[name] == undefined) {
-		this.callbacks[name] = [];
-	}
-	this.callbacks[name].push(callback);
-	//this.logger.debug("Total " + callbacks[name].length + " callbacks for " + name);
+  if (this.callbacks[name] == undefined) {
+    this.callbacks[name] = [];
+  }
+  this.callbacks[name].push(callback);
+  // this.logger.debug("Total " + callbacks[name].length + " callbacks for " + name);
 };
 
 CoreCommandRouter.prototype.callCallback = function (name, data) {
-	var self = this;
-	var calls = this.callbacks[name];
-	if (calls != undefined) {
-		var nCalls = calls.length;
-		for (var i = 0; i < nCalls; i++) {
-			var func = this.callbacks[name][i];
-			try {
-				func(data);
-			} catch (e) {
-				self.logger.error("Help! Some callbacks for " + name + " are crashing!");
-				self.logger.error(e);
-			}
-		}
-	} else {
-		self.logger.debug("No callbacks for " + name);
-	}
+  var self = this;
+  var calls = this.callbacks[name];
+  if (calls != undefined) {
+    var nCalls = calls.length;
+    for (var i = 0; i < nCalls; i++) {
+      var func = this.callbacks[name][i];
+      try {
+        func(data);
+      } catch (e) {
+        self.logger.error('Help! Some callbacks for ' + name + ' are crashing!');
+        self.logger.error(e);
+      }
+    }
+  } else {
+    self.logger.debug('No callbacks for ' + name);
+  }
 };
 
 // Volumio Add Queue Uids
 CoreCommandRouter.prototype.volumioAddQueueUids = function (arrayUids) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioAddQueueUids');
-	return this.musicLibrary.addQueueUids(arrayUids);
+  this.pushConsoleMessage('CoreCommandRouter::volumioAddQueueUids');
+  return this.musicLibrary.addQueueUids(arrayUids);
 };
 
 // TODO CLEANUP THIS FUNCTION
 CoreCommandRouter.prototype.volumioGetLibraryFilters = function (sUid) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetLibraryFilters');
-	return this.musicLibrary.getIndex(sUid);
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetLibraryFilters');
+  return this.musicLibrary.getIndex(sUid);
 };
 
 // Volumio Browse Library
 CoreCommandRouter.prototype.volumioGetLibraryListing = function (sUid, objOptions) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetLibraryListing');
-	return this.musicLibrary.getListing(sUid, objOptions);
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetLibraryListing');
+  return this.musicLibrary.getListing(sUid, objOptions);
 };
 
 // Volumio Browse Sources
 CoreCommandRouter.prototype.volumioGetBrowseSources = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetBrowseSources');
-	return this.musicLibrary.getBrowseSources();
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetBrowseSources');
+  return this.musicLibrary.getBrowseSources();
 };
 
 CoreCommandRouter.prototype.volumioGetVisibleBrowseSources = function () {
-    this.pushConsoleMessage('CoreCommandRouter::volumioGetVisibleSources');
-    return this.musicLibrary.getVisibleBrowseSources();
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetVisibleSources');
+  return this.musicLibrary.getVisibleBrowseSources();
 };
 
 CoreCommandRouter.prototype.volumioAddToBrowseSources = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioAddToBrowseSources' + data);
-	return this.musicLibrary.addToBrowseSources(data);
+  this.pushConsoleMessage('CoreCommandRouter::volumioAddToBrowseSources' + data);
+  return this.musicLibrary.addToBrowseSources(data);
 };
 
 CoreCommandRouter.prototype.volumioRemoveToBrowseSources = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioRemoveToBrowseSources' + data);
-	return this.musicLibrary.removeBrowseSource(data);
+  this.pushConsoleMessage('CoreCommandRouter::volumioRemoveToBrowseSources' + data);
+  return this.musicLibrary.removeBrowseSource(data);
 };
 
-CoreCommandRouter.prototype.volumioUpdateToBrowseSources = function (name,data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioUpdateToBrowseSources');
-	return this.musicLibrary.updateBrowseSources(name,data);
+CoreCommandRouter.prototype.volumioUpdateToBrowseSources = function (name, data) {
+  this.pushConsoleMessage('CoreCommandRouter::volumioUpdateToBrowseSources');
+  return this.musicLibrary.updateBrowseSources(name, data);
 };
 
 CoreCommandRouter.prototype.setSourceActive = function (data) {
-    this.pushConsoleMessage('CoreCommandRouter::volumiosetSourceActive' + data);
-    return this.musicLibrary.setSourceActive(data);
+  this.pushConsoleMessage('CoreCommandRouter::volumiosetSourceActive' + data);
+  return this.musicLibrary.setSourceActive(data);
 };
 // Volumio Get Playlist Index
 CoreCommandRouter.prototype.volumioGetPlaylistIndex = function (sUid) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioGetPlaylistIndex');
-	return this.playlistFS.getIndex(sUid);
+  this.pushConsoleMessage('CoreCommandRouter::volumioGetPlaylistIndex');
+  return this.playlistFS.getIndex(sUid);
 };
 
 // Service Update Tracklist
 CoreCommandRouter.prototype.serviceUpdateTracklist = function (sService) {
-	this.pushConsoleMessage('CoreCommandRouter::serviceUpdateTracklist');
-	var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
-	return thisPlugin.rebuildTracklist();
+  this.pushConsoleMessage('CoreCommandRouter::serviceUpdateTracklist');
+  var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  return thisPlugin.rebuildTracklist();
 };
 
 // Start WirelessScan
 CoreCommandRouter.prototype.volumiowirelessscan = function () {
-	this.pushConsoleMessage('CoreCommandRouter::StartWirelessScan');
-	var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
-	return thisPlugin.scanWirelessNetworks();
+  this.pushConsoleMessage('CoreCommandRouter::StartWirelessScan');
+  var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  return thisPlugin.scanWirelessNetworks();
 };
 
 // Push WirelessScan Results (TODO SEND VIA WS)
 CoreCommandRouter.prototype.volumiopushwirelessnetworks = function (results) {
-	this.pushConsoleMessage(results);
+  this.pushConsoleMessage(results);
 };
 
 // Volumio Import Playlists
 CoreCommandRouter.prototype.volumioImportServicePlaylists = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioImportServicePlaylists');
-	return this.playlistFS.importServicePlaylists();
+  this.pushConsoleMessage('CoreCommandRouter::volumioImportServicePlaylists');
+  return this.playlistFS.importServicePlaylists();
 };
 
 // Volumio Search
 CoreCommandRouter.prototype.volumioSearch = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::Search '+data);
-	var asd = this.musicLibrary.search(data);
+  this.pushConsoleMessage('CoreCommandRouter::Search ' + data);
+  var asd = this.musicLibrary.search(data);
 
-	return this.musicLibrary.search(data);
+  return this.musicLibrary.search(data);
 };
 
 // Methods usually called by the State Machine --------------------------------------------------------------------
 
 CoreCommandRouter.prototype.volumioPushState = function (state) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPushState');
-	this.executeOnPlugin('system_controller', 'volumiodiscovery', 'saveDeviceInfo', state);
-	// Announce new player state to each client interface
-	var self = this;
-	var res = libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushState === "function")
-				return thisInterface.pushState(state);
-		})
-	);
-	self.callCallback("volumioPushState", state);
-	return res;
+  this.pushConsoleMessage('CoreCommandRouter::volumioPushState');
+  this.executeOnPlugin('system_controller', 'volumiodiscovery', 'saveDeviceInfo', state);
+  // Announce new player state to each client interface
+  var self = this;
+  var res = libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushState === 'function') { return thisInterface.pushState(state); }
+    })
+  );
+  self.callCallback('volumioPushState', state);
+  return res;
 };
 
 CoreCommandRouter.prototype.volumioResetState = function () {
-	this.pushConsoleMessage('CoreCommandRouter::volumioResetState');
-	return this.stateMachine.resetVolumioState();
+  this.pushConsoleMessage('CoreCommandRouter::volumioResetState');
+  return this.stateMachine.resetVolumioState();
 };
 
 CoreCommandRouter.prototype.volumioPushQueue = function (queue) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPushQueue');
+  this.pushConsoleMessage('CoreCommandRouter::volumioPushQueue');
 
-	// Announce new player queue to each client interface
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushQueue === "function")
-				return thisInterface.pushQueue(queue);
-		})
-	);
+  // Announce new player queue to each client interface
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushQueue === 'function') { return thisInterface.pushQueue(queue); }
+    })
+  );
 };
 
 // Clear-Add-Play
 CoreCommandRouter.prototype.serviceClearAddPlayTracks = function (arrayTrackIds, sService) {
-	this.pushConsoleMessage('CoreCommandRouter::serviceClearAddPlayTracks');
-    if (sService != undefined) {
-        var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  this.pushConsoleMessage('CoreCommandRouter::serviceClearAddPlayTracks');
+  if (sService != undefined) {
+    var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
 
-        if (thisPlugin != undefined && typeof thisPlugin.clearAddPlayTracks === "function") {
-            return thisPlugin.clearAddPlayTracks(arrayTrackIds);
-        } else {
-            this.logger.error('WARNING: No clearAddPlayTracks method for service ' + sService);
-        }
+    if (thisPlugin != undefined && typeof thisPlugin.clearAddPlayTracks === 'function') {
+      return thisPlugin.clearAddPlayTracks(arrayTrackIds);
+    } else {
+      this.logger.error('WARNING: No clearAddPlayTracks method for service ' + sService);
     }
+  }
 };
 
 // MPD Stop
 CoreCommandRouter.prototype.serviceStop = function (sService) {
-
-    if (sService != undefined) {
-        this.pushConsoleMessage('CoreCommandRouter::serviceStop');
-        var thisPlugin = this.getMusicPlugin(sService);
-        if (thisPlugin != undefined && typeof thisPlugin.stop === "function") {
-            return thisPlugin.stop();
-        } else {
-            this.logger.error('WARNING: No stop method for service ' + sService);
-        }
-
+  if (sService != undefined) {
+    this.pushConsoleMessage('CoreCommandRouter::serviceStop');
+    var thisPlugin = this.getMusicPlugin(sService);
+    if (thisPlugin != undefined && typeof thisPlugin.stop === 'function') {
+      return thisPlugin.stop();
     } else {
-        this.pushConsoleMessage('Received STOP, but no service to execute it');
-        return libQ.resolve('');
+      this.logger.error('WARNING: No stop method for service ' + sService);
     }
+  } else {
+    this.pushConsoleMessage('Received STOP, but no service to execute it');
+    return libQ.resolve('');
+  }
 };
 
 // MPD Pause
 CoreCommandRouter.prototype.servicePause = function (sService) {
-    this.pushConsoleMessage('CoreCommandRouter::servicePause');
+  this.pushConsoleMessage('CoreCommandRouter::servicePause');
 
-    var thisPlugin = this.getMusicPlugin(sService);
-    if (thisPlugin != undefined && typeof thisPlugin.pause === "function") {
-        return thisPlugin.pause();
-    } else {
-        this.logger.error('WARNING: No pause method for service ' + sService);
-    }
+  var thisPlugin = this.getMusicPlugin(sService);
+  if (thisPlugin != undefined && typeof thisPlugin.pause === 'function') {
+    return thisPlugin.pause();
+  } else {
+    this.logger.error('WARNING: No pause method for service ' + sService);
+  }
 };
 
 // MPD Resume
 CoreCommandRouter.prototype.serviceResume = function (sService) {
-    this.pushConsoleMessage('CoreCommandRouter::serviceResume');
+  this.pushConsoleMessage('CoreCommandRouter::serviceResume');
 
-    var thisPlugin = this.getMusicPlugin(sService);
-    var state=this.stateMachine.getState();
+  var thisPlugin = this.getMusicPlugin(sService);
+  var state = this.stateMachine.getState();
 
-    if(state==='stop')
-    {
-        if (thisPlugin != undefined && typeof thisPlugin.clearAddPlayTracks === "function") {
-            thisPlugin.clearAddPlayTracks();
-        }
+  if (state === 'stop') {
+    if (thisPlugin != undefined && typeof thisPlugin.clearAddPlayTracks === 'function') {
+      thisPlugin.clearAddPlayTracks();
     }
-    if (thisPlugin != undefined && typeof thisPlugin.resume === "function") {
-        return thisPlugin.resume();
-    }
+  }
+  if (thisPlugin != undefined && typeof thisPlugin.resume === 'function') {
+    return thisPlugin.resume();
+  }
 };
 
 // Methods usually called by the service controllers --------------------------------------------------------------
 
 CoreCommandRouter.prototype.servicePushState = function (state, sService) {
-    this.pushConsoleMessage('CoreCommandRouter::servicePushState');
-    return this.stateMachine.syncState(state, sService);
+  this.pushConsoleMessage('CoreCommandRouter::servicePushState');
+  return this.stateMachine.syncState(state, sService);
 };
 
 CoreCommandRouter.prototype.getMusicPlugin = function (sService) {
-    // Check first if its a music service
-    var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
-    if (!thisPlugin) {
-        // check if its a audio interface
-        thisPlugin = this.pluginManager.getPlugin('audio_interface', sService);
-    }
+  // Check first if its a music service
+  var thisPlugin = this.pluginManager.getPlugin('music_service', sService);
+  if (!thisPlugin) {
+    // check if its a audio interface
+    thisPlugin = this.pluginManager.getPlugin('audio_interface', sService);
+  }
 
-    return thisPlugin
+  return thisPlugin;
 };
 
 // Methods usually called by the music library ---------------------------------------------------------------------
 
 // Get tracklists from all services and return them as an array
 CoreCommandRouter.prototype.getAllTracklists = function () {
-	this.pushConsoleMessage('CoreCommandRouter::getAllTracklists');
+  this.pushConsoleMessage('CoreCommandRouter::getAllTracklists');
 
-	// This is the synchronous way to get libraries, which waits for each controller to return its tracklist before continuing
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('music_service'), function (sService) {
-			var thisService = self.pluginManager.getPlugin('music_service', sService);
-			return thisService.getTracklist();
-		})
-	);
+  // This is the synchronous way to get libraries, which waits for each controller to return its tracklist before continuing
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('music_service'), function (sService) {
+      var thisService = self.pluginManager.getPlugin('music_service', sService);
+      return thisService.getTracklist();
+    })
+  );
 };
 
 // Volumio Add Queue Items
 CoreCommandRouter.prototype.addQueueItems = function (arrayItems) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioAddQueueItems');
+  this.pushConsoleMessage('CoreCommandRouter::volumioAddQueueItems');
 
-
-	return this.stateMachine.addQueueItems(arrayItems);
+  return this.stateMachine.addQueueItems(arrayItems);
 };
 CoreCommandRouter.prototype.replaceAndPlay = function (data) {
-        var self=this;
-	var defer = libQ.defer();
-	var self = this;
-	this.pushConsoleMessage('CoreCommandRouter::volumioReplaceandPlayItems');
+  var self = this;
+  var defer = libQ.defer();
+  var self = this;
+  this.pushConsoleMessage('CoreCommandRouter::volumioReplaceandPlayItems');
 
-	this.stateMachine.clearQueue();
+  this.stateMachine.clearQueue();
 
-    if (data.uri != undefined) {
-    	if (data.uri.indexOf('playlists/') >= 0 && data.uri.indexOf('://') == -1) {
-            this.playPlaylist(data.title);
-            defer.resolve();
-		} else {
-            this.stateMachine.addQueueItems(data)
-                .then((e)=> {
-                this.volumioPlay(e.firstItemIndex);
-            	defer.resolve();
-        	});
-        }
-    } else if (data.list && data.index !== undefined) {
-        this.stateMachine.addQueueItems(data.list)
-            .then(()=>{
-                this.volumioPlay(data.index);
-        		defer.resolve();
-            });
-    } else if (data.item!=undefined && data.item.uri!=undefined) {
-        this.stateMachine.addQueueItems(data.item)
-            .then((e)=>{
-                this.volumioPlay(e.firstItemIndex);
-        		defer.resolve();
-            });
+  if (data.uri != undefined) {
+    if (data.uri.indexOf('playlists/') >= 0 && data.uri.indexOf('://') == -1) {
+      this.playPlaylist(data.title);
+      defer.resolve();
     } else {
-    	self.logger.error('Could not Replace and Play Item');
-        defer.reject('Could not Replace and Play Item');
-	}
+      this.stateMachine.addQueueItems(data)
+        .then((e) => {
+          this.volumioPlay(e.firstItemIndex);
+          defer.resolve();
+        });
+    }
+  } else if (data.list && data.index !== undefined) {
+    this.stateMachine.addQueueItems(data.list)
+      .then(() => {
+        this.volumioPlay(data.index);
+        defer.resolve();
+      });
+  } else if (data.item != undefined && data.item.uri != undefined) {
+    this.stateMachine.addQueueItems(data.item)
+      .then((e) => {
+        this.volumioPlay(e.firstItemIndex);
+        defer.resolve();
+      });
+  } else {
+    self.logger.error('Could not Replace and Play Item');
+    defer.reject('Could not Replace and Play Item');
+  }
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.replaceAndPlayCue = function (arrayItems) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioReplaceandPlayCue');
-    this.stateMachine.clearQueue();
+  this.pushConsoleMessage('CoreCommandRouter::volumioReplaceandPlayCue');
+  this.stateMachine.clearQueue();
 
-    if (arrayItems.uri != undefined && arrayItems.uri.indexOf('playlists/') >= 0) {
-        return this.playPlaylist(arrayItems.title)
-    } else  {
-        return this.stateMachine.addQueueItems(arrayItems);
-    }
+  if (arrayItems.uri != undefined && arrayItems.uri.indexOf('playlists/') >= 0) {
+    return this.playPlaylist(arrayItems.title);
+  } else {
+    return this.stateMachine.addQueueItems(arrayItems);
+  }
 };
-
-
 
 // Volumio Check Favourites
 CoreCommandRouter.prototype.checkFavourites = function (data) {
-	var self = this;
-	//self.pushConsoleMessage('CoreCommandRouter::volumioAddQueueItems');
+  var self = this;
+  // self.pushConsoleMessage('CoreCommandRouter::volumioAddQueueItems');
 
-	return self.stateMachine.checkFavourites(data);
+  return self.stateMachine.checkFavourites(data);
 };
 
 // Volumio Emit Favourites
 CoreCommandRouter.prototype.emitFavourites = function (msg) {
-	var plugin = this.pluginManager.getPlugin('user_interface', 'websocket');
-	plugin.emitFavourites(msg);
+  var plugin = this.pluginManager.getPlugin('user_interface', 'websocket');
+  plugin.emitFavourites(msg);
 };
 
 // Volumio Play Playlist
 CoreCommandRouter.prototype.playPlaylist = function (data) {
-	var self = this;
-	return self.playListManager.playPlaylist(data);
+  var self = this;
+  return self.playListManager.playPlaylist(data);
 };
 
 // Utility functions ---------------------------------------------------------------------------------------------
@@ -530,18 +514,22 @@ CoreCommandRouter.prototype.playPlaylist = function (data) {
  * @returns {{name: *, uuid: *, time: string}}
  */
 CoreCommandRouter.prototype.getId = function () {
-	var self = this;
+  var self = this;
 
-	var file = fs.readJsonSync("data/configuration/system_controller/system/config.json");
+  var file = fs.readJsonSync('data/configuration/system_controller/system/config.json');
 
-	var name = file.playerName.value;
-	var uuid = file.uuid.value;
-	var date = new Date();
-	var time = date.getDate() + "/" + date.getMonth() + "/" + date.getFullYear() + " - " +
-			date.getHours() + ":" + date.getMinutes();
+  var name = file.playerName.value;
+  var uuid = file.uuid.value;
+  var date = new Date();
+  var time = date.getDate() + '/' + date.getMonth() + '/' + date.getFullYear() + ' - ' +
+    date.getHours() + ':' + date.getMinutes();
 
-	return {'name': name, 'uuid': uuid, 'time': time};
-}
+  return {
+    'name': name,
+    'uuid': uuid,
+    'time': time
+  };
+};
 
 /**
  * Returns as an object the configuration file for a given plugin
@@ -550,18 +538,18 @@ CoreCommandRouter.prototype.getId = function () {
  * @returns {*|string}
  */
 CoreCommandRouter.prototype.getPlugConf = function (category, plugin) {
-	var cName = category;
-	var name = plugin;
-	try{
-		var config = fs.readJsonSync(("/data/configuration/" + cName + "/" +
-			name + "/" + "config.json"), 'utf-8',
-			{throws: false});
-	}
-	catch(e) {
-		var config ="";
-	}
-	return config;
-}
+  var cName = category;
+  var name = plugin;
+  try {
+    var config = fs.readJsonSync(('/data/configuration/' + cName + '/' +
+      name + '/' + 'config.json'), 'utf-8', {
+      throws: false
+    });
+  } catch (e) {
+    var config = '';
+  }
+  return config;
+};
 
 /**
  * Returns an array of plugins with status and configuration included, given a category
@@ -570,48 +558,56 @@ CoreCommandRouter.prototype.getPlugConf = function (category, plugin) {
  * @returns {Array}
  */
 CoreCommandRouter.prototype.catPluginsConf = function (category, array) {
-	var self = this;
-	var plugins = array;
-	var plugConf = [];
-	for (var j = 0; j < plugins.length; j++) {
-		var name = plugins[j].name;
-		var status = plugins[j].enabled;
-		var config = self.getPlugConf(category, name);
-		plugConf.push({name, status, config});
-	}
-	return plugConf;
-}
+  var self = this;
+  var plugins = array;
+  var plugConf = [];
+  for (var j = 0; j < plugins.length; j++) {
+    var name = plugins[j].name;
+    var status = plugins[j].enabled;
+    var config = self.getPlugConf(category, name);
+    plugConf.push({
+      name,
+      status,
+      config
+    });
+  }
+  return plugConf;
+};
 
 /**
  * Returns the configuration of every plugins, sorted by category
  * @returns {Array}
  */
 CoreCommandRouter.prototype.getPluginsConf = function () {
-	var self = this;
-	var paths = self.pluginManager.getPluginsMatrix();
-	var confs = [];
-	for (var i = 0; i < paths.length; i++){
-		var cName = paths[i].cName;
-		var plugins = paths[i].catPlugin;
-		var plugConf = self.catPluginsConf(cName, plugins);
-		confs.push({cName, plugConf});
-	}
+  var self = this;
+  var paths = self.pluginManager.getPluginsMatrix();
+  var confs = [];
+  for (var i = 0; i < paths.length; i++) {
+    var cName = paths[i].cName;
+    var plugins = paths[i].catPlugin;
+    var plugConf = self.catPluginsConf(cName, plugins);
+    confs.push({
+      cName,
+      plugConf
+    });
+  }
 
-	var identification = self.getId();
-	return confs;
-}
+  var identification = self.getId();
+  return confs;
+};
 
 /**
  * Writes the configuration of every plugin into a json file
  */
 CoreCommandRouter.prototype.writePluginsConf = function () {
-	var self = this;
-	var confs = self.getPluginsConf();
+  var self = this;
+  var confs = self.getPluginsConf();
 
-	var file = "/data/configuration/generalConfig";
-	fs.outputJson(file, confs, function (err) {
-		console.log(err)})
-}
+  var file = '/data/configuration/generalConfig';
+  fs.outputJson(file, confs, function (err) {
+    console.log(err);
+  });
+};
 
 /**
  * restores plugins configuration, given in the request, returns a promise
@@ -619,29 +615,29 @@ CoreCommandRouter.prototype.writePluginsConf = function () {
  * @returns {*}
  */
 CoreCommandRouter.prototype.restorePluginsConf = function (request) {
-	var self = this;
+  var self = this;
 
-	var defer = libQ.defer();
-	var backup = request;
-	var current = self.pluginManager.getPluginsMatrix();
-	var usefulConfs = [];
+  var defer = libQ.defer();
+  var backup = request;
+  var current = self.pluginManager.getPluginsMatrix();
+  var usefulConfs = [];
 
-	for(var i = 0; i < current.length; i++){
-		var j = 0;
-		while(j < backup.length && current[i].cName != backup[j].cName){
-			j++;
-		}
-		if(j < backup.length) {
-			var availPlugins = current[i].catPlugin;
-			var backPlugins = backup[j];
-			usefulConfs.push(self.usefulBackupConfs(availPlugins, backPlugins));
-		}
-	}
+  for (var i = 0; i < current.length; i++) {
+    var j = 0;
+    while (j < backup.length && current[i].cName != backup[j].cName) {
+      j++;
+    }
+    if (j < backup.length) {
+      var availPlugins = current[i].catPlugin;
+      var backPlugins = backup[j];
+      usefulConfs.push(self.usefulBackupConfs(availPlugins, backPlugins));
+    }
+  }
 
-	defer.resolve(usefulConfs);
-	self.writeConfs(usefulConfs);
-	return defer.promise;
-}
+  defer.resolve(usefulConfs);
+  self.writeConfs(usefulConfs);
+  return defer.promise;
+};
 
 /**
  * check in the backups for plugins already installed, if it remains with plugins in the backup
@@ -651,50 +647,53 @@ CoreCommandRouter.prototype.restorePluginsConf = function (request) {
  * @returns {{cName: *, plugConf: Array}}
  */
 CoreCommandRouter.prototype.usefulBackupConfs = function (currArray, backArray) {
-	var self = this;
-	var availPlugins = currArray;
-	var catName = backArray.cName;
-	var backPlugins = backArray.plugConf;
-	var backNum = backPlugins.length;
-	var i = 0;
+  var self = this;
+  var availPlugins = currArray;
+  var catName = backArray.cName;
+  var backPlugins = backArray.plugConf;
+  var backNum = backPlugins.length;
+  var i = 0;
 
-	var existingPlug = [];
-	while (i < availPlugins.length && backNum > 0) {
-		var j = 0;
-		while (j < backPlugins.length && availPlugins[i].name != backPlugins[j].name) {
-			j++;
-		}
-		if(j < backPlugins.length){
-			existingPlug.push(backPlugins[j]);
-			backNum--;
-			backPlugins.splice(j, 1);
-		}
-		i++;
-	}
-	if (backNum > 0){
-		self.installBackupPlugins(catName, backPlugins);
-	}
-	return {'cName': catName, 'plugConf': existingPlug};
-}
+  var existingPlug = [];
+  while (i < availPlugins.length && backNum > 0) {
+    var j = 0;
+    while (j < backPlugins.length && availPlugins[i].name != backPlugins[j].name) {
+      j++;
+    }
+    if (j < backPlugins.length) {
+      existingPlug.push(backPlugins[j]);
+      backNum--;
+      backPlugins.splice(j, 1);
+    }
+    i++;
+  }
+  if (backNum > 0) {
+    self.installBackupPlugins(catName, backPlugins);
+  }
+  return {
+    'cName': catName,
+    'plugConf': existingPlug
+  };
+};
 
 /**
  * writes each config.json in the appropriate folder
  * @param data is a json with useful plugin's configuration files, sorted by category
  */
 CoreCommandRouter.prototype.writeConfs = function (data) {
-	var self = this;
+  var self = this;
 
-	var usefulConfs = data;
-	for(var i = 0; i < usefulConfs.length; i++){
-		for(var j = 0; j < usefulConfs[i].plugConf.length; j++){
-			if (usefulConfs[i].plugConf[j].config != "") {
-				var path = "/data/configuration/" + usefulConfs[i].cName + "/" +
-					usefulConfs[i].plugConf[j].name + "/config.json";
-				fs.outputJsonSync(path, usefulConfs[i].plugConf[j].config);
-			}
-		}
-	}
-}
+  var usefulConfs = data;
+  for (var i = 0; i < usefulConfs.length; i++) {
+    for (var j = 0; j < usefulConfs[i].plugConf.length; j++) {
+      if (usefulConfs[i].plugConf[j].config != '') {
+        var path = '/data/configuration/' + usefulConfs[i].cName + '/' +
+          usefulConfs[i].plugConf[j].name + '/config.json';
+        fs.outputJsonSync(path, usefulConfs[i].plugConf[j].config);
+      }
+    }
+  }
+};
 
 /**
  * self explanatory
@@ -703,13 +702,10 @@ CoreCommandRouter.prototype.writeConfs = function (data) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.min = function (a, b) {
-	var self = this;
+  var self = this;
 
-	if (a < b)
-		return a;
-	else
-		return b;
-}
+  if (a < b) { return a; } else { return b; }
+};
 
 /**
  * checks if remaining backed up plugins are available for installation, installs them if found
@@ -717,35 +713,38 @@ CoreCommandRouter.prototype.min = function (a, b) {
  * @param array array of plugins
  */
 CoreCommandRouter.prototype.installBackupPlugins = function (name, array) {
-	var self = this;
+  var self = this;
 
-	var availablePlugins = self.pluginManager.getAvailablePlugins();
-	var cat = [];
-	availablePlugins.then(function (available) {
-		cat = available.categories;
-		var plug = [];
+  var availablePlugins = self.pluginManager.getAvailablePlugins();
+  var cat = [];
+  availablePlugins.then(function (available) {
+    cat = available.categories;
+    var plug = [];
 
-		for (var i = 0; i < cat.length; i++) {
-			if (cat[i].name == name) {
-				plug = cat[i].plugins;
-			}
-		}
+    for (var i = 0; i < cat.length; i++) {
+      if (cat[i].name == name) {
+        plug = cat[i].plugins;
+      }
+    }
 
-		if (plug.length > 0) {
-			for (var j = 0; j < array.length; j++) {
-				var k = 0;
-				while (k < plug.length && array[j].name != plug[k].name) {
-					k++;
-				}
-				if (k < plug.length) {
-					self.logger.info("Backup: installing plugin: " + plug[k].name);
-					self.pluginManager.installPlugin(plug[k].url);
-				}
-			}
-			self.writeConfs([{'cName': name, 'plugConf': array}]);
-		}
-	});
-}
+    if (plug.length > 0) {
+      for (var j = 0; j < array.length; j++) {
+        var k = 0;
+        while (k < plug.length && array[j].name != plug[k].name) {
+          k++;
+        }
+        if (k < plug.length) {
+          self.logger.info('Backup: installing plugin: ' + plug[k].name);
+          self.pluginManager.installPlugin(plug[k].url);
+        }
+      }
+      self.writeConfs([{
+        'cName': name,
+        'plugConf': array
+      }]);
+    }
+  });
+};
 
 /**
  * loads the backup for the selected playlist, according to request, returns it
@@ -753,51 +752,62 @@ CoreCommandRouter.prototype.installBackupPlugins = function (name, array) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.loadBackup = function (request) {
-	var self = this;
+  var self = this;
 
-	var defer = libQ.defer();
+  var defer = libQ.defer();
 
-	var data = [];
+  var data = [];
 
-	self.logger.info("Backup: retrieving "+ request.type + " backup");
+  self.logger.info('Backup: retrieving ' + request.type + ' backup');
 
-	if(request.type == "playlist"){
-		var identification = self.getId();
-		data = {'id' : identification, 'backup': self.loadPlaylistsBackup()};
-		defer.resolve(data);
-	}else if (request.type == "radio-favourites" || request.type == "favourites"
-	|| request.type == "my-web-radio"){
-		var identification = self.getId();
-		data = {'id' : identification, 'backup': self.loadFavBackup(request.type)};
-		defer.resolve(data);
-	} else{
-		self.logger.info("Backup: request not accepted, unexisting category");
-		defer.resolve(undefined);
-	}
+  if (request.type == 'playlist') {
+    var identification = self.getId();
+    data = {
+      'id': identification,
+      'backup': self.loadPlaylistsBackup()
+    };
+    defer.resolve(data);
+  } else if (request.type == 'radio-favourites' || request.type == 'favourites' ||
+    request.type == 'my-web-radio') {
+    var identification = self.getId();
+    data = {
+      'id': identification,
+      'backup': self.loadFavBackup(request.type)
+    };
+    defer.resolve(data);
+  } else {
+    self.logger.info('Backup: request not accepted, unexisting category');
+    defer.resolve(undefined);
+  }
 
-	return defer.promise;
-}
+  return defer.promise;
+};
 
 /**
  * load backup for the playlists
  * @returns {Array}
  */
 CoreCommandRouter.prototype.loadPlaylistsBackup = function () {
-	var self = this;
+  var self = this;
 
-	//data=[{"name": "", "content": []}]
-	var data = [];
-	var playlists = self.playListManager.retrievePlaylists();
+  // data=[{"name": "", "content": []}]
+  var data = [];
+  var playlists = self.playListManager.retrievePlaylists();
 
-	for (var i = 0; i < playlists.length; i++){
-		var name = playlists[i];
-		var path = self.playListManager.playlistFolder + name;
-		var songs = fs.readJsonSync(path, {throws: false});
-		data.push({"name": name, "content": songs});
-	}
+  for (var i = 0; i < playlists.length; i++) {
+    var name = playlists[i];
+    var path = self.playListManager.playlistFolder + name;
+    var songs = fs.readJsonSync(path, {
+      throws: false
+    });
+    data.push({
+      'name': name,
+      'content': songs
+    });
+  }
 
-	return data;
-}
+  return data;
+};
 
 /**
  * load backup for the selected playlist in favourites
@@ -805,124 +815,129 @@ CoreCommandRouter.prototype.loadPlaylistsBackup = function () {
  * @returns {Array}
  */
 CoreCommandRouter.prototype.loadFavBackup = function (type) {
-	var self = this;
+  var self = this;
 
-	var path = self.playListManager.favouritesPlaylistFolder;
-	var data = [];
+  var path = self.playListManager.favouritesPlaylistFolder;
+  var data = [];
 
-	try{
-		data = fs.readJsonSync(path + type, {throws: false});
-	}catch(e){
-		self.logger.info("No "+ type + " in favourites folder");
-	};
+  try {
+    data = fs.readJsonSync(path + type, {
+      throws: false
+    });
+  } catch (e) {
+    self.logger.info('No ' + type + ' in favourites folder');
+  }
 
-	return data;
-}
+  return data;
+};
 
 /**
  * writes the playlists and their content in a json
  */
 CoreCommandRouter.prototype.writePlaylistsBackup = function () {
-	var self = this;
+  var self = this;
 
-	var data = self.loadPlaylistsBackup();
+  var data = self.loadPlaylistsBackup();
 
-	var file = "/data/configuration/playlists";
-	fs.outputJsonSync(file, data);
-}
+  var file = '/data/configuration/playlists';
+  fs.outputJsonSync(file, data);
+};
 
 /**
  * writes radio and songs favourites in a json
  */
 CoreCommandRouter.prototype.writeFavouritesBackup = function () {
-	var self = this;
+  var self = this;
 
-	var data = self.loadFavBackup("favourites");
-	var radio = self.loadFavBackup("radio-favourites");
-	var myRadio = self.loadFavBackup("my-web-radio");
+  var data = self.loadFavBackup('favourites');
+  var radio = self.loadFavBackup('radio-favourites');
+  var myRadio = self.loadFavBackup('my-web-radio');
 
-	var favourites = {"songs": data, "radios": radio, "myRadios": myRadio};
+  var favourites = {
+    'songs': data,
+    'radios': radio,
+    'myRadios': myRadio
+  };
 
-	var file = "/data/configuration/favourites";
-	fs.outputJsonSync(file, favourites);
-}
+  var file = '/data/configuration/favourites';
+  fs.outputJsonSync(file, favourites);
+};
 
 /**
  * Restores the playlist from the available local backup file
  */
 CoreCommandRouter.prototype.restorePlaylistBackup = function () {
-	var self = this;
-	var check = self.checkBackup("playlists");
-	var path = self.playListManager.playlistFolder;
-	var isbackup = check[0];
+  var self = this;
+  var check = self.checkBackup('playlists');
+  var path = self.playListManager.playlistFolder;
+  var isbackup = check[0];
 
-	if(isbackup){
-		self.restorePlaylist({'type': "playlist", 'backup': backup});
-	}
-}
+  if (isbackup) {
+    self.restorePlaylist({
+      'type': 'playlist',
+      'backup': backup
+    });
+  }
+};
 
 /**
  * restores the default playlist specified in type, from the avilable local backup
  * @param type
  */
 CoreCommandRouter.prototype.restoreFavouritesBackup = function (type) {
-	var self = this;
+  var self = this;
 
-	var backup = self.checkBackup("favourites");
-	var isbackup = backup[0];
-	var path = self.playListManager.favouritesPlaylistFolder;
+  var backup = self.checkBackup('favourites');
+  var isbackup = backup[0];
+  var path = self.playListManager.favouritesPlaylistFolder;
 
-	if(isbackup){
-		var kind = self.checkFavouritesType(type, backup[1]);
-		var file = kind[0];
-		var data = kind[1];
-		self.restorePlaylist({'type': type, 'path': file, 'backup': data});
-	}
-}
+  if (isbackup) {
+    var kind = self.checkFavouritesType(type, backup[1]);
+    var file = kind[0];
+    var data = kind[1];
+    self.restorePlaylist({
+      'type': type,
+      'path': file,
+      'backup': data
+    });
+  }
+};
 
 /**
  * restores the playlist specified in req.type, given the data in req.backup and the eventual
  * @param req
  */
 CoreCommandRouter.prototype.restorePlaylist = function (req) {
-	var self = this;
-	var path = "";
-	var backup = req.backup;
+  var self = this;
+  var path = '';
+  var backup = req.backup;
 
-	if (req.type == "playlist") {
-		path = self.playListManager.playlistFolder;
-		self.logger.info("Backup: restoring playlists");
-		for (var i = 0; i < backup.length; i++) {
-			var name = backup[i].name;
-			var songs = backup[i].content;
-			fs.outputJsonSync(path + name, songs);
-		}
-	}
-	else if(req.type == "favourites" || req.type == "radio-favourites" ||
-		req.type == "my-web-radio"){
-		path = self.playListManager.favouritesPlaylistFolder + req.type;
-		try{
-			var fav = fs.readJsonSync(path);
-			backup = self.mergePlaylists(backup, fav);
-		}catch(e){
-			self.logger.info("Backup: no existing playlist for selected category");
-		};
-		self.logger.info("Backup: restoring " + req.type + "!");
-		fs.outputJsonSync(path, backup);
-	}
-	else
-		self.logger.info("Backup: impossible to restore data");
-}
+  if (req.type == 'playlist') {
+    path = self.playListManager.playlistFolder;
+    self.logger.info('Backup: restoring playlists');
+    for (var i = 0; i < backup.length; i++) {
+      var name = backup[i].name;
+      var songs = backup[i].content;
+      fs.outputJsonSync(path + name, songs);
+    }
+  } else if (req.type == 'favourites' || req.type == 'radio-favourites' ||
+    req.type == 'my-web-radio') {
+    path = self.playListManager.favouritesPlaylistFolder + req.type;
+    try {
+      var fav = fs.readJsonSync(path);
+      backup = self.mergePlaylists(backup, fav);
+    } catch (e) {
+      self.logger.info('Backup: no existing playlist for selected category');
+    }
+    self.logger.info('Backup: restoring ' + req.type + '!');
+    fs.outputJsonSync(path, backup);
+  } else { self.logger.info('Backup: impossible to restore data'); }
+};
 
-CoreCommandRouter.prototype.getPath = function (type){
-	if(type == "songs")
-		return "favourites";
-	else if (type == "radios")
-		return "radio-favourites";
-	else if (type == "myRadios")
-		return "my-web-radio";
-	return "";
-}
+CoreCommandRouter.prototype.getPath = function (type) {
+  if (type == 'songs') { return 'favourites'; } else if (type == 'radios') { return 'radio-favourites'; } else if (type == 'myRadios') { return 'my-web-radio'; }
+  return '';
+};
 
 /**
  * check if there's a backup for the given playlist, returns a boolean and the file
@@ -930,20 +945,20 @@ CoreCommandRouter.prototype.getPath = function (type){
  * @returns {*[]}
  */
 CoreCommandRouter.prototype.checkBackup = function (backup) {
-	var self = this;
-	var isbackup = false;
-	var file = [];
-	var path = "/data/configuration/" + backup;
+  var self = this;
+  var isbackup = false;
+  var file = [];
+  var path = '/data/configuration/' + backup;
 
-	try{
-		file = fs.readJsonSync(path);
-		isbackup = true;
-	}catch(e){
-		self.logger.info("Backup: no " + backup + " backup available");
-	};
+  try {
+    file = fs.readJsonSync(path);
+    isbackup = true;
+  } catch (e) {
+    self.logger.info('Backup: no ' + backup + ' backup available');
+  }
 
-	return [isbackup, file];
-}
+  return [isbackup, file];
+};
 
 /**
  * selects the type of a default playlist from a json, returns the path and a json with
@@ -953,27 +968,23 @@ CoreCommandRouter.prototype.checkBackup = function (backup) {
  * @returns {*[]}
  */
 CoreCommandRouter.prototype.checkFavouritesType = function (type, backup) {
-	var self = this;
-	var data = [];
-	var file = "";
+  var self = this;
+  var data = [];
+  var file = '';
 
-	if(type == "songs") {
-		data = backup.songs;
-		file = "favourites";
-	}
-	else if(type == "radios") {
-		data = backup.radios;
-		file = "radio-favourites";
-	}
-	else if(type == "myRadios") {
-		data = backup.myRadios;
-		file = "my-web-radio";
-	}
-	else
-		self.logger.info("Error: category non existent");
+  if (type == 'songs') {
+    data = backup.songs;
+    file = 'favourites';
+  } else if (type == 'radios') {
+    data = backup.radios;
+    file = 'radio-favourites';
+  } else if (type == 'myRadios') {
+    data = backup.myRadios;
+    file = 'my-web-radio';
+  } else { self.logger.info('Error: category non existent'); }
 
-	return [file, data];
-}
+  return [file, data];
+};
 
 /**
  * merges the backup with the current existing playlist, returns the whole
@@ -982,24 +993,24 @@ CoreCommandRouter.prototype.checkFavouritesType = function (type, backup) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.mergePlaylists = function (recent, old) {
-	var self = this;
-	var backup = recent;
-	var current = old;
+  var self = this;
+  var backup = recent;
+  var current = old;
 
-	for (var i = 0; i < current.length; i++){
-		var isthere = false;
-		for (var j = 0; j < backup.length; j++){
-			if (current[i].uri == backup[j].uri) {
-				isthere = true;
-			}
-		}
-		if (!isthere) {
-			backup.push(current[i]);
-		}
-	}
+  for (var i = 0; i < current.length; i++) {
+    var isthere = false;
+    for (var j = 0; j < backup.length; j++) {
+      if (current[i].uri == backup[j].uri) {
+        isthere = true;
+      }
+    }
+    if (!isthere) {
+      backup.push(current[i]);
+    }
+  }
 
-	return backup;
-}
+  return backup;
+};
 
 /**
  * manages the backup for playlists, saves or restores it according to value
@@ -1007,24 +1018,24 @@ CoreCommandRouter.prototype.mergePlaylists = function (recent, old) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.managePlaylists = function (value) {
-	var self = this;
+  var self = this;
 
-	var defer = libQ.defer();
+  var defer = libQ.defer();
 
-	if (value == 0){
-		setTimeout(function () {
-			self.writePlaylistsBackup();
-			defer.resolve();
-		}, 10000);
-	}else{
-		setTimeout(function () {
-			self.restorePlaylistBackup();
-			defer.resolve();
-		}, 10000);
-	}
+  if (value == 0) {
+    setTimeout(function () {
+      self.writePlaylistsBackup();
+      defer.resolve();
+    }, 10000);
+  } else {
+    setTimeout(function () {
+      self.restorePlaylistBackup();
+      defer.resolve();
+    }, 10000);
+  }
 
-	return defer.promise;
-}
+  return defer.promise;
+};
 
 /**
  * manages the backup for favourites, saves or restores it, according to value
@@ -1032,141 +1043,141 @@ CoreCommandRouter.prototype.managePlaylists = function (value) {
  * @returns {*}
  */
 CoreCommandRouter.prototype.manageFavourites = function (value) {
-	var self = this;
+  var self = this;
 
-	var defer = libQ.defer();
+  var defer = libQ.defer();
 
-	if (value == 0){
-		setTimeout(function () {
-			self.writeFavouritesBackup();
-			defer.resolve();
-		}, 10000);
-	}else{
-		setTimeout(function () {
-			self.restoreFavouritesBackup("songs");
-		}, 10000);
-		setTimeout(function () {
-			self.restoreFavouritesBackup("radios");
-		}, 10000);
-		setTimeout(function () {
-			self.restoreFavouritesBackup("myRadios");
-			defer.resolve();
-		}, 10000);
-	}
+  if (value == 0) {
+    setTimeout(function () {
+      self.writeFavouritesBackup();
+      defer.resolve();
+    }, 10000);
+  } else {
+    setTimeout(function () {
+      self.restoreFavouritesBackup('songs');
+    }, 10000);
+    setTimeout(function () {
+      self.restoreFavouritesBackup('radios');
+    }, 10000);
+    setTimeout(function () {
+      self.restoreFavouritesBackup('myRadios');
+      defer.resolve();
+    }, 10000);
+  }
 
-	return defer.promise;
-}
+  return defer.promise;
+};
 
 CoreCommandRouter.prototype.executeOnPlugin = function (type, name, method, data) {
-	this.pushConsoleMessage('CoreCommandRouter::executeOnPlugin: ' + name + ' , ' + method);
+  this.pushConsoleMessage('CoreCommandRouter::executeOnPlugin: ' + name + ' , ' + method);
 
-	var thisPlugin = this.pluginManager.getPlugin(type, name);
+  var thisPlugin = this.pluginManager.getPlugin(type, name);
 
-	if (thisPlugin != undefined)
-		if (thisPlugin[method]) {
-			return thisPlugin[method](data);
-		} else {
-			this.pushConsoleMessage('Error : CoreCommandRouter::executeOnPlugin: No method [' + method + '] in plugin ' + name);
-		}
-	else return undefined;
+  if (thisPlugin != undefined) {
+    if (thisPlugin[method]) {
+      return thisPlugin[method](data);
+    } else {
+      this.pushConsoleMessage('Error : CoreCommandRouter::executeOnPlugin: No method [' + method + '] in plugin ' + name);
+    }
+  } else return undefined;
 };
 
 CoreCommandRouter.prototype.getUIConfigOnPlugin = function (type, name, data) {
-	var self=this
-    this.pushConsoleMessage('CoreCommandRouter::getUIConfigOnPlugin');
-	var noConf = {"page": {"label": self.getI18nString('PLUGINS.NO_CONFIGURATION_AVAILABLE')}, "sections": []};
+  var self = this;
+  this.pushConsoleMessage('CoreCommandRouter::getUIConfigOnPlugin');
+  var noConf = {
+    'page': {
+      'label': self.getI18nString('PLUGINS.NO_CONFIGURATION_AVAILABLE')
+    },
+    'sections': []
+  };
 
-	var defer=libQ.defer()
+  var defer = libQ.defer();
 
-	var thisPlugin = this.pluginManager.getPlugin(type, name);
+  var thisPlugin = this.pluginManager.getPlugin(type, name);
 
-	try {
-        thisPlugin.getUIConfig(data)
-            .then(function(uiconf){
-                var filePath=__dirname + '/plugins/'+type+'/'+name+'/override.json'
+  try {
+    thisPlugin.getUIConfig(data)
+      .then(function (uiconf) {
+        var filePath = __dirname + '/plugins/' + type + '/' + name + '/override.json';
 
-                self.overrideUIConfig(uiconf,filePath)
-                    .then(function(){
-                        defer.resolve(uiconf)
-                    })
-                    .fail(function()
-                    {
-                        defer.reject(new Error());
-                    })
-            })
-            .fail(function()
-            {
-                defer.reject(new Error("Error retrieving UIConfig from plugin "+name))
-            })
-	} catch(e) {
-        defer.resolve(noConf)
-	}
+        self.overrideUIConfig(uiconf, filePath)
+          .then(function () {
+            defer.resolve(uiconf);
+          })
+          .fail(function () {
+            defer.reject(new Error());
+          });
+      })
+      .fail(function () {
+        defer.reject(new Error('Error retrieving UIConfig from plugin ' + name));
+      });
+  } catch (e) {
+    defer.resolve(noConf);
+  }
 
-
-
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.writePlayerControls = function (config) {
-	var self = this;
-	var pCtrlFile = '/data/playerstate/playback-controls.json';
+  var self = this;
+  var pCtrlFile = '/data/playerstate/playback-controls.json';
 
-	this.pushConsoleMessage('CoreCommandRouter::writePlayerControls');
+  this.pushConsoleMessage('CoreCommandRouter::writePlayerControls');
 
-	var state = self.stateMachine.getState();
+  var state = self.stateMachine.getState();
 
-	var data = Object.assign({
-		random: state.random,
-		repeat: state.repeat
-	}, config);
+  var data = Object.assign({
+    random: state.random,
+    repeat: state.repeat
+  }, config);
 
-	fs.writeFile(pCtrlFile, JSON.stringify(data, null, 4), function (err) {
-		if (err) self.pushConsoleMessage('Failed setting player state in CoreCommandRouter::initPlayerState');
-	});
+  fs.writeFile(pCtrlFile, JSON.stringify(data, null, 4), function (err) {
+    if (err) self.pushConsoleMessage('Failed setting player state in CoreCommandRouter::initPlayerState');
+  });
 };
 
 CoreCommandRouter.prototype.initPlayerControls = function () {
-	var pCtrlFile = '/data/playerstate/playback-controls.json';
-	var self = this;
+  var pCtrlFile = '/data/playerstate/playback-controls.json';
+  var self = this;
 
-	this.pushConsoleMessage('CoreCommandRouter::initPlayerControls');
+  this.pushConsoleMessage('CoreCommandRouter::initPlayerControls');
 
-	function handleError() {
-		self.pushConsoleMessage('Failed setting player state in CoreCommandRouter::initPlayerControls');
-	}
+  function handleError () {
+    self.pushConsoleMessage('Failed setting player state in CoreCommandRouter::initPlayerControls');
+  }
 
-	fs.ensureFile(pCtrlFile, function (err) {
-		if (err) handleError();
+  fs.ensureFile(pCtrlFile, function (err) {
+    if (err) handleError();
 
-		fs.readFile(pCtrlFile, function (err, data) {
-			if (err) handleError();
+    fs.readFile(pCtrlFile, function (err, data) {
+      if (err) handleError();
 
-			try {
-				var config = JSON.parse(data.toString());
-				self.stateMachine.setRepeat(config.repeat);
-				self.stateMachine.setRandom(config.random);
-			} catch(e) {
-				var state = self.stateMachine.getState();
-				var config = {
-					random: state.random,
-					repeat: state.repeat
-				};
+      try {
+        var config = JSON.parse(data.toString());
+        self.stateMachine.setRepeat(config.repeat);
+        self.stateMachine.setRandom(config.random);
+      } catch (e) {
+        var state = self.stateMachine.getState();
+        var config = {
+          random: state.random,
+          repeat: state.repeat
+        };
 
-				fs.writeFile(pCtrlFile, JSON.stringify(config, null, 4), function (err) {
-					if (err) handleError();
-				});
-			}
-		});
-	});
+        fs.writeFile(pCtrlFile, JSON.stringify(config, null, 4), function (err) {
+          if (err) handleError();
+        });
+      }
+    });
+  });
 };
-
 
 /**
  * This method shall be used to push debug messages
  * @param sMessage The debug message to push
  */
 CoreCommandRouter.prototype.pushDebugConsoleMessage = function (sMessage) {
-    this.logger.info(sMessage);
+  this.logger.info(sMessage);
 };
 
 /**
@@ -1174,397 +1185,357 @@ CoreCommandRouter.prototype.pushDebugConsoleMessage = function (sMessage) {
  * @param sMessage The error message to push
  */
 CoreCommandRouter.prototype.pushErrorConsoleMessage = function (sMessage) {
-    this.logger.error(sMessage);
+  this.logger.error(sMessage);
 };
 
 CoreCommandRouter.prototype.pushConsoleMessage = function (sMessage) {
-	// Uncomment for more logging
-	this.logger.info(sMessage);
+  // Uncomment for more logging
+  this.logger.info(sMessage);
 };
 
 CoreCommandRouter.prototype.pushToastMessage = function (type, title, message) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.printToastMessage === "function")
-				return thisInterface.printToastMessage(type, title, message);
-		})
-	);
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.printToastMessage === 'function') { return thisInterface.printToastMessage(type, title, message); }
+    })
+  );
 };
 
 CoreCommandRouter.prototype.broadcastToastMessage = function (type, title, message) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.broadcastToastMessage === "function")
-				return thisInterface.broadcastToastMessage(type, title, message);
-		})
-	);
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.broadcastToastMessage === 'function') { return thisInterface.broadcastToastMessage(type, title, message); }
+    })
+  );
 };
 
 CoreCommandRouter.prototype.broadcastMessage = function (msg, value) {
-	var self = this;
-	this.pushConsoleMessage('CoreCommandRouter::BroadCastMessage '+msg);
+  var self = this;
+  this.pushConsoleMessage('CoreCommandRouter::BroadCastMessage ' + msg);
 
-	return libQ.all(
+  return libQ.all(
 
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var emit = {msg:msg,value:value};
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.broadcastMessage === "function")
-				return thisInterface.broadcastMessage(emit);
-		})
-	);
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var emit = {
+        msg: msg,
+        value: value
+      };
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.broadcastMessage === 'function') { return thisInterface.broadcastMessage(emit); }
+    })
+  );
 };
 
 CoreCommandRouter.prototype.pushMultiroomDevices = function (data) {
-	var self = this;
+  var self = this;
 
-	var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'multiroom');
-    if (audioOutputPlugin != undefined && typeof audioOutputPlugin.pushOutputsState === "function") {
-        audioOutputPlugin.pushOutputsState(data);
-    }
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushMultiroomDevices === "function")
-				return thisInterface.pushMultiroomDevices(data);
-		})
-	);
+  var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'multiroom');
+  if (audioOutputPlugin != undefined && typeof audioOutputPlugin.pushOutputsState === 'function') {
+    audioOutputPlugin.pushOutputsState(data);
+  }
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushMultiroomDevices === 'function') { return thisInterface.pushMultiroomDevices(data); }
+    })
+  );
 };
 
 CoreCommandRouter.prototype.pushMultiroom = function (data) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushMultiroom === "function")
-				return thisInterface.pushMultiroom(data);
-		})
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushMultiroom === 'function') { return thisInterface.pushMultiroom(data); }
+    })
 
-	);
+  );
 };
-
 
 CoreCommandRouter.prototype.pushAirplay = function (data) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.pushAirplay === "function")
-				return thisInterface.pushAirplay(data);
-		})
-	);
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.pushAirplay === 'function') { return thisInterface.pushAirplay(data); }
+    })
+  );
 };
-
 
 // Platform specific & Hardware related options, they can be found in platformSpecific.js
 // This allows to change system commands across different devices\environments
 CoreCommandRouter.prototype.shutdown = function () {
-	var self = this;
-	
-	self.pluginManager.onVolumioShutdown().then( function() {
-		self.platformspecific.shutdown();
-	}).fail(function(e){
-		self.logger.info("Error in onVolumioShutdown Plugin Promise handling: "+ e);
-		self.platformspecific.shutdown();
-	});
-	
+  var self = this;
+
+  self.pluginManager.onVolumioShutdown().then(function () {
+    self.platformspecific.shutdown();
+  }).fail(function (e) {
+    self.logger.info('Error in onVolumioShutdown Plugin Promise handling: ' + e);
+    self.platformspecific.shutdown();
+  });
 };
 
 CoreCommandRouter.prototype.reboot = function () {
-	var self = this;
-	
-	self.pluginManager.onVolumioReboot().then( function() {
-		 self.platformspecific.reboot();
-	}).fail(function(e){
-		self.logger.info("Error in onVolumioReboot Plugin Promise handling: "+ e);
-		self.platformspecific.reboot();
-	});
-	
+  var self = this;
+
+  self.pluginManager.onVolumioReboot().then(function () {
+    self.platformspecific.reboot();
+  }).fail(function (e) {
+    self.logger.info('Error in onVolumioReboot Plugin Promise handling: ' + e);
+    self.platformspecific.reboot();
+  });
 };
 
 CoreCommandRouter.prototype.networkRestart = function () {
-	this.platformspecific.networkRestart();
+  this.platformspecific.networkRestart();
 };
 
 CoreCommandRouter.prototype.wirelessRestart = function () {
-	this.platformspecific.wirelessRestart();
+  this.platformspecific.wirelessRestart();
 };
 
 CoreCommandRouter.prototype.startupSound = function () {
-	this.platformspecific.startupSound();
+  this.platformspecific.startupSound();
 };
 
 CoreCommandRouter.prototype.fileUpdate = function (data) {
-	this.platformspecific.fileUpdate(data);
-}
-
-
-
-
-//------------------------- Multiservice queue methods -----------------------------------
-
-CoreCommandRouter.prototype.explodeUriFromService = function (service, uri) {
-	this.logger.info("Exploding uri "+uri+" in service "+service);
-
-	var thisPlugin = this.pluginManager.getPlugin('music_service', service);
-	if(thisPlugin.explodeUri !=undefined)
-		return  thisPlugin.explodeUri(uri);
-	else {
-		var promise=libQ.defer();
-		promise.resolve({
-			uri: uri,
-			service: service
-		});
-		return promise.promise;
-	}
+  this.platformspecific.fileUpdate(data);
 };
 
+// ------------------------- Multiservice queue methods -----------------------------------
 
+CoreCommandRouter.prototype.explodeUriFromService = function (service, uri) {
+  this.logger.info('Exploding uri ' + uri + ' in service ' + service);
 
+  var thisPlugin = this.pluginManager.getPlugin('music_service', service);
+  if (thisPlugin.explodeUri != undefined) { return thisPlugin.explodeUri(uri); } else {
+    var promise = libQ.defer();
+    promise.resolve({
+      uri: uri,
+      service: service
+    });
+    return promise.promise;
+  }
+};
 
-
-
-
-//------------------------ Used in new play system -------------------------------
+// ------------------------ Used in new play system -------------------------------
 
 // Volumio Play
 CoreCommandRouter.prototype.volumioPlay = function (N) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioPlay');
+  this.pushConsoleMessage('CoreCommandRouter::volumioPlay');
 
-    this.stateMachine.unSetVolatile();
+  this.stateMachine.unSetVolatile();
 
-	if(N===undefined)
-		return this.stateMachine.play();
-	else
-	{
-		return this.stateMachine.play(N);
-	}
+  if (N === undefined) { return this.stateMachine.play(); } else {
+    return this.stateMachine.play(N);
+  }
 };
 
 // Volumio Play
 CoreCommandRouter.prototype.volumioVolatilePlay = function () {
-    this.pushConsoleMessage('CoreCommandRouter::volumioVolatilePlay');
+  this.pushConsoleMessage('CoreCommandRouter::volumioVolatilePlay');
 
-    return this.stateMachine.volatilePlay();
+  return this.stateMachine.volatilePlay();
 };
 
 // Volumio Toggle
 CoreCommandRouter.prototype.volumioToggle = function () {
-    this.pushConsoleMessage('CoreCommandRouter::volumioToggle');
+  this.pushConsoleMessage('CoreCommandRouter::volumioToggle');
 
-    var state=this.stateMachine.getState();
+  var state = this.stateMachine.getState();
 
-	if (state.status != undefined) {
-		if(state.status==='stop' || state.status==='pause')
-		{
-			return this.stateMachine.play();
-		} else {
-			if(state.trackType == 'webradio') {
-				return this.stateMachine.stop();
-			} else {
-				return this.stateMachine.pause();
-			}
-		}
+  if (state.status != undefined) {
+    if (state.status === 'stop' || state.status === 'pause') {
+      return this.stateMachine.play();
+    } else {
+      if (state.trackType == 'webradio') {
+        return this.stateMachine.stop();
+      } else {
+        return this.stateMachine.pause();
+      }
     }
+  }
 };
-
 
 // Volumio Seek
 CoreCommandRouter.prototype.volumioSeek = function (position) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioSeek');
-	return this.stateMachine.seek(position);
+  this.pushConsoleMessage('CoreCommandRouter::volumioSeek');
+  return this.stateMachine.seek(position);
 };
 
 CoreCommandRouter.prototype.installPlugin = function (uri) {
-	var self=this;
-	var defer=libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-	this.pluginManager.installPlugin(uri).then(function()
-	{
-		defer.resolve();
-	}).fail(function(e){
-		self.logger.info("Error: "+e);
-		defer.reject(new Error('Cannot install plugin. Error: '+e));
-	});
+  this.pluginManager.installPlugin(uri).then(function () {
+    defer.resolve();
+  }).fail(function (e) {
+    self.logger.info('Error: ' + e);
+    defer.reject(new Error('Cannot install plugin. Error: ' + e));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.updatePlugin = function (data) {
-	var self=this;
-	var defer=libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-	this.pluginManager.updatePlugin(data).then(function()
-	{
-		defer.resolve();
-	}).fail(function(e){
-		self.logger.info("Error: "+e);
-		self.logger.info("Error: "+e);
-		defer.reject(new Error('Cannot Update plugin. Error: '+e));
-	});
+  this.pluginManager.updatePlugin(data).then(function () {
+    defer.resolve();
+  }).fail(function (e) {
+    self.logger.info('Error: ' + e);
+    self.logger.info('Error: ' + e);
+    defer.reject(new Error('Cannot Update plugin. Error: ' + e));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.unInstallPlugin = function (data) {
-	var self = this;
-	var defer=libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-	self.logger.info('Starting Uninstall of plugin ' + data.category + ' - ' +data.name);
+  self.logger.info('Starting Uninstall of plugin ' + data.category + ' - ' + data.name);
 
-	this.pluginManager.unInstallPlugin(data.category,data.name).then(function()
-	{
-		defer.resolve();
-	}).fail(function(){
-		defer.reject(new Error('Cannot uninstall plugin'));
-	});
+  this.pluginManager.unInstallPlugin(data.category, data.name).then(function () {
+    defer.resolve();
+  }).fail(function () {
+    defer.reject(new Error('Cannot uninstall plugin'));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.enablePlugin = function (data) {
-	var defer=libQ.defer();
+  var defer = libQ.defer();
 
-	this.pluginManager.enablePlugin(data.category,data.plugin).then(function()
-	{
-		defer.resolve();
-	}).fail(function(){
-		defer.reject(new Error('Cannot enable plugin'));
-	});
+  this.pluginManager.enablePlugin(data.category, data.plugin).then(function () {
+    defer.resolve();
+  }).fail(function () {
+    defer.reject(new Error('Cannot enable plugin'));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.disablePlugin = function (data) {
-	var defer=libQ.defer();
+  var defer = libQ.defer();
 
-	this.pluginManager.disablePlugin(data.category,data.plugin).then(function()
-	{
-		defer.resolve();
-	}).fail(function(){
-		defer.reject(new Error('Cannot disable plugin'));
-	});
+  this.pluginManager.disablePlugin(data.category, data.plugin).then(function () {
+    defer.resolve();
+  }).fail(function () {
+    defer.reject(new Error('Cannot disable plugin'));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
 CoreCommandRouter.prototype.modifyPluginStatus = function (data) {
-	var defer=libQ.defer();
+  var defer = libQ.defer();
 
-	this.pluginManager.modifyPluginStatus(data.category,data.plugin,data.status).then(function()
-	{
-		defer.resolve();
-	}).fail(function(){
-		defer.reject(new Error('Cannot update plugin status'));
-	});
+  this.pluginManager.modifyPluginStatus(data.category, data.plugin, data.status).then(function () {
+    defer.resolve();
+  }).fail(function () {
+    defer.reject(new Error('Cannot update plugin status'));
+  });
 
-	return defer.promise;
+  return defer.promise;
 };
 
-CoreCommandRouter.prototype.broadcastMessage = function (emit,payload) {
-	var self = this;
-	return libQ.all(
-		libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
-			var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
-			if (typeof thisInterface.broadcastMessage === "function")
-				return thisInterface.broadcastMessage(emit,payload);
-		})
-	);
+CoreCommandRouter.prototype.broadcastMessage = function (emit, payload) {
+  var self = this;
+  return libQ.all(
+    libFast.map(this.pluginManager.getPluginNames('user_interface'), function (sInterface) {
+      var thisInterface = self.pluginManager.getPlugin('user_interface', sInterface);
+      if (typeof thisInterface.broadcastMessage === 'function') { return thisInterface.broadcastMessage(emit, payload); }
+    })
+  );
 };
 
 CoreCommandRouter.prototype.getInstalledPlugins = function () {
-	return this.pluginManager.getInstalledPlugins();
+  return this.pluginManager.getInstalledPlugins();
 };
 
 CoreCommandRouter.prototype.getAvailablePlugins = function () {
-	return this.pluginManager.getAvailablePlugins();
+  return this.pluginManager.getAvailablePlugins();
 };
 
 CoreCommandRouter.prototype.getPluginDetails = function (data) {
-	return this.pluginManager.getPluginDetails(data);
+  return this.pluginManager.getPluginDetails(data);
 };
 
-
-
-CoreCommandRouter.prototype.enableAndStartPlugin = function (category,name) {
-	return this.pluginManager.enableAndStartPlugin(category,name);
+CoreCommandRouter.prototype.enableAndStartPlugin = function (category, name) {
+  return this.pluginManager.enableAndStartPlugin(category, name);
 };
 
-
-CoreCommandRouter.prototype.disableAndStopPlugin = function (category,name) {
-	return this.pluginManager.disableAndStopPlugin(category,name);
+CoreCommandRouter.prototype.disableAndStopPlugin = function (category, name) {
+  return this.pluginManager.disableAndStopPlugin(category, name);
 };
-
 
 CoreCommandRouter.prototype.volumioRandom = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioRandom');
+  this.pushConsoleMessage('CoreCommandRouter::volumioRandom');
 
-	this.writePlayerControls({
-		random: data
-	});
+  this.writePlayerControls({
+    random: data
+  });
 
-	return this.stateMachine.setRandom(data);
+  return this.stateMachine.setRandom(data);
 };
 
+CoreCommandRouter.prototype.randomToggle = function () {
+  var self = this;
 
+  var state = self.stateMachine.getState();
 
+  if (state.random) {
+    var random = false;
+  } else {
+    var random = true;
+  }
 
-CoreCommandRouter.prototype.randomToggle = function(){
-    var self = this;
+  this.writePlayerControls({
+    random: random
+  });
 
-    var state = self.stateMachine.getState();
+  return self.stateMachine.setRandom(random);
+};
 
-    if(state.random){
-        var random = false;
-    }
-    else{
-        var random = true;
-    }
+CoreCommandRouter.prototype.volumioRepeat = function (repeat, repeatSingle) {
+  this.pushConsoleMessage('CoreCommandRouter::volumioRandom');
 
-    this.writePlayerControls({
-        random: random
-	});
+  this.writePlayerControls({
+    repeat: repeat
+  });
 
-    return self.stateMachine.setRandom(random);
-
-}
-
-CoreCommandRouter.prototype.volumioRepeat = function (repeat,repeatSingle) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioRandom');
-
-    this.writePlayerControls({
-        repeat: repeat
-    });
-
-    return this.stateMachine.setRepeat(repeat,repeatSingle);
+  return this.stateMachine.setRepeat(repeat, repeatSingle);
 };
 
 CoreCommandRouter.prototype.repeatToggle = function () {
-    var self = this;
+  var self = this;
 
-    var state = self.stateMachine.getState();
+  var state = self.stateMachine.getState();
 
-    if(state.repeat){
-        var repeat = false;
-    }
-    else{
-        var repeat = true;
-    }
+  if (state.repeat) {
+    var repeat = false;
+  } else {
+    var repeat = true;
+  }
 
-    this.writePlayerControls({
-        repeat: repeat
-    });
+  this.writePlayerControls({
+    repeat: repeat
+  });
 
-    return self.stateMachine.setRepeat(repeat, false);
-}
+  return self.stateMachine.setRepeat(repeat, false);
+};
 
 CoreCommandRouter.prototype.volumioConsume = function (data) {
-	this.pushConsoleMessage('CoreCommandRouter::volumioConsume');
-	return this.stateMachine.setConsume(data);
+  this.pushConsoleMessage('CoreCommandRouter::volumioConsume');
+  return this.stateMachine.setConsume(data);
 };
 
 /**
@@ -1572,680 +1543,643 @@ CoreCommandRouter.prototype.volumioConsume = function (data) {
  * Return a promise
  */
 CoreCommandRouter.prototype.volumioFFWDRew = function (millisecs) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioFFWDRew '+millisecs);
+  this.pushConsoleMessage('CoreCommandRouter::volumioFFWDRew ' + millisecs);
 
-    return this.stateMachine.ffwdRew(millisecs);
+  return this.stateMachine.ffwdRew(millisecs);
 };
 
 CoreCommandRouter.prototype.volumioSkipBackwards = function (data) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioSkipBackwards');
+  this.pushConsoleMessage('CoreCommandRouter::volumioSkipBackwards');
 
-    return this.stateMachine.skipBackwards(data);
+  return this.stateMachine.skipBackwards(data);
 };
 
 CoreCommandRouter.prototype.volumioSkipForward = function (data) {
-    this.pushConsoleMessage('CoreCommandRouter::volumioSkipForward');
+  this.pushConsoleMessage('CoreCommandRouter::volumioSkipForward');
 
-    return this.stateMachine.skipForward(data);
+  return this.stateMachine.skipForward(data);
 };
-
 
 CoreCommandRouter.prototype.volumioSaveQueueToPlaylist = function (name) {
-	var self=this;
-    this.pushConsoleMessage('CoreCommandRouter::volumioSaveQueueToPlaylist');
+  var self = this;
+  this.pushConsoleMessage('CoreCommandRouter::volumioSaveQueueToPlaylist');
 
-	var queueArray=this.stateMachine.getQueue();
-	var defer=this.playListManager.commonAddItemsToPlaylist(this.playListManager.playlistFolder,name,queueArray);
+  var queueArray = this.stateMachine.getQueue();
+  var defer = this.playListManager.commonAddItemsToPlaylist(this.playListManager.playlistFolder, name, queueArray);
 
-    defer.then(function()
-    {
-        self.pushToastMessage('success', self.getI18nString('COMMON.SAVE_QUEUE_SUCCESS') + name);
-    })
+  defer.then(function () {
+    self.pushToastMessage('success', self.getI18nString('COMMON.SAVE_QUEUE_SUCCESS') + name);
+  })
     .fail(function () {
-        self.pushToastMessage('success', self.getI18nString('COMMON.SAVE_QUEUE_ERROR')+name);
+      self.pushToastMessage('success', self.getI18nString('COMMON.SAVE_QUEUE_ERROR') + name);
     });
 
-    return defer;
+  return defer;
 };
 
+CoreCommandRouter.prototype.volumioMoveQueue = function (from, to) {
+  var defer = libQ.defer();
+  this.pushConsoleMessage('CoreCommandRouter::volumioMoveQueue');
 
-CoreCommandRouter.prototype.volumioMoveQueue = function (from,to) {
-	var defer = libQ.defer();
-	this.pushConsoleMessage('CoreCommandRouter::volumioMoveQueue');
-
-	if (from && to) {
-        return this.stateMachine.moveQueueItem(from,to);
-	} else {
-		this.logger.error('Cannot move item in queue, from or to parameter missing');
-        var queueArray=this.stateMachine.getQueue();
-        defer.resolve(queueArray);
-        return defer.promise
-	}
-
+  if (from && to) {
+    return this.stateMachine.moveQueueItem(from, to);
+  } else {
+    this.logger.error('Cannot move item in queue, from or to parameter missing');
+    var queueArray = this.stateMachine.getQueue();
+    defer.resolve(queueArray);
+    return defer.promise;
+  }
 };
 
 CoreCommandRouter.prototype.getI18nString = function (key) {
-    var splitted=key.split('.');
+  var splitted = key.split('.');
 
-    if (this.i18nStrings) {
-        if(splitted.length==1)
-        {
-            if(this.i18nStrings[key]!==undefined)
-                return this.i18nStrings[key];
-            else return this.i18nStringsDefaults[key];
-        }
-        else {
-            if(this.i18nStrings[splitted[0]]!==undefined &&
-                this.i18nStrings[splitted[0]][splitted[1]]!==undefined)
-                return this.i18nStrings[splitted[0]][splitted[1]];
-            else return this.i18nStringsDefaults[splitted[0]][splitted[1]];
-        }
-	} else {
-    	var emptyString = '';
-    	return emptyString
-	}
-
+  if (this.i18nStrings) {
+    if (splitted.length == 1) {
+      if (this.i18nStrings[key] !== undefined) { return this.i18nStrings[key]; } else return this.i18nStringsDefaults[key];
+    } else {
+      if (this.i18nStrings[splitted[0]] !== undefined &&
+        this.i18nStrings[splitted[0]][splitted[1]] !== undefined) { return this.i18nStrings[splitted[0]][splitted[1]]; } else return this.i18nStringsDefaults[splitted[0]][splitted[1]];
+    }
+  } else {
+    var emptyString = '';
+    return emptyString;
+  }
 };
 
 CoreCommandRouter.prototype.loadI18nStrings = function () {
-    var self=this;
-    var language_code=this.sharedVars.get('language_code');
+  var self = this;
+  var language_code = this.sharedVars.get('language_code');
 
-	this.i18nStringsDefaults=fs.readJsonSync(__dirname+'/i18n/strings_en.json');
-	
-    try {
-        this.logger.info("Loading i18n strings for locale "+language_code);
-    	this.i18nStrings=fs.readJsonSync(__dirname+'/i18n/strings_'+language_code+".json");
-    } catch(e){
-        this.logger.error("Failed to load i18n strings for locale "+language_code + ": " +e);
-        this.i18nStrings = this.i18nStringsDefaults;
-    }
-    
-    var categories=this.pluginManager.getPluginCategories();
-    for(var i in categories)
-    {
-        var category=categories[i];
-        var names=this.pluginManager.getPluginNames(category);
-        for(var j in names)
-        {
-            var name=names[j];
-            var instance=this.pluginManager.getPlugin(category,name);
+  this.i18nStringsDefaults = fs.readJsonSync(__dirname + '/i18n/strings_en.json');
 
-            if (instance && instance.getI18nFile) {
-              var pluginI18NFile = instance.getI18nFile(language_code);
-              if (pluginI18NFile && fs.pathExistsSync(pluginI18NFile)) {
-                var pluginI18nStrings = fs.readJsonSync(pluginI18NFile);
-      
-                for (var locale in pluginI18nStrings) {
-                  // check if locale does not already exist to avoid that volumio
-                  // strings get overwritten
-                  if (!this.i18nStrings[locale]) {
-                    this.i18nStrings[locale] = pluginI18nStrings[locale];
-                  } else {
-                    this.logger.info("Plugin " + name + " has duplicated i18n key " + locale + ". It is ignored.");
-                  }
-                }
-              }
+  try {
+    this.logger.info('Loading i18n strings for locale ' + language_code);
+    this.i18nStrings = fs.readJsonSync(__dirname + '/i18n/strings_' + language_code + '.json');
+  } catch (e) {
+    this.logger.error('Failed to load i18n strings for locale ' + language_code + ': ' + e);
+    this.i18nStrings = this.i18nStringsDefaults;
+  }
+
+  var categories = this.pluginManager.getPluginCategories();
+  for (var i in categories) {
+    var category = categories[i];
+    var names = this.pluginManager.getPluginNames(category);
+    for (var j in names) {
+      var name = names[j];
+      var instance = this.pluginManager.getPlugin(category, name);
+
+      if (instance && instance.getI18nFile) {
+        var pluginI18NFile = instance.getI18nFile(language_code);
+        if (pluginI18NFile && fs.pathExistsSync(pluginI18NFile)) {
+          var pluginI18nStrings = fs.readJsonSync(pluginI18NFile);
+
+          for (var locale in pluginI18nStrings) {
+            // check if locale does not already exist to avoid that volumio
+            // strings get overwritten
+            if (!this.i18nStrings[locale]) {
+              this.i18nStrings[locale] = pluginI18nStrings[locale];
+            } else {
+              this.logger.info('Plugin ' + name + ' has duplicated i18n key ' + locale + '. It is ignored.');
             }
+          }
         }
+      }
     }
+  }
 };
 
-CoreCommandRouter.prototype.i18nJson = function (dictionaryFile,defaultDictionaryFile,jsonFile) {
-    var self=this;
-    var methodDefer=libQ.defer();
-    var defers=[];
+CoreCommandRouter.prototype.i18nJson = function (dictionaryFile, defaultDictionaryFile, jsonFile) {
+  var self = this;
+  var methodDefer = libQ.defer();
+  var defers = [];
 
+  try {
+    fs.readJsonSync(dictionaryFile);
+  } catch (e) {
+    dictionaryFile = defaultDictionaryFile;
+  }
 
-	try {
-		fs.readJsonSync(dictionaryFile);
-	} catch(e) {
-		dictionaryFile = defaultDictionaryFile;
-	}
+  defers.push(libQ.nfcall(fs.readJson, dictionaryFile));
+  defers.push(libQ.nfcall(fs.readJson, defaultDictionaryFile));
+  defers.push(libQ.nfcall(fs.readJson, jsonFile));
 
-    defers.push(libQ.nfcall(fs.readJson,dictionaryFile));
-    defers.push(libQ.nfcall(fs.readJson,defaultDictionaryFile));
-    defers.push(libQ.nfcall(fs.readJson,jsonFile));
+  libQ.all(defers)
+    .then(function (documents) {
+      var dictionary = documents[0];
+      var defaultDictionary = documents[1];
+      var jsonFile = documents[2];
 
-    libQ.all(defers).
-            then(function(documents)
-    {
+      self.translateKeys(jsonFile, dictionary, defaultDictionary);
 
-        var dictionary=documents[0];
-        var defaultDictionary=documents[1];
-        var jsonFile=documents[2];
-
-        self.translateKeys(jsonFile,dictionary,defaultDictionary);
-
-        methodDefer.resolve(jsonFile);
+      methodDefer.resolve(jsonFile);
     })
-    .fail(function(err){
-        self.logger.info("ERROR LOADING JSON "+err);
+    .fail(function (err) {
+      self.logger.info('ERROR LOADING JSON ' + err);
 
-        methodDefer.reject(new Error());
+      methodDefer.reject(new Error());
     });
 
-    return methodDefer.promise;
-
+  return methodDefer.promise;
 };
 
-CoreCommandRouter.prototype.translateKeys = function (parent,dictionary,defaultDictionary) {
-    var self=this;
+CoreCommandRouter.prototype.translateKeys = function (parent, dictionary, defaultDictionary) {
+  var self = this;
 
-    try {
-        var keys=Object.keys(parent);
+  try {
+    var keys = Object.keys(parent);
 
-        for(var i in keys)
-        {
-            var obj=parent[keys[i]];
-            var type=typeof(obj);
+    for (var i in keys) {
+      var obj = parent[keys[i]];
+      var type = typeof (obj);
 
-            if(type==='object')
-            {
-                self.translateKeys(obj,dictionary,defaultDictionary);
+      if (type === 'object') {
+        self.translateKeys(obj, dictionary, defaultDictionary);
+      } else if (type === 'string') {
+        if (obj.startsWith('TRANSLATE.')) {
+          var replaceKey = obj.slice(10);
+
+          var dotIndex = replaceKey.indexOf('.');
+
+          if (dotIndex == -1) {
+            var value = dictionary[replaceKey];
+            if (value === undefined) {
+              value = defaultDictionary[replaceKey];
             }
-            else if(type==='string')
-            {
-                if(obj.startsWith("TRANSLATE."))
-                {
-                    var replaceKey=obj.slice(10);
+            parent[keys[i]] = value;
+          } else {
+            var category = replaceKey.slice(0, dotIndex);
+            var key = replaceKey.slice(dotIndex + 1);
 
-                    var dotIndex=replaceKey.indexOf('.');
-
-                    if(dotIndex==-1)
-                    {
-                        var value=dictionary[replaceKey];
-                        if(value===undefined)
-                        {
-                            value=defaultDictionary[replaceKey];
-                        }
-                        parent[keys[i]]=value;
-                    }
-                    else {
-                        var category=replaceKey.slice(0,dotIndex);
-                        var key=replaceKey.slice(dotIndex+1);
-
-                        if(dictionary[category]===undefined || dictionary[category][key]===undefined)
-                        {
-                            var value=defaultDictionary[category][key];
-                        } else {
-                            var value=dictionary[category][key];
-                        }
-                        parent[keys[i]]=value;
-                    }
-                }
+            if (dictionary[category] === undefined || dictionary[category][key] === undefined) {
+              var value = defaultDictionary[category][key];
+            } else {
+              var value = dictionary[category][key];
             }
+            parent[keys[i]] = value;
+          }
         }
-	} catch(e) {
-    	self.logger.error('Cannot translate keys: ' + e);
-	}
-}
+      }
+    }
+  } catch (e) {
+    self.logger.error('Cannot translate keys: ' + e);
+  }
+};
 
 CoreCommandRouter.prototype.overrideUIConfig = function (uiconfig, overrideFile) {
-    var self=this;
-    var methodDefer=libQ.defer();
+  var self = this;
+  var methodDefer = libQ.defer();
 
-    fs.readJson(overrideFile, function(err,override){
+  fs.readJson(overrideFile, function (err, override) {
+    if (err) {
+      methodDefer.resolve();
+    } else {
+      for (var i in override) {
+        var attr = override[i];
 
-        if(err)
-        {
-            methodDefer.resolve()
-        }
-        else {
-            for(var i in override)
-            {
-                var attr=override[i]
+        var attribute_name = attr.attribute_name;
+        var attribute_value = attr.value;
+        var id = attr.id;
 
-                var attribute_name=attr.attribute_name
-                var attribute_value=attr.value
-                var id=attr.id
+        self.overrideField(uiconfig, id, attribute_name, attribute_value);
+      }
 
-                self.overrideField(uiconfig,id,attribute_name,attribute_value)
-            }
+      methodDefer.resolve();
+    }
+  });
 
-            methodDefer.resolve()
-        }
-    })
-
-    return methodDefer.promise;
-
+  return methodDefer.promise;
 };
 
-CoreCommandRouter.prototype.overrideField = function (parent,id,attribute_name,attribute_value) {
-    var self=this;
+CoreCommandRouter.prototype.overrideField = function (parent, id, attribute_name, attribute_value) {
+  var self = this;
 
-    if(typeof(parent)==='object')
-    {
-        if(parent.id===id)
-        {
-            parent[attribute_name]=attribute_value
-        } else {
-            var keys=Object.keys(parent);
+  if (typeof (parent) === 'object') {
+    if (parent.id === id) {
+      parent[attribute_name] = attribute_value;
+    } else {
+      var keys = Object.keys(parent);
 
-            for(var i in keys)
-            {
-                var obj=parent[keys[i]];
+      for (var i in keys) {
+        var obj = parent[keys[i]];
 
-                self.overrideField(obj,id,attribute_name,attribute_value);
-            }
-
-        }
+        self.overrideField(obj, id, attribute_name, attribute_value);
+      }
     }
-}
-
+  }
+};
 
 CoreCommandRouter.prototype.updateBrowseSourcesLang = function () {
-	var self=this;
+  var self = this;
 
-	return this.musicLibrary.updateBrowseSourcesLang();
-}
-
+  return this.musicLibrary.updateBrowseSourcesLang();
+};
 
 /**
  * This function checks if update files are placed in the update folder
  */
 CoreCommandRouter.prototype.checkAndPerformSystemUpdates = function () {
-    //var defer=libQ.defer();
-    var self=this;
+  // var defer=libQ.defer();
+  var self = this;
 
-    var updateFolder='/volumio/update';
-	try {
-		var files = fs.readdirSync(updateFolder);
-	} catch (e)
-	{
-		//Nothing to do
-	}
+  var updateFolder = '/volumio/update';
+  try {
+    var files = fs.readdirSync(updateFolder);
+  } catch (e) {
+    // Nothing to do
+  }
 
-    if(files!==undefined && files.length>0)
-    {
-        self.logger.info("Updating system");
+  if (files !== undefined && files.length > 0) {
+    self.logger.info('Updating system');
 
-        try {
-            for(var i in files)
-            {
-                var file=files[i];
+    try {
+      for (var i in files) {
+        var file = files[i];
 
-                if(file.endsWith(".sh"))
-                {
-                    var output = execSync('sh '+updateFolder+'/'+file, { encoding: 'utf8' });
-                }
-
-
-            }
-
-            for(var i in files)
-            {
-                var file=files[i];
-
-                fs.unlinkSync(updateFolder+'/'+file);
-            }
+        if (file.endsWith('.sh')) {
+          var output = execSync('sh ' + updateFolder + '/' + file, {
+            encoding: 'utf8'
+          });
         }
-        catch(err)
-        {
-            self.logger.error("An error occurred when updating Volumio. Details: "+err);
+      }
 
-            //TODO: decide what to do in case of errors when updating
-        }
+      for (var i in files) {
+        var file = files[i];
 
+        fs.unlinkSync(updateFolder + '/' + file);
+      }
+    } catch (err) {
+      self.logger.error('An error occurred when updating Volumio. Details: ' + err);
 
+      // TODO: decide what to do in case of errors when updating
     }
-}
+  }
+};
 
 CoreCommandRouter.prototype.safeRemoveDrive = function (data) {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    exec("/usr/bin/sudo /bin/umount /mnt/USB/"+data, function (error, stdout, stderr) {
-        if (error !== null) {
-            self.pushConsoleMessage(error);
-            self.pushToastMessage('error',data,
-                self.getI18nString('SYSTEM.CANNOT_REMOVE_MEDIA')+ ': ' +error);
-        } else {
-            self.pushToastMessage('success',self.getI18nString('SYSTEM.MEDIA_REMOVED_SUCCESSFULLY'),
-                self.getI18nString('SYSTEM.MEDIA_REMOVED_SUCCESSFULLY'));
-            self.executeOnPlugin('music_service', 'mpd', 'updateMpdDB', '/USB/');
-            execSync('/usr/bin/mpc update', { uid:1000, gid:1000, encoding: 'utf8' });
-            exec('/usr/bin/mpc idle update', {uid:1000, gid:1000, timeout: 10000}, function (error, stdout, stderr) {
-                if (error !== null) {
-                } else {
-                    var response = self.musicLibrary.executeBrowseSource('music-library/USB');
-                    if (response != undefined) {
-                        response.then(function (result) {
-                            defer.resolve(result);
-                        })
-                            .fail(function () {
-                                defer.reject();
-                            });
-                    }
-				}
-            });
+  exec('/usr/bin/sudo /bin/umount /mnt/USB/' + data, function (error, stdout, stderr) {
+    if (error !== null) {
+      self.pushConsoleMessage(error);
+      self.pushToastMessage('error', data,
+        self.getI18nString('SYSTEM.CANNOT_REMOVE_MEDIA') + ': ' + error);
+    } else {
+      self.pushToastMessage('success', self.getI18nString('SYSTEM.MEDIA_REMOVED_SUCCESSFULLY'),
+        self.getI18nString('SYSTEM.MEDIA_REMOVED_SUCCESSFULLY'));
+      self.executeOnPlugin('music_service', 'mpd', 'updateMpdDB', '/USB/');
+      execSync('/usr/bin/mpc update', {
+        uid: 1000,
+        gid: 1000,
+        encoding: 'utf8'
+      });
+      exec('/usr/bin/mpc idle update', {
+        uid: 1000,
+        gid: 1000,
+        timeout: 10000
+      }, function (error, stdout, stderr) {
+        if (error !== null) {} else {
+          var response = self.musicLibrary.executeBrowseSource('music-library/USB');
+          if (response != undefined) {
+            response.then(function (result) {
+              defer.resolve(result);
+            })
+              .fail(function () {
+                defer.reject();
+              });
+          }
         }
-    });
-    return defer.promise;
-}
+      });
+    }
+  });
+  return defer.promise;
+};
 
 CoreCommandRouter.prototype.closeModals = function () {
-    var self=this;
-    this.pushConsoleMessage('CoreCommandRouter::Close All Modals sent');
+  var self = this;
+  this.pushConsoleMessage('CoreCommandRouter::Close All Modals sent');
 
-    return self.broadcastMessage('closeAllModals', '');
-}
+  return self.broadcastMessage('closeAllModals', '');
+};
 
 CoreCommandRouter.prototype.getMyVolumioToken = function () {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    var response = self.executeOnPlugin('system_controller', 'my_volumio', 'getMyVolumioToken', '');
+  var response = self.executeOnPlugin('system_controller', 'my_volumio', 'getMyVolumioToken', '');
 
-    if (response != undefined) {
-        response.then(function (result) {
-            defer.resolve(result);
-        })
-            .fail(function () {
-                var jsonobject = {"tokenAvailable":false}
-                defer.resolve(jsonobject);
-            });
-    }
+  if (response != undefined) {
+    response.then(function (result) {
+      defer.resolve(result);
+    })
+      .fail(function () {
+        var jsonobject = {
+          'tokenAvailable': false
+        };
+        defer.resolve(jsonobject);
+      });
+  }
 
-    return defer.promise;
-}
+  return defer.promise;
+};
 
 CoreCommandRouter.prototype.setMyVolumioToken = function (data) {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    var response = self.executeOnPlugin('system_controller', 'my_volumio', 'setMyVolumioToken', data);
+  var response = self.executeOnPlugin('system_controller', 'my_volumio', 'setMyVolumioToken', data);
 
-    if (response != undefined) {
-        response.then(function (result) {
-            defer.resolve(result);
-        })
-            .fail(function () {
+  if (response != undefined) {
+    response.then(function (result) {
+      defer.resolve(result);
+    })
+      .fail(function () {
+        defer.resolve('');
+      });
+  }
 
-                defer.resolve('');
-            });
-    }
-
-    return defer.promise;
-}
+  return defer.promise;
+};
 
 CoreCommandRouter.prototype.getMyVolumioStatus = function () {
-    var self=this;
-    var defer = libQ.defer();
-    var notLoggedInResponseObject = {"loggedIn":false};
+  var self = this;
+  var defer = libQ.defer();
+  var notLoggedInResponseObject = {
+    'loggedIn': false
+  };
 
-    var response = self.executeOnPlugin('system_controller', 'my_volumio', 'getMyVolumioStatus', '');
-    if (response != undefined) {
-        response.then(function (result) {
-            defer.resolve(result);
-        }).fail(function () {
-			defer.resolve(notLoggedInResponseObject);
-		});
-    } else {
-    	// MyVolumio plugin not loaded
-        defer.resolve(notLoggedInResponseObject);
-	}
+  var response = self.executeOnPlugin('system_controller', 'my_volumio', 'getMyVolumioStatus', '');
+  if (response != undefined) {
+    response.then(function (result) {
+      defer.resolve(result);
+    }).fail(function () {
+      defer.resolve(notLoggedInResponseObject);
+    });
+  } else {
+    // MyVolumio plugin not loaded
+    defer.resolve(notLoggedInResponseObject);
+  }
 
-    return defer.promise;
-}
+  return defer.promise;
+};
 
 CoreCommandRouter.prototype.myVolumioLogout = function () {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    return self.executeOnPlugin('system_controller', 'my_volumio', 'myVolumioLogout', '');
-}
+  return self.executeOnPlugin('system_controller', 'my_volumio', 'myVolumioLogout', '');
+};
 
 CoreCommandRouter.prototype.enableMyVolumioDevice = function (device) {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    return self.executeOnPlugin('system_controller', 'my_volumio', 'enableMyVolumioDevice', device);
-}
+  return self.executeOnPlugin('system_controller', 'my_volumio', 'enableMyVolumioDevice', device);
+};
 
 CoreCommandRouter.prototype.disableMyVolumioDevice = function (device) {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    return self.executeOnPlugin('system_controller', 'my_volumio', 'disableMyVolumioDevice', device);
-}
+  return self.executeOnPlugin('system_controller', 'my_volumio', 'disableMyVolumioDevice', device);
+};
 
 CoreCommandRouter.prototype.deleteMyVolumioDevice = function (device) {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    return self.executeOnPlugin('system_controller', 'my_volumio', 'deleteMyVolumioDevice', device);
-}
+  return self.executeOnPlugin('system_controller', 'my_volumio', 'deleteMyVolumioDevice', device);
+};
 
 CoreCommandRouter.prototype.reloadUi = function () {
-    var self=this;
-    this.pushConsoleMessage('CoreCommandRouter::Reload Ui');
+  var self = this;
+  this.pushConsoleMessage('CoreCommandRouter::Reload Ui');
 
-    return self.broadcastMessage('reloadUi', '');
-}
+  return self.broadcastMessage('reloadUi', '');
+};
 
 CoreCommandRouter.prototype.getMenuItems = function () {
-    var self=this;
-    var defer = libQ.defer();
-    var lang_code = self.sharedVars.get('language_code');
+  var self = this;
+  var defer = libQ.defer();
+  var lang_code = self.sharedVars.get('language_code');
 
-    self.i18nJson(__dirname+'/i18n/strings_'+lang_code+'.json',
-        __dirname+'/i18n/strings_en.json',
-        __dirname + '/mainmenu.json')
-        .then(function(menuItemsJson)
-        {
-            if (fs.existsSync('/myvolumio/')) {
-                var menuItems = [{"id": "my-volumio"}];
-                menuItems = menuItems.concat(menuItemsJson.menuItems);
-            } else {
-                var menuItems = menuItemsJson['menuItems'];
-            }
-            defer.resolve(menuItems);
-        });
-    return defer.promise
-}
+  self.i18nJson(__dirname + '/i18n/strings_' + lang_code + '.json',
+    __dirname + '/i18n/strings_en.json',
+    __dirname + '/mainmenu.json')
+    .then(function (menuItemsJson) {
+      if (fs.existsSync('/myvolumio/')) {
+        var menuItems = [{
+          'id': 'my-volumio'
+        }];
+        menuItems = menuItems.concat(menuItemsJson.menuItems);
+      } else {
+        var menuItems = menuItemsJson['menuItems'];
+      }
+      defer.resolve(menuItems);
+    });
+  return defer.promise;
+};
 
 CoreCommandRouter.prototype.usbAudioAttach = function () {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    if (typeof self.platformspecific.usbAudioAttach === "function") {
-        self.platformspecific.usbAudioAttach();
-    } else {
-        defer.resolve();
-	}
-    return defer.promise
-}
+  if (typeof self.platformspecific.usbAudioAttach === 'function') {
+    self.platformspecific.usbAudioAttach();
+  } else {
+    defer.resolve();
+  }
+  return defer.promise;
+};
 
 CoreCommandRouter.prototype.usbAudioDetach = function () {
-    var self=this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    if (typeof self.platformspecific.usbAudioDetach === "function") {
-        self.platformspecific.usbAudioDetach();
-    } else {
-        defer.resolve();
-    }
-    return defer.promise
-}
+  if (typeof self.platformspecific.usbAudioDetach === 'function') {
+    self.platformspecific.usbAudioDetach();
+  } else {
+    defer.resolve();
+  }
+  return defer.promise;
+};
 
 CoreCommandRouter.prototype.getMyMusicPlugins = function () {
-    var self=this;
+  var self = this;
 
-    return  this.pluginManager.getMyMusicPlugins();
-}
+  return this.pluginManager.getMyMusicPlugins();
+};
 
 CoreCommandRouter.prototype.enableDisableMyMusicPlugin = function (data) {
-    var self=this;
+  var self = this;
 
-    return  this.pluginManager.enableDisableMyMusicPlugin(data);
-}
+  return this.pluginManager.enableDisableMyMusicPlugin(data);
+};
 
 CoreCommandRouter.prototype.addPluginRestEndpoint = function (data) {
-    var self=this;
-    var updated = false;
+  var self = this;
+  var updated = false;
 
-    if (data.endpoint && data.type && data.name && data.method) {
-        if (self.pluginsRestEndpoints.length) {
-            for (var i in self.pluginsRestEndpoints) {
-                var endpoint = self.pluginsRestEndpoints[i];
-                if (endpoint.endpoint === data.endpoint) {
-                    updated = true;
-                    endpoint = data;
-                    return self.logger.info('Updating ' + data.endpoint + ' REST Endpoint for plugin: ' + data.type + '/' + data.name);
-                }
-            }
-            if (!updated) {
-                self.logger.info('Adding ' + data.endpoint + ' REST Endpoint for plugin: ' + data.type + '/' + data.name);
-                self.pluginsRestEndpoints.push(data);
-            }
-        } else {
-            self.logger.info('Adding ' + data.endpoint + ' REST Endpoint for plugin: ' + data.type + '/' + data.name);
-            self.pluginsRestEndpoints.push(data);
+  if (data.endpoint && data.type && data.name && data.method) {
+    if (self.pluginsRestEndpoints.length) {
+      for (var i in self.pluginsRestEndpoints) {
+        var endpoint = self.pluginsRestEndpoints[i];
+        if (endpoint.endpoint === data.endpoint) {
+          updated = true;
+          endpoint = data;
+          return self.logger.info('Updating ' + data.endpoint + ' REST Endpoint for plugin: ' + data.type + '/' + data.name);
         }
+      }
+      if (!updated) {
+        self.logger.info('Adding ' + data.endpoint + ' REST Endpoint for plugin: ' + data.type + '/' + data.name);
+        self.pluginsRestEndpoints.push(data);
+      }
     } else {
-        self.logger.error('Not Adding plugin to REST Endpoints, missing parameters');
+      self.logger.info('Adding ' + data.endpoint + ' REST Endpoint for plugin: ' + data.type + '/' + data.name);
+      self.pluginsRestEndpoints.push(data);
     }
-}
+  } else {
+    self.logger.error('Not Adding plugin to REST Endpoints, missing parameters');
+  }
+};
 
 CoreCommandRouter.prototype.getPluginsRestEndpoints = function () {
-    var self=this;
+  var self = this;
 
-    return self.pluginsRestEndpoints
-}
+  return self.pluginsRestEndpoints;
+};
 
 CoreCommandRouter.prototype.getPluginEnabled = function (category, pluginName) {
-    var self=this;
+  var self = this;
 
-    return this.pluginManager.isEnabled(category, pluginName);
-}
+  return this.pluginManager.isEnabled(category, pluginName);
+};
 
 CoreCommandRouter.prototype.getSystemVersion = function () {
-    var self=this;
+  var self = this;
 
-    return this.executeOnPlugin('system_controller', 'system', 'getSystemVersion', '');
-}
+  return this.executeOnPlugin('system_controller', 'system', 'getSystemVersion', '');
+};
 
 CoreCommandRouter.prototype.getAdvancedSettingsStatus = function () {
-    var self=this;
+  var self = this;
 
-    return this.executeOnPlugin('system_controller', 'system', 'getAdvancedSettingsStatus', '');
-}
+  return this.executeOnPlugin('system_controller', 'system', 'getAdvancedSettingsStatus', '');
+};
 
 CoreCommandRouter.prototype.getExperienceAdvancedSettings = function () {
-    var self=this;
+  var self = this;
 
-    return this.executeOnPlugin('system_controller', 'system', 'getExperienceAdvancedSettings', '');
-}
+  return this.executeOnPlugin('system_controller', 'system', 'getExperienceAdvancedSettings', '');
+};
 
 CoreCommandRouter.prototype.broadcastUiSettings = function () {
-    var self=this;
-    var returnedData = self.executeOnPlugin('miscellanea', 'appearance', 'getUiSettings', '');
+  var self = this;
+  var returnedData = self.executeOnPlugin('miscellanea', 'appearance', 'getUiSettings', '');
 
-    if (returnedData != undefined) {
-        returnedData.then(function (data) {
-            self.broadcastMessage('pushUiSettings', data);
-        });
-    }
-}
+  if (returnedData != undefined) {
+    returnedData.then(function (data) {
+      self.broadcastMessage('pushUiSettings', data);
+    });
+  }
+};
 
 // ============================  AUDIO OUTPUTS =================================
 
-
 CoreCommandRouter.prototype.addAudioOutput = function (data) {
-	var self = this;
+  var self = this;
 
-	var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
-	if (audioOutputPlugin != undefined && typeof audioOutputPlugin.addAudioOutput === "function") {
-		return audioOutputPlugin.addAudioOutput(data);
-	} else {
-		this.logger.error('WARNING: No Audio Output plugin found');
-	}
-
+  var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
+  if (audioOutputPlugin != undefined && typeof audioOutputPlugin.addAudioOutput === 'function') {
+    return audioOutputPlugin.addAudioOutput(data);
+  } else {
+    this.logger.error('WARNING: No Audio Output plugin found');
+  }
 };
 
 CoreCommandRouter.prototype.updateAudioOutput = function (data) {
-	var self = this;
+  var self = this;
 
-	var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
-	if (audioOutputPlugin != undefined && typeof audioOutputPlugin.updateAudioOutput === "function") {
-		return audioOutputPlugin.updateAudioOutput(data);
-	} else {
-		this.logger.error('WARNING: No Audio Output plugin found');
-	}
+  var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
+  if (audioOutputPlugin != undefined && typeof audioOutputPlugin.updateAudioOutput === 'function') {
+    return audioOutputPlugin.updateAudioOutput(data);
+  } else {
+    this.logger.error('WARNING: No Audio Output plugin found');
+  }
 };
 
 CoreCommandRouter.prototype.removeAudioOutput = function (id) {
-	var self = this;
+  var self = this;
 
-	var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
-	if (audioOutputPlugin != undefined && typeof audioOutputPlugin.removeAudioOutput === "function") {
-		return audioOutputPlugin.removeAudioOutput(id);
-	} else {
-		this.logger.error('WARNING: No Audio Output plugin found');
-	}
+  var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
+  if (audioOutputPlugin != undefined && typeof audioOutputPlugin.removeAudioOutput === 'function') {
+    return audioOutputPlugin.removeAudioOutput(id);
+  } else {
+    this.logger.error('WARNING: No Audio Output plugin found');
+  }
 };
 
 CoreCommandRouter.prototype.getAudioOutputs = function () {
-	var self = this;
+  var self = this;
 
-	var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
-	if (audioOutputPlugin != undefined && typeof audioOutputPlugin.getAudioOutputs === "function") {
-		return audioOutputPlugin.getAudioOutputs();
-	} else {
-		this.logger.error('WARNING: No Audio Output plugin found');
-	}
+  var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
+  if (audioOutputPlugin != undefined && typeof audioOutputPlugin.getAudioOutputs === 'function') {
+    return audioOutputPlugin.getAudioOutputs();
+  } else {
+    this.logger.error('WARNING: No Audio Output plugin found');
+  }
 };
 
 CoreCommandRouter.prototype.enableAudioOutput = function (data) {
-	var self = this;
+  var self = this;
 
-	var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
-	if (audioOutputPlugin != undefined && typeof audioOutputPlugin.enableAudioOutput === "function") {
-		return audioOutputPlugin.enableAudioOutput(data);
-	} else {
-		this.logger.error('WARNING: No Audio Output plugin found');
-	}
+  var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
+  if (audioOutputPlugin != undefined && typeof audioOutputPlugin.enableAudioOutput === 'function') {
+    return audioOutputPlugin.enableAudioOutput(data);
+  } else {
+    this.logger.error('WARNING: No Audio Output plugin found');
+  }
 };
 
 CoreCommandRouter.prototype.disableAudioOutput = function (id) {
-	var self = this;
+  var self = this;
 
-	var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
-	if (audioOutputPlugin != undefined && typeof audioOutputPlugin.disableAudioOutput === "function") {
-		return audioOutputPlugin.disableAudioOutput(id);
-	} else {
-		this.logger.error('WARNING: No Audio Output plugin found');
-	}
+  var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
+  if (audioOutputPlugin != undefined && typeof audioOutputPlugin.disableAudioOutput === 'function') {
+    return audioOutputPlugin.disableAudioOutput(id);
+  } else {
+    this.logger.error('WARNING: No Audio Output plugin found');
+  }
 };
 
 CoreCommandRouter.prototype.setAudioOutputVolume = function (data) {
-	var self = this;
+  var self = this;
 
-	var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
-	if (audioOutputPlugin != undefined && typeof audioOutputPlugin.setAudioOutputVolume === "function") {
-		return audioOutputPlugin.setAudioOutputVolume(data);
-	} else {
-		this.logger.error('WARNING: No Audio Output plugin found');
-	}
+  var audioOutputPlugin = this.pluginManager.getPlugin('audio_interface', 'outputs');
+  if (audioOutputPlugin != undefined && typeof audioOutputPlugin.setAudioOutputVolume === 'function') {
+    return audioOutputPlugin.setAudioOutputVolume(data);
+  } else {
+    this.logger.error('WARNING: No Audio Output plugin found');
+  }
 };
 
 CoreCommandRouter.prototype.getHwuuid = function () {
-    var self = this;
+  var self = this;
 
-    return self.executeOnPlugin('system_controller', 'system', 'getHwuuid', '');
+  return self.executeOnPlugin('system_controller', 'system', 'getHwuuid', '');
 };
 
 CoreCommandRouter.prototype.setOauthData = function (data) {
-    var self = this;
+  var self = this;
 
-    var pluginCategory = data.plugin.split('/')[0];
-    var pluginName = data.plugin.split('/')[1];
+  var pluginCategory = data.plugin.split('/')[0];
+  var pluginName = data.plugin.split('/')[1];
 
-    var thisPlugin = this.pluginManager.getPlugin(pluginCategory, pluginName);
-    if (thisPlugin != undefined && typeof thisPlugin.oauthLogin === "function") {
-        return thisPlugin.oauthLogin(data);
-    } else {
-        self.logger.error('Could not execute OAUTH Login: no function for plugin ' + pluginCategory + ' ' + pluginName);
-	}
+  var thisPlugin = this.pluginManager.getPlugin(pluginCategory, pluginName);
+  if (thisPlugin != undefined && typeof thisPlugin.oauthLogin === 'function') {
+    return thisPlugin.oauthLogin(data);
+  } else {
+    self.logger.error('Could not execute OAUTH Login: no function for plugin ' + pluginCategory + ' ' + pluginName);
+  }
 };

--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -13,1045 +13,1139 @@ var additionalSVInfo;
 // Define the ControllerSystem class
 module.exports = ControllerSystem;
 
-function ControllerSystem(context) {
-    var self = this;
+function ControllerSystem (context) {
+  var self = this;
 
+  // Save a reference to the parent commandRouter
+  self.context = context;
+  self.commandRouter = self.context.coreCommand;
+  self.configManager = self.context.configManager;
 
-    // Save a reference to the parent commandRouter
-    self.context = context;
-    self.commandRouter = self.context.coreCommand;
-    self.configManager=self.context.configManager;
-
-    self.logger = self.context.logger;
-    self.callbacks = [];
+  self.logger = self.context.logger;
+  self.callbacks = [];
 }
 
 ControllerSystem.prototype.onVolumioStart = function () {
-    var self = this;
+  var self = this;
 
-    //getting configuration
-    var configFile = this.commandRouter.pluginManager.getConfigurationFile(this.context, 'config.json');
+  // getting configuration
+  var configFile = this.commandRouter.pluginManager.getConfigurationFile(this.context, 'config.json');
 
-	this.config = new (require('v-conf'))();
-	this.config.loadFile(configFile);
+  this.config = new (require('v-conf'))();
+  this.config.loadFile(configFile);
 
-	var uuid = this.config.get('uuid');
-	if (uuid == undefined) {
-		console.log("No id defined. Creating one");
-		var uuid = require('node-uuid');
-		self.config.addConfigValue('uuid', 'string', uuid.v4());
-	}
+  var uuid = this.config.get('uuid');
+  if (uuid == undefined) {
+    console.log('No id defined. Creating one');
+    var uuid = require('node-uuid');
+    self.config.addConfigValue('uuid', 'string', uuid.v4());
+  }
 
-    this.commandRouter.sharedVars.addConfigValue('system.uuid', 'string', uuid);
-	this.commandRouter.sharedVars.addConfigValue('system.name', 'string', self.config.get('playerName'));
+  this.commandRouter.sharedVars.addConfigValue('system.uuid', 'string', uuid);
+  this.commandRouter.sharedVars.addConfigValue('system.name', 'string', self.config.get('playerName'));
 
-    process.env.ADVANCED_SETTINGS_MODE = this.config.get('advanced_settings_mode', true);
+  process.env.ADVANCED_SETTINGS_MODE = this.config.get('advanced_settings_mode', true);
 
-	self.deviceDetect();
-	self.callHome();
+  self.deviceDetect();
+  self.callHome();
 
-    return libQ.resolve();
+  return libQ.resolve();
 };
 
 ControllerSystem.prototype.onStop = function () {
-    var self = this;
-    //Perform startup tasks here
+  var self = this;
+  // Perform startup tasks here
 };
 
 ControllerSystem.prototype.onRestart = function () {
-    var self = this;
-    //Perform startup tasks here
+  var self = this;
+  // Perform startup tasks here
 };
 
 ControllerSystem.prototype.onInstall = function () {
-    var self = this;
-    //Perform your installation tasks here
+  var self = this;
+  // Perform your installation tasks here
 };
 
 ControllerSystem.prototype.onUninstall = function () {
-    var self = this;
-    //Perform your installation tasks here
+  var self = this;
+  // Perform your installation tasks here
 };
 
 ControllerSystem.prototype.getUIConfig = function () {
-	var self = this;
-	var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-	var lang_code = self.commandRouter.sharedVars.get('language_code');
-    var showLanguageSelector = self.getAdditionalConf('miscellanea', 'appearance', 'language_on_system_page', false);
-    var device = self.config.get('device', '');
-    var showDiskInstaller = self.config.get('show_disk_installer', true);
-	var HDMIEnabled = self.config.get('hdmi_enabled', false);
-	self.commandRouter.i18nJson(__dirname+'/../../../i18n/strings_'+lang_code+'.json',
-		__dirname+'/../../../i18n/strings_en.json',
-		__dirname + '/UIConfig.json')
-		.then(function(uiconf)
-		{
-    self.configManager.setUIConfigParam(uiconf,'sections[0].content[0].value',self.config.get('playerName'));
-    self.configManager.setUIConfigParam(uiconf,'sections[0].content[1].value',self.config.get('startupSound'));
-    var advancedSettingsStatus = self.getAdvancedSettingsStatus();
-    self.configManager.setUIConfigParam(uiconf,'sections[0].content[3].value.value', advancedSettingsStatus);
-    self.configManager.setUIConfigParam(uiconf, 'sections[0].content[3].value.label', self.getLabelForSelect(self.configManager.getValue(uiconf, 'sections[0].content[3].options'), advancedSettingsStatus));
-    if (process.env.SHOW_ADVANCED_SETTINGS_MODE_SELECTOR === 'true') {
-        self.configManager.setUIConfigParam(uiconf,'sections[0].content[3].hidden', false);
-	}
+  var lang_code = self.commandRouter.sharedVars.get('language_code');
+  var showLanguageSelector = self.getAdditionalConf('miscellanea', 'appearance', 'language_on_system_page', false);
+  var device = self.config.get('device', '');
+  var showDiskInstaller = self.config.get('show_disk_installer', true);
+  var HDMIEnabled = self.config.get('hdmi_enabled', false);
+  self.commandRouter.i18nJson(__dirname + '/../../../i18n/strings_' + lang_code + '.json',
+    __dirname + '/../../../i18n/strings_en.json',
+    __dirname + '/UIConfig.json')
+    .then(function (uiconf) {
+      self.configManager.setUIConfigParam(uiconf, 'sections[0].content[0].value', self.config.get('playerName'));
+      self.configManager.setUIConfigParam(uiconf, 'sections[0].content[1].value', self.config.get('startupSound'));
+      var advancedSettingsStatus = self.getAdvancedSettingsStatus();
+      self.configManager.setUIConfigParam(uiconf, 'sections[0].content[3].value.value', advancedSettingsStatus);
+      self.configManager.setUIConfigParam(uiconf, 'sections[0].content[3].value.label', self.getLabelForSelect(self.configManager.getValue(uiconf, 'sections[0].content[3].options'), advancedSettingsStatus));
+      if (process.env.SHOW_ADVANCED_SETTINGS_MODE_SELECTOR === 'true') {
+        self.configManager.setUIConfigParam(uiconf, 'sections[0].content[3].hidden', false);
+      }
 
-    self.configManager.setUIConfigParam(uiconf,'sections[1].content[0].value', HDMIEnabled);
+      self.configManager.setUIConfigParam(uiconf, 'sections[1].content[0].value', HDMIEnabled);
 
-
-	if (device != undefined && device.length > 0 && (device === 'Tinkerboard' || device === 'x86') && showDiskInstaller) {
-		var disks = self.getDisks();
+      if (device != undefined && device.length > 0 && (device === 'Tinkerboard' || device === 'x86') && showDiskInstaller) {
+        var disks = self.getDisks();
         if (disks != undefined) {
-            disks.then(function (result) {
-				if (result.available.length > 0) {
-                    uiconf.sections[4].hidden = false;
-					var disklist = result.available;
-                    for (var i in disklist) {
-                        var device = disklist[i];
-                        var label = self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK') + ' ' + device.name;
-                        var description = self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_DESC') + ': ' + device.name + ' ' + self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_SIZE') + ': ' + device.size;
-                        var title = self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_DESC') + ' ' + device.name;
-                        var message = self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_MESSAGE') + ' ' + device.name + ' ' + device.size + '. ' + self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_MESSAGE_WARNING');
-						var onClick = {"type":"emit", "message":"installToDisk", "data":{"from": result.current, "target":device.device}, "askForConfirm": {"title": title, "message": message}}
-						var item = {"id": "install_to_disk"+device.device, "element":"button", "label": label, "description": description, "onClick" : onClick};
-                        uiconf.sections[4].content.push(item);
-                    }
-				}
-            })
-                .fail(function () {
-                });
+          disks.then(function (result) {
+            if (result.available.length > 0) {
+              uiconf.sections[4].hidden = false;
+              var disklist = result.available;
+              for (var i in disklist) {
+                var device = disklist[i];
+                var label = self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK') + ' ' + device.name;
+                var description = self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_DESC') + ': ' + device.name + ' ' + self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_SIZE') + ': ' + device.size;
+                var title = self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_DESC') + ' ' + device.name;
+                var message = self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_MESSAGE') + ' ' + device.name + ' ' + device.size + '. ' + self.commandRouter.getI18nString('SYSTEM.INSTALL_TO_DISK_MESSAGE_WARNING');
+                var onClick = {
+                  'type': 'emit',
+                  'message': 'installToDisk',
+                  'data': {
+                    'from': result.current,
+                    'target': device.device
+                  },
+                  'askForConfirm': {
+                    'title': title,
+                    'message': message
+                  }
+                };
+                var item = {
+                  'id': 'install_to_disk' + device.device,
+                  'element': 'button',
+                  'label': label,
+                  'description': description,
+                  'onClick': onClick
+                };
+                uiconf.sections[4].content.push(item);
+              }
+            }
+          })
+            .fail(function () {});
         }
+      }
 
-	}
+      if (showLanguageSelector) {
+        self.commandRouter.i18nJson(__dirname + '/../../../i18n/strings_' + lang_code + '.json',
+          __dirname + '/../../../i18n/strings_en.json',
+          __dirname + '/language_selector.json')
+          .then(function (languageSelector) {
+            var languagesdata = fs.readJsonSync(('/volumio/app/plugins/miscellanea/appearance/languages.json'), 'utf8', {
+              throws: false
+            });
+            var language = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getConfigParam', 'language');
+            var language_code = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getConfigParam', 'language_code');
+            uiconf.sections.unshift(languageSelector);
 
+            self.configManager.setUIConfigParam(uiconf, 'sections[0].content[0].value', {
+              value: language_code,
+              label: language
+            });
 
-    if (showLanguageSelector) {
-        self.commandRouter.i18nJson(__dirname+'/../../../i18n/strings_'+lang_code+'.json',
-            __dirname+'/../../../i18n/strings_en.json',
-            __dirname + '/language_selector.json')
-            .then(function(languageSelector)
-            {
-        	var languagesdata = fs.readJsonSync(('/volumio/app/plugins/miscellanea/appearance/languages.json'),  'utf8', {throws: false});
-        	var language = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getConfigParam', 'language');
-        	var language_code = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'getConfigParam', 'language_code');
-        	uiconf.sections.unshift(languageSelector);
-
-        	self.configManager.setUIConfigParam(uiconf, 'sections[0].content[0].value', {
-            value: language_code,
-            label: language
-        	});
-
-        	for (var n = 0; n < languagesdata.languages.length; n++){
-				self.configManager.pushUIConfigParam(uiconf, 'sections[0].content[0].options', {
+            for (var n = 0; n < languagesdata.languages.length; n++) {
+              self.configManager.pushUIConfigParam(uiconf, 'sections[0].content[0].options', {
                 value: languagesdata.languages[n].code,
                 label: languagesdata.languages[n].name
-				});
-        	}
-                defer.resolve(uiconf);
-            })
-    } else {
+              });
+            }
+            defer.resolve(uiconf);
+          });
+      } else {
         defer.resolve(uiconf);
-	}
+      }
+    })
+    .fail(function (error) {
+      self.logger.info(error);
+      defer.reject(new Error());
+    });
 
-
-		})
-		.fail(function(error)
-		{   self.logger.info(error);
-			defer.reject(new Error());
-		})
-
-	return defer.promise
+  return defer.promise;
 };
 
-
-ControllerSystem.prototype.capitalize = function() {
-	return this.charAt(0).toUpperCase() + this.slice(1);
-}
+ControllerSystem.prototype.capitalize = function () {
+  return this.charAt(0).toUpperCase() + this.slice(1);
+};
 
 ControllerSystem.prototype.setUIConfig = function (data) {
-    var self = this;
+  var self = this;
 
-    var uiconf = fs.readJsonSync(__dirname + '/UIConfig.json');
-
+  var uiconf = fs.readJsonSync(__dirname + '/UIConfig.json');
 };
 
 ControllerSystem.prototype.getConf = function (varName) {
-    var self = this;
+  var self = this;
 
-    return self.config.get(varName);
+  return self.config.get(varName);
 };
 
 ControllerSystem.prototype.setConf = function (varName, varValue) {
-    var self = this;
+  var self = this;
 
-    var defer = libQ.defer();
+  var defer = libQ.defer();
 
-    self.config.set(varName, varValue);
-    if (varName = 'player_name') {
-        var player_name = varValue;
+  self.config.set(varName, varValue);
+  if (varName = 'player_name') {
+    var player_name = varValue;
 
-        for (var i in self.callbacks) {
-            var callback = self.callbacks[i];
+    for (var i in self.callbacks) {
+      var callback = self.callbacks[i];
 
-            callback.call(callback, player_name);
-        }
-        return defer.promise;
+      callback.call(callback, player_name);
     }
+    return defer.promise;
+  }
 };
-
 
 ControllerSystem.prototype.getConfigurationFiles = function () {
-    var self = this;
+  var self = this;
 
-    return ['config.json'];
+  return ['config.json'];
 };
 
-//Optional functions exposed for making development easier and more clear
+// Optional functions exposed for making development easier and more clear
 ControllerSystem.prototype.getSystemConf = function (pluginName, varName) {
-    var self = this;
-    //Perform your installation tasks here
+  var self = this;
+  // Perform your installation tasks here
 };
 
 ControllerSystem.prototype.setSystemConf = function (pluginName, varName) {
-    var self = this;
-    //Perform your installation tasks here
+  var self = this;
+  // Perform your installation tasks here
 };
 
 ControllerSystem.prototype.getAdditionalConf = function () {
-    var self = this;
-    //Perform your installation tasks here
+  var self = this;
+  // Perform your installation tasks here
 };
 
 ControllerSystem.prototype.setAdditionalConf = function () {
-    var self = this;
-    //Perform your installation tasks here
+  var self = this;
+  // Perform your installation tasks here
 };
 
 ControllerSystem.prototype.getConfigParam = function (key) {
-    return this.config.get(key);
+  return this.config.get(key);
 };
 
 ControllerSystem.prototype.saveGeneralSettings = function (data) {
-    var self = this;
+  var self = this;
 
-    var defer = libQ.defer();
+  var defer = libQ.defer();
 
-    if (data['startup_sound'] != undefined) {
-        self.config.set('startupSound', data['startup_sound']);
+  if (data['startup_sound'] != undefined) {
+    self.config.set('startupSound', data['startup_sound']);
+  }
+
+  if (data['advanced_settings'] !== undefined && data['advanced_settings'].value !== undefined) {
+    self.config.set('advanced_settings_mode', data['advanced_settings'].value);
+    process.env.ADVANCED_SETTINGS_MODE = data['advanced_settings'].value;
+  }
+
+  var oldPlayerName = self.config.get('playerName');
+  var player_name = data['player_name'];
+  if (player_name !== oldPlayerName) {
+    var hostname = data['player_name'].split(' ').join('-');
+    self.config.set('playerName', player_name);
+    self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE_SUCCESS'));
+    self.setHostname(player_name);
+    self.commandRouter.sharedVars.set('system.name', player_name);
+    defer.resolve({});
+
+    for (var i in self.callbacks) {
+      var callback = self.callbacks[i];
+
+      callback.call(callback, player_name);
     }
+  } else {
+    defer.resolve({});
+  }
 
-    if (data['advanced_settings'] !== undefined && data['advanced_settings'].value !== undefined) {
-        self.config.set('advanced_settings_mode', data['advanced_settings'].value);
-        process.env.ADVANCED_SETTINGS_MODE = data['advanced_settings'].value;
-    }
-
-    var oldPlayerName = self.config.get('playerName');
-    var player_name = data['player_name'];
-    if (player_name !== oldPlayerName) {
-        var hostname = data['player_name'].split(" ").join("-");
-        self.config.set('playerName', player_name);
-        self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE_SUCCESS'));
-        self.setHostname(player_name);
-        self.commandRouter.sharedVars.set('system.name', player_name);
-        defer.resolve({});
-
-        for (var i in self.callbacks) {
-            var callback = self.callbacks[i];
-
-            callback.call(callback, player_name);
-        }
-	} else {
-        defer.resolve({});
-	}
-
-    return defer.promise;
+  return defer.promise;
 };
 
 ControllerSystem.prototype.saveSoundQuality = function (data) {
-    var self = this;
+  var self = this;
 
-    var defer = libQ.defer();
+  var defer = libQ.defer();
 
-    var kernel_profile_value = data['kernel_profile'].value;
-    var kernel_profile_label = data['kernel_profile'].label;
+  var kernel_profile_value = data['kernel_profile'].value;
+  var kernel_profile_label = data['kernel_profile'].label;
 
-    self.config.set('kernelSettingValue', kernel_profile_value);
-    self.config.set('kernelSettingLabel', kernel_profile_label);
+  self.config.set('kernelSettingValue', kernel_profile_value);
+  self.config.set('kernelSettingLabel', kernel_profile_label);
 
-	self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE_SUCCESS'));
+  self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE_SUCCESS'));
 
-    defer.resolve({});
-    return defer.promise;
+  defer.resolve({});
+  return defer.promise;
 };
 
-
 ControllerSystem.prototype.getData = function (data, key) {
-    var self = this;
+  var self = this;
 
-    for (var i in data) {
-        var ithdata = data[i];
+  for (var i in data) {
+    var ithdata = data[i];
 
-        if (ithdata[key] != undefined)
-            return ithdata[key];
+    if (ithdata[key] != undefined) {
+      return ithdata[key];
     }
+  }
 
-    return null;
+  return null;
 };
 
 ControllerSystem.prototype.setHostname = function (hostname) {
-	var self = this;
-	var newhostname = hostname.toLowerCase().replace(/ /g,'-');
+  var self = this;
+  var newhostname = hostname.toLowerCase().replace(/ /g, '-');
 
-	fs.writeFile('/etc/hostname', newhostname, function (err) {
-		if (err) {
-			console.log(err);
-			self.commandRouter.pushToastMessage('alert', self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME_ERROR'));
-		}
-		else {
-			exec("/usr/bin/sudo /bin/chmod 777 /etc/hosts", {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
-				if (error !== null) {
-					console.log('Cannot set permissions for /etc/hosts: ' + error);
+  fs.writeFile('/etc/hostname', newhostname, function (err) {
+    if (err) {
+      console.log(err);
+      self.commandRouter.pushToastMessage('alert', self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME_ERROR'));
+    } else {
+      exec('/usr/bin/sudo /bin/chmod 777 /etc/hosts', {
+        uid: 1000,
+        gid: 1000
+      }, function (error, stdout, stderr) {
+        if (error !== null) {
+          console.log('Cannot set permissions for /etc/hosts: ' + error);
+        } else {
+          self.logger.info('Permissions for /etc/hosts set');
+          exec('/usr/bin/sudo /bin/hostname ' + newhostname, {
+            uid: 1000,
+            gid: 1000
+          }, function (error, stdout, stderr) {
+            if (error !== null) {
+              console.log('Cannot set new hostname: ' + error);
+            } else {
+              self.logger.info('New hostname set');
+            }
+          });
+        }
 
-				} else {
-					self.logger.info('Permissions for /etc/hosts set')
-					exec("/usr/bin/sudo /bin/hostname "+ newhostname, {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
-						if (error !== null) {
-							console.log('Cannot set new hostname: ' + error);
-
-						} else {
-							self.logger.info('New hostname set')
-						}
-					});
-				}
-
-
-				fs.writeFile('/etc/hosts', '127.0.0.1       localhost ' + newhostname, function (err) {
-					if (err) {
-						console.log(err);
-					}
-					else {
-						self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME_NOW') + ' ' + hostname);
-						self.logger.info('Hostname now is ' + newhostname);
-						var avahiconf = '<?xml version="1.0" standalone="no"?><service-group><name replace-wildcards="yes">'+ hostname +'</name><service><type>_http._tcp</type><port>80</port></service></service-group>';
-						exec("/usr/bin/sudo /bin/chmod -R 777 /etc/avahi/services/", {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
-							if (error !== null) {
-								console.log('Cannot set permissions for /etc/avahi/services/: ' + error);
-
-							} else {
-								self.logger.info('Permissions for /etc/avahi/services/volumio.service')
-								fs.writeFile('/etc/avahi/services/volumio.service', avahiconf, function (err) {
-									if (err) {
-										console.log(err);
-									} else {
-										self.logger.info('Avahi name changed to '+ newhostname);
-									}
-								});
-							}
-
-						});
-						setTimeout(function () {
-							// Restarting AVAHI results in system crashing
-							//self.restartAvahi();
-						}, 10000)
-					}
-				});
-			});
-		}
-
-	});
-
+        fs.writeFile('/etc/hosts', '127.0.0.1       localhost ' + newhostname, function (err) {
+          if (err) {
+            console.log(err);
+          } else {
+            self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME_NOW') + ' ' + hostname);
+            self.logger.info('Hostname now is ' + newhostname);
+            var avahiconf = '<?xml version="1.0" standalone="no"?><service-group><name replace-wildcards="yes">' + hostname + '</name><service><type>_http._tcp</type><port>80</port></service></service-group>';
+            exec('/usr/bin/sudo /bin/chmod -R 777 /etc/avahi/services/', {
+              uid: 1000,
+              gid: 1000
+            }, function (error, stdout, stderr) {
+              if (error !== null) {
+                console.log('Cannot set permissions for /etc/avahi/services/: ' + error);
+              } else {
+                self.logger.info('Permissions for /etc/avahi/services/volumio.service');
+                fs.writeFile('/etc/avahi/services/volumio.service', avahiconf, function (err) {
+                  if (err) {
+                    console.log(err);
+                  } else {
+                    self.logger.info('Avahi name changed to ' + newhostname);
+                  }
+                });
+              }
+            });
+            setTimeout(function () {
+              // Restarting AVAHI results in system crashing
+              // self.restartAvahi();
+            }, 10000);
+          }
+        });
+      });
+    }
+  });
 };
 
 ControllerSystem.prototype.restartAvahi = function () {
-    var self = this;
+  var self = this;
 
-    exec("/usr/bin/sudo /bin/systemctl restart avahi-daemon.service", {
-        uid: 1000,
-        gid: 1000
-    }, function (error, stdout, stderr) {
-        if (error !== null) {
-            console.log(error);
-            self.commandRouter.pushToastMessage('alert', self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME_ERROR'));
-        } else {
-            self.logger.info('Avahi Daemon Restarted')
-        }
-    });
+  exec('/usr/bin/sudo /bin/systemctl restart avahi-daemon.service', {
+    uid: 1000,
+    gid: 1000
+  }, function (error, stdout, stderr) {
+    if (error !== null) {
+      console.log(error);
+      self.commandRouter.pushToastMessage('alert', self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_NAME_ERROR'));
+    } else {
+      self.logger.info('Avahi Daemon Restarted');
+    }
+  });
 };
 
-
-
 ControllerSystem.prototype.registerCallback = function (callback) {
-    var self = this;
+  var self = this;
 
-    self.callbacks.push(callback);
+  self.callbacks.push(callback);
 };
 
 ControllerSystem.prototype.getSystemVersion = function () {
-	var self = this;
-	var defer = libQ.defer();
-	var file = fs.readFileSync('/etc/os-release').toString().split('\n');
-	var releaseinfo = {
-		'systemversion': null,
-		'builddate': null,
-		'variant': null,
-		'hardware':null
-	};
-	//console.log(file);
-	var nLines = file.length;
-	var str;
-	for (var l = 0; l < nLines; l++) {
-		if (file[l].match(/VOLUMIO_VERSION/i)) {
-			str = file[l].split('=');
-			releaseinfo.systemversion = str[1].replace(/\"/gi, "");
-		}
-		if (file[l].match(/VOLUMIO_BUILD_DATE/i)) {
-			str = file[l].split('=');
-			releaseinfo.builddate = str[1].replace(/\"/gi, "");
-		}
-		if (file[l].match(/VOLUMIO_VARIANT/i)) {
-			str = file[l].split('=');
-			releaseinfo.variant = str[1].replace(/\"/gi, "");
-		}
-		if (file[l].match(/VOLUMIO_HARDWARE/i)) {
-			str = file[l].split('=');
-			releaseinfo.hardware = str[1].replace(/\"/gi, "");
-		}
-	}
+  var self = this;
+  var defer = libQ.defer();
+  var file = fs.readFileSync('/etc/os-release').toString().split('\n');
+  var releaseinfo = {
+    'systemversion': null,
+    'builddate': null,
+    'variant': null,
+    'hardware': null
+  };
+  // console.log(file);
+  var nLines = file.length;
+  var str;
+  for (var l = 0; l < nLines; l++) {
+    if (file[l].match(/VOLUMIO_VERSION/i)) {
+      str = file[l].split('=');
+      releaseinfo.systemversion = str[1].replace(/\"/gi, '');
+    }
+    if (file[l].match(/VOLUMIO_BUILD_DATE/i)) {
+      str = file[l].split('=');
+      releaseinfo.builddate = str[1].replace(/\"/gi, '');
+    }
+    if (file[l].match(/VOLUMIO_VARIANT/i)) {
+      str = file[l].split('=');
+      releaseinfo.variant = str[1].replace(/\"/gi, '');
+    }
+    if (file[l].match(/VOLUMIO_HARDWARE/i)) {
+      str = file[l].split('=');
+      releaseinfo.hardware = str[1].replace(/\"/gi, '');
+    }
+  }
 
-	if (additionalSVInfo) {
-        releaseinfo.additionalSVInfo = additionalSVInfo;
-	}
+  if (additionalSVInfo) {
+    releaseinfo.additionalSVInfo = additionalSVInfo;
+  }
 
-	defer.resolve(releaseinfo);
+  defer.resolve(releaseinfo);
 
-	return defer.promise;
+  return defer.promise;
 };
 
 ControllerSystem.prototype.setTestSystem = function (data) {
-    var self = this;
+  var self = this;
 
-    if (data == 'true') {
-        fs.writeFile('/data/test', ' ', function (err) {
-            if (err) {
-                self.logger.info('Cannot set as test device:' + err)
-            }
-            self.logger.info('Device is now in test mode')
-        });
-    } else if (data == 'false') {
-        fs.exists('/data/test', function (exists) {
-            exec('rm /data/test', function (error, stdout, stderr) {
-                if (error !== null) {
-                    console.log(error);
-                    self.logger.info('Cannot delete test file: ' + error);
-                } else {
-                    self.logger.info('Test File deleted');
-                }
-            });
-        });
-
-    }
+  if (data == 'true') {
+    fs.writeFile('/data/test', ' ', function (err) {
+      if (err) {
+        self.logger.info('Cannot set as test device:' + err);
+      }
+      self.logger.info('Device is now in test mode');
+    });
+  } else if (data == 'false') {
+    fs.exists('/data/test', function (exists) {
+      exec('rm /data/test', function (error, stdout, stderr) {
+        if (error !== null) {
+          console.log(error);
+          self.logger.info('Cannot delete test file: ' + error);
+        } else {
+          self.logger.info('Test File deleted');
+        }
+      });
+    });
+  }
 };
 
-
 ControllerSystem.prototype.sendBugReport = function (message) {
-	var self = this;
+  var self = this;
 
-	if (message == undefined || message.text == undefined || message.text.length < 1 ) {
-		message.text = 'No info available';
-	}
-	// Must single-quote the message or the shell may interpret it and crash.
-	// single-quotes already within the message need to be escaped.
-	// The resulting string always starts and ends with single quotes.
-	var description = '';
-	var pieces = message.text.split("'");
-	var n = pieces.length;
-	for (var i=0; i<n; i++) {
-		description = description + "'" + pieces[i] + "'";
-		if (i < (n-1)) description = description + "\\'";
-	}
+  if (message == undefined || message.text == undefined || message.text.length < 1) {
+    message.text = 'No info available';
+  }
+  // Must single-quote the message or the shell may interpret it and crash.
+  // single-quotes already within the message need to be escaped.
+  // The resulting string always starts and ends with single quotes.
+  var description = '';
+  var pieces = message.text.split("'");
+  var n = pieces.length;
+  for (var i = 0; i < n; i++) {
+    description = description + "'" + pieces[i] + "'";
+    if (i < (n - 1)) description = description + "\\'";
+  }
 
-	exec("/usr/local/bin/node /volumio/logsubmit.js " + description, {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
-		if (error !== null) {
-			self.logger.info('Cannot send bug report: ' + error);
-		} else {
-			self.logger.info('Log sent successfully, reply: '+stdout);
-			//if (stdout != undefined && stdout.status != undefined && stdout.status == 'OK' && stdout.link != undefined ) {
-				return self.commandRouter.broadcastMessage('pushSendBugReport', stdout);
-			//}
-
-
-
-
-		}
-	});
-
+  exec('/usr/local/bin/node /volumio/logsubmit.js ' + description, {
+    uid: 1000,
+    gid: 1000
+  }, function (error, stdout, stderr) {
+    if (error !== null) {
+      self.logger.info('Cannot send bug report: ' + error);
+    } else {
+      self.logger.info('Log sent successfully, reply: ' + stdout);
+      // if (stdout != undefined && stdout.status != undefined && stdout.status == 'OK' && stdout.link != undefined ) {
+      return self.commandRouter.broadcastMessage('pushSendBugReport', stdout);
+      // }
+    }
+  });
 };
 
 ControllerSystem.prototype.deleteUserData = function () {
-    var self = this;
+  var self = this;
 
-    fs.writeFile('/boot/user_data', ' ', function (err) {
-        if (err) {
-            self.logger.info('Cannot User Data delete file');
-        } else {
-            self.logger.info('Created User Data delete file, rebooting');
-            self.commandRouter.reboot();
-        }
-
-    });
+  fs.writeFile('/boot/user_data', ' ', function (err) {
+    if (err) {
+      self.logger.info('Cannot User Data delete file');
+    } else {
+      self.logger.info('Created User Data delete file, rebooting');
+      self.commandRouter.reboot();
+    }
+  });
 };
 
 ControllerSystem.prototype.factoryReset = function () {
-    var self = this;
+  var self = this;
 
-    fs.writeFile('/boot/factory_reset', ' ', function (err) {
-        if (err) {
-            self.logger.info('Cannot Initiate factory reset');
-        } else {
-            self.logger.info('Created Factory Reset file, rebooting');
-            self.commandRouter.reboot();
-        }
-
-    });
+  fs.writeFile('/boot/factory_reset', ' ', function (err) {
+    if (err) {
+      self.logger.info('Cannot Initiate factory reset');
+    } else {
+      self.logger.info('Created Factory Reset file, rebooting');
+      self.commandRouter.reboot();
+    }
+  });
 };
 
-
 ControllerSystem.prototype.deviceDetect = function (data) {
-	var self = this;
-	var defer = libQ.defer();
-	var device = '';
+  var self = this;
+  var defer = libQ.defer();
+  var device = '';
 
-    var info = self.getSystemVersion();
-    info.then(function(infos)
-    {
-		if (infos != undefined && infos.hardware != undefined && infos.hardware === 'x86') {
-			device = 'x86';
-            defer.resolve(device);
-            self.deviceCheck(device);
-		} else {
-            exec("cat /proc/cpuinfo | grep Hardware", {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
-                if (error !== null) {
-                    self.logger.info('Cannot read proc/cpuinfo: ' + error);
-                } else {
-                    var hardwareLine = stdout.split(":");
-                    var cpuidparam = hardwareLine[1].replace(/\s/g, '');
-                    var deviceslist = fs.readJsonSync(('/volumio/app/plugins/system_controller/system/devices.json'),  'utf8', {throws: false});
-                    //self.logger.info('CPU ID ::'+cpuidparam+'::');
-                    for(var i = 0; i < deviceslist.devices.length; i++)
-                    {
-                        if(deviceslist.devices[i].cpuid == cpuidparam)
-                        {
-                            defer.resolve(deviceslist.devices[i].name);
-                            device = deviceslist.devices[i].name;
-                            self.deviceCheck(device);
-                        }
-                    }
+  var info = self.getSystemVersion();
+  info.then(function (infos) {
+    if (infos != undefined && infos.hardware != undefined && infos.hardware === 'x86') {
+      device = 'x86';
+      defer.resolve(device);
+      self.deviceCheck(device);
+    } else {
+      exec('cat /proc/cpuinfo | grep Hardware', {
+        uid: 1000,
+        gid: 1000
+      }, function (error, stdout, stderr) {
+        if (error !== null) {
+          self.logger.info('Cannot read proc/cpuinfo: ' + error);
+        } else {
+          var hardwareLine = stdout.split(':');
+          var cpuidparam = hardwareLine[1].replace(/\s/g, '');
+          var deviceslist = fs.readJsonSync(('/volumio/app/plugins/system_controller/system/devices.json'), 'utf8', {
+            throws: false
+          });
+          // self.logger.info('CPU ID ::'+cpuidparam+'::');
+          for (var i = 0; i < deviceslist.devices.length; i++) {
+            if (deviceslist.devices[i].cpuid == cpuidparam) {
+              defer.resolve(deviceslist.devices[i].name);
+              device = deviceslist.devices[i].name;
+              self.deviceCheck(device);
+            }
+          }
+        }
+      });
+    }
+  });
 
-                }
-            });
-		}
-    });
-
-	return defer.promise;
+  return defer.promise;
 };
 
 ControllerSystem.prototype.deviceCheck = function (data) {
-    var self = this;
+  var self = this;
 
-    var device = config.get('device');
+  var device = config.get('device');
 
-    if (device == undefined) {
-        self.logger.info ('Setting Device type: ' + data)
-        self.config.set('device', data);
-    } else if (device != data) {
-        self.logger.info ('Device has changed, setting Device type: ' + data)
-        self.config.set('device', data);
-    }
-}
-
-
-ControllerSystem.prototype.callHome = function () {
-	var self = this;
-
-
-	try {
-		var macaddr = fs.readFileSync('/sys/class/net/eth0/address', "utf8");
-		var anonid = macaddr.toString().replace(':','');
-
-	} catch (e) {
-		console.log(e)
-		var anonid = self.config.get('uuid');
-	}
-	var md5 = crypto.createHash('md5').update(anonid).digest("hex");
-	var info = self.getSystemVersion();
-	info.then(function(infos)
-	{
-		if ((infos.variant) && (infos.systemversion) && (infos.hardware) && (md5)) {
-		console.log('Volumio Calling Home');
-		exec('/usr/bin/curl -X POST --data-binary "device='+ infos.hardware + '&variante=' + infos.variant + '&version=' + infos.systemversion + '&uuid=' + md5 +'" http://updates.volumio.org:7070/downloader-v1/track-device',
-			function (error, stdout, stderr) {
-
-				if (error !== null) {
-					if (calltrials < 3) {
-					setTimeout(function () {
-						self.logger.info('Cannot call home: '+error+ ' retrying in 5 seconds, trial '+calltrials);
-						calltrials++
-						self.callHome();
-					}, 10000);
-					}
-				}
-				else self.logger.info('Volumio called home');
-
-			});
-	} else {
-			self.logger.info('Cannot retrieve data for calling home');
-	}
-	});
+  if (device == undefined) {
+    self.logger.info('Setting Device type: ' + data);
+    self.config.set('device', data);
+  } else if (device != data) {
+    self.logger.info('Device has changed, setting Device type: ' + data);
+    self.config.set('device', data);
+  }
 };
 
+ControllerSystem.prototype.callHome = function () {
+  var self = this;
+
+  try {
+    var macaddr = fs.readFileSync('/sys/class/net/eth0/address', 'utf8');
+    var anonid = macaddr.toString().replace(':', '');
+  } catch (e) {
+    console.log(e);
+    var anonid = self.config.get('uuid');
+  }
+  var md5 = crypto.createHash('md5').update(anonid).digest('hex');
+  var info = self.getSystemVersion();
+  info.then(function (infos) {
+    if ((infos.variant) && (infos.systemversion) && (infos.hardware) && (md5)) {
+      console.log('Volumio Calling Home');
+      exec('/usr/bin/curl -X POST --data-binary "device=' + infos.hardware + '&variante=' + infos.variant + '&version=' + infos.systemversion + '&uuid=' + md5 + '" http://updates.volumio.org:7070/downloader-v1/track-device',
+        function (error, stdout, stderr) {
+          if (error !== null) {
+            if (calltrials < 3) {
+              setTimeout(function () {
+                self.logger.info('Cannot call home: ' + error + ' retrying in 5 seconds, trial ' + calltrials);
+                calltrials++;
+                self.callHome();
+              }, 10000);
+            }
+          } else self.logger.info('Volumio called home');
+        });
+    } else {
+      self.logger.info('Cannot retrieve data for calling home');
+    }
+  });
+};
 
 ControllerSystem.prototype.enableSSH = function (data) {
-    var self = this;
+  var self = this;
 
-    var action = 'enable';
-    var immediate = 'start'
-    if (data == 'false') {
-        action = 'disable';
-        immediate = 'stop';
+  var action = 'enable';
+  var immediate = 'start';
+  if (data == 'false') {
+    action = 'disable';
+    immediate = 'stop';
+  }
+
+  exec('/usr/bin/sudo /bin/systemctl ' + immediate + ' ssh.service && /usr/bin/sudo /bin/systemctl ' + action + ' ssh.service', {
+    uid: 1000,
+    gid: 1000
+  }, function (error, stdout, stderr) {
+    if (error !== null) {
+      console.log(error);
+      self.logger.info('Cannot ' + action + ' SSH service: ' + error);
+    } else {
+      self.logger.info(action + ' SSH service success');
     }
-
-    exec('/usr/bin/sudo /bin/systemctl '+immediate+' ssh.service && /usr/bin/sudo /bin/systemctl '+action+' ssh.service',{uid:1000,gid:1000}, function (error, stdout, stderr) {
-        if (error !== null) {
-            console.log(error);
-            self.logger.info('Cannot '+action+' SSH service: ' + error);
-        } else {
-            self.logger.info(action+ ' SSH service success');
-        }
-    });
-}
+  });
+};
 
 ControllerSystem.prototype.checkPassword = function (data) {
-	var self = this;
-	var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-	var currentpass = self.config.get('system_password', 'volumio');
+  var currentpass = self.config.get('system_password', 'volumio');
 
-	if (data.password === currentpass) {
-		defer.resolve(true);
-	} else {
-		defer.resolve(false)
-	}
+  if (data.password === currentpass) {
+    defer.resolve(true);
+  } else {
+    defer.resolve(false);
+  }
 
-
-	return defer.promise;
-}
+  return defer.promise;
+};
 
 ControllerSystem.prototype.getDisks = function () {
-	var self = this;
-	var defer = libQ.defer();
-	var availablearray = [];
+  var self = this;
+  var defer = libQ.defer();
+  var availablearray = [];
 
-	var currentdiskRaw = execSync('/bin/mount | head -n 1 | cut -d " " -f 1', { uid: 1000, gid: 1000, encoding: 'utf8'});
-	var currentdisk = currentdiskRaw.replace(/[0-9]/g, '').replace('/dev/', '').replace(/\n/,'');
+  var currentdiskRaw = execSync('/bin/mount | head -n 1 | cut -d " " -f 1', {
+    uid: 1000,
+    gid: 1000,
+    encoding: 'utf8'
+  });
+  var currentdisk = currentdiskRaw.replace(/[0-9]/g, '').replace('/dev/', '').replace(/\n/, '');
 
+  var disksraw = execSync('/bin/lsblk -P -o KNAME,SIZE,MODEL -d', {
+    uid: 1000,
+    gid: 1000,
+    encoding: 'utf8'
+  });
+  var disks = disksraw.split('\n');
 
-	var disksraw = execSync('/bin/lsblk -P -o KNAME,SIZE,MODEL -d', { uid: 1000, gid: 1000, encoding: 'utf8'});
-	var disks = disksraw.split("\n");
+  if (currentdisk === 'mmcblkp') {
+    currentdiskRaw = execSync('/bin/mount | head -n 1 | cut -d " " -f 1 | cut -d "/" -f 3 | cut -d "p" -f 1', {
+      uid: 1000,
+      gid: 1000,
+      encoding: 'utf8'
+    });
+    currentdisk = currentdiskRaw.replace(/\n/, '');
+  }
 
+  for (var i = 0; i < disks.length; i++) {
+    if ((disks[i].indexOf(currentdisk) >= 0) || (disks[i].indexOf('loop') >= 0) || (disks[i].indexOf('rpmb') >= 0) || (disks[i].indexOf('boot') >= 0)) {
 
-    if (currentdisk === 'mmcblkp') {
-        currentdiskRaw = execSync('/bin/mount | head -n 1 | cut -d " " -f 1 | cut -d "/" -f 3 | cut -d "p" -f 1', { uid: 1000, gid: 1000, encoding: 'utf8'});
-		currentdisk = currentdiskRaw.replace(/\n/,'');
+    } else {
+      var disksarray = disks[i].split(' ');
+
+      var diskinfo = {
+        'device': '',
+        'name': '',
+        'size': ''
+      };
+      var count = 0;
+      for (var a = 0; a < disksarray.length; a++) {
+        count++;
+        if (disksarray[a].indexOf('KNAME') >= 0) {
+          diskinfo.device = disksarray[a].replace('KNAME=', '').replace(/"/g, '');
+        }
+        if (disksarray[a].indexOf('SIZE') >= 0) {
+          diskinfo.size = disksarray[a].replace('SIZE=', '').replace(/"/g, '');
+        }
+        if (disksarray[a].indexOf('MODEL') >= 0) {
+          diskinfo.name = disksarray[a].replace('MODEL=', '').replace(/"/g, '');
+        }
+        if (diskinfo.device.indexOf('mmcblk') >= 0) {
+          diskinfo.name = 'eMMC/SD';
+        }
+
+        if (count === 3) {
+          if (diskinfo.device && diskinfo.size) {
+            availablearray.push(diskinfo);
+            diskinfo = {
+              'device': '',
+              'name': '',
+              'size': ''
+            };
+          }
+          count = 0;
+        }
+      }
     }
+  }
+  var final = {
+    'current': currentdisk,
+    'available': availablearray
+  };
+  defer.resolve(final);
+  // console.log('BBBBBBBBBBBBBBBBBBBBBBBBBBB'+JSON.stringify(final))
 
-	for (var i = 0; i < disks.length; i++) {
-
-		if ((disks[i].indexOf(currentdisk) >= 0) || (disks[i].indexOf('loop') >= 0) || (disks[i].indexOf('rpmb') >= 0) || (disks[i].indexOf('boot') >= 0)) {
-
-		} else {
-			var disksarray = disks[i].split(' ');
-
-			var diskinfo = {'device': '', 'name': '', 'size': ''};
-			var count = 0;
-			for (var a = 0; a < disksarray.length; a++) {
-				count++
-				if (disksarray[a].indexOf('KNAME') >= 0) {
-					diskinfo.device = disksarray[a].replace('KNAME=', '').replace(/"/g, '');
-				}
-				if (disksarray[a].indexOf('SIZE') >= 0) {
-					diskinfo.size = disksarray[a].replace('SIZE=', '').replace(/"/g, '');
-				}
-				if (disksarray[a].indexOf('MODEL') >= 0) {
-					diskinfo.name = disksarray[a].replace('MODEL=', '').replace(/"/g, '');
-				}
-				if (diskinfo.device.indexOf('mmcblk') >= 0) {
-				   diskinfo.name = 'eMMC/SD';
-				}
-
-				if (count === 3) {
-					if ( diskinfo.device && diskinfo.size) {
-						availablearray.push(diskinfo);
-						diskinfo = {'device': '', 'name': '', 'size': ''};
-					}
-					count = 0;
-				}
-
-			}
-		}
-	}
-	var final = {'current': currentdisk, 'available': availablearray};
-	defer.resolve(final);
-	//console.log('BBBBBBBBBBBBBBBBBBBBBBBBBBB'+JSON.stringify(final))
-
-	return defer.promise;
-}
+  return defer.promise;
+};
 
 ControllerSystem.prototype.installToDisk = function () {
-	var self = this;
-	var defer = libQ.defer();
-	var copymessage = self.commandRouter.getI18nString('SYSTEM.COPYING_TO_DISK_MESSAGE');
-	var modaltitle = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK');
+  var self = this;
+  var defer = libQ.defer();
+  var copymessage = self.commandRouter.getI18nString('SYSTEM.COPYING_TO_DISK_MESSAGE');
+  var modaltitle = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK');
 
-	self.startInstall()
-		.then(self.pushMessage.bind(self, 'installPluginStatus', {
-			'progress': 5,
-			'message': copymessage,
-			'title' : modaltitle
-		}))
-		.then(self.ddToDisk.bind(self))
-		.then(function (e) {
-			currentMessage = 'Unpacking plugin';
-			advancedlog = advancedlog + "<br>" + currentMessage;
-			self.pushMessage('installPluginStatus', {'progress': 40, 'message': currentMessage, 'title' : modaltitle, 'advancedLog': advancedlog});
-			return e;
-		})
+  self.startInstall()
+    .then(self.pushMessage.bind(self, 'installPluginStatus', {
+      'progress': 5,
+      'message': copymessage,
+      'title': modaltitle
+    }))
+    .then(self.ddToDisk.bind(self))
+    .then(function (e) {
+      currentMessage = 'Unpacking plugin';
+      advancedlog = advancedlog + '<br>' + currentMessage;
+      self.pushMessage('installPluginStatus', {
+        'progress': 40,
+        'message': currentMessage,
+        'title': modaltitle,
+        'advancedLog': advancedlog
+      });
+      return e;
+    });
 
-
-
-	return defer.promise;
-}
-
+  return defer.promise;
+};
 
 ControllerSystem.prototype.startInstall = function () {
-	var self = this;
-	var defer=libQ.defer();
-	var time = 0;
-	var currentMessage = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_MESSAGE');
-	var modaltitle = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK');
+  var self = this;
+  var defer = libQ.defer();
+  var time = 0;
+  var currentMessage = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_MESSAGE');
+  var modaltitle = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK');
 
-	self.pushMessage('volumioInstallStatus', {'progress': 1, 'message': currentMessage, 'title' : modaltitle})
-	setTimeout(function () {
-		defer.resolve();
-	}, 5000)
+  self.pushMessage('volumioInstallStatus', {
+    'progress': 1,
+    'message': currentMessage,
+    'title': modaltitle
+  });
+  setTimeout(function () {
+    defer.resolve();
+  }, 5000);
 
+  return defer.promise;
+};
 
-	return defer.promise;
-}
+ControllerSystem.prototype.pushMessage = function (emit, payload) {
+  var self = this;
+  var defer = libQ.defer();
 
-ControllerSystem.prototype.pushMessage = function (emit,payload) {
-	var self = this;
-	var defer=libQ.defer();
+  self.coreCommand.broadcastMessage(emit, payload);
 
-	self.coreCommand.broadcastMessage(emit,payload);
-
-	defer.resolve();
-	return defer.promise;
-}
+  defer.resolve();
+  return defer.promise;
+};
 
 ControllerSystem.prototype.getAdditionalConf = function (type, controller, data, def) {
-    var self = this;
-    var setting = self.commandRouter.executeOnPlugin(type, controller, 'getConfigParam', data);
+  var self = this;
+  var setting = self.commandRouter.executeOnPlugin(type, controller, 'getConfigParam', data);
 
-    if (setting == undefined) {
-        setting = def;
-    }
-    return setting
+  if (setting == undefined) {
+    setting = def;
+  }
+  return setting;
 };
 
 ControllerSystem.prototype.getShowWizard = function () {
-    var self = this;
+  var self = this;
 
-    var show = self.config.get('show_wizard', false);
+  var show = self.config.get('show_wizard', false);
 
-    return  show
+  return show;
 };
 
 ControllerSystem.prototype.setShowWizard = function (data) {
-    var self = this;
+  var self = this;
 
-    self.config.set('show_wizard', data);
+  self.config.set('show_wizard', data);
 };
 
 ControllerSystem.prototype.installToDisk = function (data) {
-    var self = this;
+  var self = this;
 
-    var ddsize = '';
-    var error = false;
-    if (data.from != undefined) {
-    	var source = '/dev/' + data.from;
-	}
+  var ddsize = '';
+  var error = false;
+  if (data.from != undefined) {
+    var source = '/dev/' + data.from;
+  }
 
-	if (data.target != undefined) {
-    	var target = '/dev/' + data.target;
-	}
-    self.notifyInstallToDiskStatus({'progress': 0, 'status':'started'});
-    var ddsizeRaw = execSync("/bin/lsblk -b | grep -w " + data.from + " | awk '{print $4}' | head -n1", { uid: 1000, gid: 1000, encoding: 'utf8'});
-    ddsize = Math.ceil(ddsizeRaw/1024/1024);
-    var ddsizeRawDest = execSync("/bin/lsblk -b | grep -w " + data.target + " | awk '{print $4}' | head -n1", { uid: 1000, gid: 1000, encoding: 'utf8'});
+  if (data.target != undefined) {
+    var target = '/dev/' + data.target;
+  }
+  self.notifyInstallToDiskStatus({
+    'progress': 0,
+    'status': 'started'
+  });
+  var ddsizeRaw = execSync('/bin/lsblk -b | grep -w ' + data.from + " | awk '{print $4}' | head -n1", {
+    uid: 1000,
+    gid: 1000,
+    encoding: 'utf8'
+  });
+  ddsize = Math.ceil(ddsizeRaw / 1024 / 1024);
+  var ddsizeRawDest = execSync('/bin/lsblk -b | grep -w ' + data.target + " | awk '{print $4}' | head -n1", {
+    uid: 1000,
+    gid: 1000,
+    encoding: 'utf8'
+  });
 
-    if (Number(ddsizeRaw) > Number(ddsizeRawDest)) {
-        error = true;
-        var sizeError = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_ERROR_TARGET_SIZE');
-        self.notifyInstallToDiskStatus({'progress':0, 'status':'error', 'error': sizeError});
-    } else {
+  if (Number(ddsizeRaw) > Number(ddsizeRawDest)) {
+    error = true;
+    var sizeError = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_ERROR_TARGET_SIZE');
+    self.notifyInstallToDiskStatus({
+      'progress': 0,
+      'status': 'error',
+      'error': sizeError
+    });
+  } else {
+    try {
+      var copy = exec('/usr/bin/sudo /usr/bin/dcfldd if=' + source + ' of=' + target + ' bs=1M status=on sizeprobe=if statusinterval=10 >> /tmp/install_progress 2>&1', {
+        uid: 1000,
+        gid: 1000,
+        encoding: 'utf8'
+      });
+    } catch (e) {
+      error = true;
+      self.notifyInstallToDiskStatus({
+        'progress': 0,
+        'status': 'error',
+        'error': 'Cannot install on new Disk'
+      });
+    }
+
+    var copyProgress = exec('tail -f /tmp/install_progress');
+
+    copyProgress.stdout.on('data', function (data) {
+      if (data.indexOf('%') >= 0) {
+        var progressRaw = data.split('(')[1].split('Mb)')[0];
+        var progress = Math.ceil((100 * progressRaw) / ddsize);
+        if (progress <= 100) {
+          if (progress >= 95) {
+            progress = 95;
+          }
+          self.notifyInstallToDiskStatus({
+            'progress': progress,
+            'status': 'progress'
+          });
+        }
+      }
+    });
+
+    copy.on('close', function (code) {
+      if (code === 0) {
+        self.logger.info('Successfully cloned system');
+
         try {
-            var copy = exec('/usr/bin/sudo /usr/bin/dcfldd if=' + source +' of=' + target +' bs=1M status=on sizeprobe=if statusinterval=10 >> /tmp/install_progress 2>&1',  {uid: 1000, gid: 1000, encoding: 'utf8'});
-        } catch(e) {
-            error = true;
-            self.notifyInstallToDiskStatus({'progress':0, 'status':'error', 'error': 'Cannot install on new Disk'});
+          fs.unlinkSync('/tmp/boot');
+          fs.unlinkSync('/tmp/imgpart');
+        } catch (e) {}
+        // TODO: remove resize sentinel once initrd for arm devices have been aligned with x86
+        try {
+          if (target === '/dev/mmcblk0' || target === '/dev/mmcblk1') {
+            target = target + 'p';
+          }
+          execSync('mkdir /tmp/boot', {
+            uid: 1000,
+            gid: 1000,
+            encoding: 'utf8'
+          });
+          execSync('/usr/bin/sudo /bin/mount ' + target + '1 /tmp/boot -o rw,uid=1000,gid=1000', {
+            uid: 1000,
+            gid: 1000,
+            encoding: 'utf8'
+          });
+          execSync('/bin/touch /tmp/boot/resize-volumio-datapart', {
+            uid: 1000,
+            gid: 1000,
+            encoding: 'utf8'
+          });
+          execSync('/bin/sync', {
+            uid: 1000,
+            gid: 1000,
+            encoding: 'utf8'
+          });
+          execSync('/usr/bin/sudo /bin/umount ' + target + '1', {
+            uid: 1000,
+            gid: 1000,
+            encoding: 'utf8'
+          });
+          execSync('rm -rf /tmp/boot', {
+            uid: 1000,
+            gid: 1000,
+            encoding: 'utf8'
+          });
+          self.logger.info('Successfully prepared system for resize');
+        } catch (e) {
+          self.logger.error('Cannot prepare system for resize');
+          error = true;
+          self.notifyInstallToDiskStatus({
+            'progress': 0,
+            'status': 'error',
+            'error': 'Cannot prepare system for resize'
+          });
         }
 
-
-
-
-        var copyProgress = exec('tail -f /tmp/install_progress');
-
-
-        copyProgress.stdout.on('data', function(data) {
-            if (data.indexOf('%') >= 0) {
-                var progressRaw = data.split('(')[1].split('Mb)')[0];
-                var progress = Math.ceil((100*progressRaw)/ddsize);
-                if (progress <= 100) {
-                    if (progress >= 95) {
-                        progress = 95;
-                    }
-                    self.notifyInstallToDiskStatus({'progress':progress, 'status':'progress'});
-                }
-            }
+        if (!error) {
+          self.notifyInstallToDiskStatus({
+            'progress': 100,
+            'status': 'done'
+          });
+        }
+      } else {
+        self.notifyInstallToDiskStatus({
+          'progress': 0,
+          'status': 'error'
         });
-
-        copy.on('close', function(code) {
-            if (code === 0) {
-                self.logger.info('Successfully cloned system');
-
-                try {
-                    fs.unlinkSync('/tmp/boot');
-                    fs.unlinkSync('/tmp/imgpart');
-                } catch(e) {}
-                //TODO: remove resize sentinel once initrd for arm devices have been aligned with x86
-                try {
-                    if (target === '/dev/mmcblk0' || target === '/dev/mmcblk1') {
-                        target = target + 'p';
-                    }
-                    execSync('mkdir /tmp/boot', { uid: 1000, gid: 1000, encoding: 'utf8'});
-                    execSync('/usr/bin/sudo /bin/mount ' + target + '1 /tmp/boot -o rw,uid=1000,gid=1000', { uid: 1000, gid: 1000, encoding: 'utf8'});
-                    execSync('/bin/touch /tmp/boot/resize-volumio-datapart', { uid: 1000, gid: 1000, encoding: 'utf8'});
-                    execSync('/bin/sync', { uid: 1000, gid: 1000, encoding: 'utf8'});
-                    execSync('/usr/bin/sudo /bin/umount ' + target + '1', { uid: 1000, gid: 1000, encoding: 'utf8'});
-                    execSync('rm -rf /tmp/boot', { uid: 1000, gid: 1000, encoding: 'utf8'});
-                    self.logger.info('Successfully prepared system for resize');
-                } catch (e) {
-                    self.logger.error('Cannot prepare system for resize');
-                    error = true;
-                    self.notifyInstallToDiskStatus({'progress':0, 'status':'error', 'error': 'Cannot prepare system for resize'});
-                }
-
-                if (!error) {
-                    self.notifyInstallToDiskStatus({'progress':100, 'status':'done'});
-                }
-            } else {
-                self.notifyInstallToDiskStatus({'progress':0, 'status':'error'});
-            }
-        });
-	}
-
-
-
-
-
+      }
+    });
+  }
 };
 
 ControllerSystem.prototype.notifyInstallToDiskStatus = function (data) {
-	var self = this;
-	var progress = data.progress;
-	var status = data.status;
-	var title = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK');
-	var message = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_MESSAGE');
-	var emit = '';
+  var self = this;
+  var progress = data.progress;
+  var status = data.status;
+  var title = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK');
+  var message = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_MESSAGE');
+  var emit = '';
 
-    var responseData = {
-        progress : true,
-        progressNumber : progress,
-        title: title,
-        message: message,
-        size: 'lg',
-        buttons: [
-            {
-                name: self.commandRouter.getI18nString('COMMON.GOT_IT'),
-                class: 'btn btn-info ng-scope',
-                emit:'',
-                payload:''
-            }
-        ]
-    }
+  var responseData = {
+    progress: true,
+    progressNumber: progress,
+    title: title,
+    message: message,
+    size: 'lg',
+    buttons: [{
+      name: self.commandRouter.getI18nString('COMMON.GOT_IT'),
+      class: 'btn btn-info ng-scope',
+      emit: '',
+      payload: ''
+    }]
+  };
 
-    if (status === 'started') {
-    	emit = 'openModal';
-    } else if (status === 'progress') {
-    	emit = 'modalProgress';
-    } else if (status === 'done') {
-    	emit = 'modalDone';
-        responseData.title = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_SUCCESS_TITLE');
-        responseData.message = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_SUCCESS_MESSAGE');
-        var restartButton = {
-                name: self.commandRouter.getI18nString('COMMON.RESTART'),
-                class: 'btn btn-warning ng-scope',
-                emit:'reboot',
-                payload:''
-            };
-        responseData.buttons.push(restartButton);
-    } else if (status === 'error') {
-        emit = 'modalDone';
-        responseData.message = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_ERROR_MESSAGE') + ': ' + data.error;
-	}
-    self.commandRouter.broadcastMessage(emit, responseData);
+  if (status === 'started') {
+    emit = 'openModal';
+  } else if (status === 'progress') {
+    emit = 'modalProgress';
+  } else if (status === 'done') {
+    emit = 'modalDone';
+    responseData.title = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_SUCCESS_TITLE');
+    responseData.message = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_SUCCESS_MESSAGE');
+    var restartButton = {
+      name: self.commandRouter.getI18nString('COMMON.RESTART'),
+      class: 'btn btn-warning ng-scope',
+      emit: 'reboot',
+      payload: ''
+    };
+    responseData.buttons.push(restartButton);
+  } else if (status === 'error') {
+    emit = 'modalDone';
+    responseData.message = self.commandRouter.getI18nString('SYSTEM.INSTALLING_TO_DISK_ERROR_MESSAGE') + ': ' + data.error;
+  }
+  self.commandRouter.broadcastMessage(emit, responseData);
 };
 
 ControllerSystem.prototype.saveHDMISettings = function (data) {
-    var self = this;
+  var self = this;
 
-	var currentConf = self.config.get('hdmi_enabled', false);
-	if (currentConf |=  data['hdmi_enabled'])  {
-        self.config.set('hdmi_enabled', data['hdmi_enabled']);
+  var currentConf = self.config.get('hdmi_enabled', false);
+  if (currentConf |= data['hdmi_enabled']) {
+    self.config.set('hdmi_enabled', data['hdmi_enabled']);
 
-        var action = 'enable';
-        var immediate = 'start'
-        if (!data['hdmi_enabled']) {
-            action = 'disable';
-            immediate = 'stop';
-        }
+    var action = 'enable';
+    var immediate = 'start';
+    if (!data['hdmi_enabled']) {
+      action = 'disable';
+      immediate = 'stop';
+    }
 
-        exec('/usr/bin/sudo /bin/systemctl '+immediate+' volumio-kiosk.service && /usr/bin/sudo /bin/systemctl '+action+' volumio-kiosk.service',{uid:1000,gid:1000}, function (error, stdout, stderr) {
-            if (error !== null) {
-                console.log(error);
-                self.logger.info('Cannot '+action+' volumio-kiosk service: ' + error);
-            } else {
-                self.logger.info(action+ ' volumio-kiosk service success');
-                self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('SYSTEM.HDMI_UI'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE_SUCCESS'));
-            }
-        });
-	}
-}
+    exec('/usr/bin/sudo /bin/systemctl ' + immediate + ' volumio-kiosk.service && /usr/bin/sudo /bin/systemctl ' + action + ' volumio-kiosk.service', {
+      uid: 1000,
+      gid: 1000
+    }, function (error, stdout, stderr) {
+      if (error !== null) {
+        console.log(error);
+        self.logger.info('Cannot ' + action + ' volumio-kiosk service: ' + error);
+      } else {
+        self.logger.info(action + ' volumio-kiosk service success');
+        self.commandRouter.pushToastMessage('success', self.commandRouter.getI18nString('SYSTEM.HDMI_UI'), self.commandRouter.getI18nString('SYSTEM.SYSTEM_CONFIGURATION_UPDATE_SUCCESS'));
+      }
+    });
+  }
+};
 
 ControllerSystem.prototype.versionChangeDetect = function () {
-    var self = this;
+  var self = this;
 
-    var info = self.getSystemVersion();
-    info.then(function(infos)
-    {
-        if (infos != undefined && infos.systemversion != undefined) {
-        	var systemVersion = self.config.get('system_version', 'none');
-        	if (systemVersion !== infos.systemversion) {
-        		self.config.set('system_version', infos.systemversion);
-        		self.logger.info('Version has changed, forcing UI Reload');
-        		return self.commandRouter.reloadUi();
-			}
-        }
-    });
+  var info = self.getSystemVersion();
+  info.then(function (infos) {
+    if (infos != undefined && infos.systemversion != undefined) {
+      var systemVersion = self.config.get('system_version', 'none');
+      if (systemVersion !== infos.systemversion) {
+        self.config.set('system_version', infos.systemversion);
+        self.logger.info('Version has changed, forcing UI Reload');
+        return self.commandRouter.reloadUi();
+      }
+    }
+  });
 };
 
 ControllerSystem.prototype.getMainDiskUsage = function () {
-    var self = this;
-    var defer = libQ.defer();
-    var unity = ' MB';
-    var mainDiskUsageObj = {'size':'','used':'','free':'','usedPercentage':'','freePercentage':''};
+  var self = this;
+  var defer = libQ.defer();
+  var unity = ' MB';
+  var mainDiskUsageObj = {
+    'size': '',
+    'used': '',
+    'free': '',
+    'usedPercentage': '',
+    'freePercentage': ''
+  };
 
-    exec("/bin/df -h -m | grep overlay", {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
-        if (error !== null) {
-            defer.reject({'error':error})
-        } else {
-        	try {
-                var mainDiskArray = stdout.toString().split(' ').filter(item => item.trim() !== '');
-                mainDiskUsageObj.size = mainDiskArray[1] + unity;
-                mainDiskUsageObj.used = mainDiskArray[2] + unity;
-                mainDiskUsageObj.free = mainDiskArray[3] + unity;
-                mainDiskUsageObj.usedPercentage = parseInt(mainDiskArray[4].replace('%', ''));
-                mainDiskUsageObj.freePercentage = 100 - mainDiskUsageObj.usedPercentage;
-                defer.resolve(mainDiskUsageObj);
-			} catch(e) {
-        		self.logger.error('Error in parsing main disk data: ' + e);
-                defer.reject({'error':error})
-			}
-        }
-    });
-    return defer.promise
+  exec('/bin/df -h -m | grep overlay', {
+    uid: 1000,
+    gid: 1000
+  }, function (error, stdout, stderr) {
+    if (error !== null) {
+      defer.reject({
+        'error': error
+      });
+    } else {
+      try {
+        var mainDiskArray = stdout.toString().split(' ').filter(item => item.trim() !== '');
+        mainDiskUsageObj.size = mainDiskArray[1] + unity;
+        mainDiskUsageObj.used = mainDiskArray[2] + unity;
+        mainDiskUsageObj.free = mainDiskArray[3] + unity;
+        mainDiskUsageObj.usedPercentage = parseInt(mainDiskArray[4].replace('%', ''));
+        mainDiskUsageObj.freePercentage = 100 - mainDiskUsageObj.usedPercentage;
+        defer.resolve(mainDiskUsageObj);
+      } catch (e) {
+        self.logger.error('Error in parsing main disk data: ' + e);
+        defer.reject({
+          'error': error
+        });
+      }
+    }
+  });
+  return defer.promise;
 };
 
 ControllerSystem.prototype.setAdditionalSVInfo = function (data) {
-    var self = this;
-	self.logger.info('Setting Additional System Software info: ' + data);
-    additionalSVInfo = data;
+  var self = this;
+  self.logger.info('Setting Additional System Software info: ' + data);
+  additionalSVInfo = data;
 };
 
 ControllerSystem.prototype.getAdvancedSettingsStatus = function () {
-    var self = this;
-    if (process.env.ADVANCED_SETTINGS_MODE === 'true') {
-    	return true
-	} else {
-    	return false
-	}
+  var self = this;
+  if (process.env.ADVANCED_SETTINGS_MODE === 'true') {
+    return true;
+  } else {
+    return false;
+  }
 };
 
 ControllerSystem.prototype.getExperienceAdvancedSettings = function () {
-    var self = this;
+  var self = this;
 
-    var simpleSettingsString = self.commandRouter.getI18nString('SYSTEM.SIMPLE_SETTINGS_SET_EXTENDED');
-    var fullSettingsString = self.commandRouter.getI18nString('SYSTEM.FULL_SETTINGS_SET_EXTENDED');
-    var advancedSettingsStatus = self.getAdvancedSettingsStatus();
-    var advancedSettingsStatusObject = {id: false, label: simpleSettingsString};
-    if (advancedSettingsStatus) {
-        advancedSettingsStatusObject = {id: true, label: fullSettingsString}
-    }
-    var responseObject = {
-        "options": [{id: false, label: simpleSettingsString}, {id: true, label: fullSettingsString}],
-        "status": advancedSettingsStatusObject
-    }
+  var simpleSettingsString = self.commandRouter.getI18nString('SYSTEM.SIMPLE_SETTINGS_SET_EXTENDED');
+  var fullSettingsString = self.commandRouter.getI18nString('SYSTEM.FULL_SETTINGS_SET_EXTENDED');
+  var advancedSettingsStatus = self.getAdvancedSettingsStatus();
+  var advancedSettingsStatusObject = {
+    id: false,
+    label: simpleSettingsString
+  };
+  if (advancedSettingsStatus) {
+    advancedSettingsStatusObject = {
+      id: true,
+      label: fullSettingsString
+    };
+  }
+  var responseObject = {
+    'options': [{
+      id: false,
+      label: simpleSettingsString
+    }, {
+      id: true,
+      label: fullSettingsString
+    }],
+    'status': advancedSettingsStatusObject
+  };
 
-    return responseObject
+  return responseObject;
 };
 
 ControllerSystem.prototype.setExperienceAdvancedSettings = function (data) {
-    var self = this;
+  var self = this;
 
-    self.logger.info('Saving Experience Advanced Settings');
-    if (data !== undefined) {
-        self.config.set('advanced_settings_mode', data);
-        process.env.ADVANCED_SETTINGS_MODE = data;
-    }
+  self.logger.info('Saving Experience Advanced Settings');
+  if (data !== undefined) {
+    self.config.set('advanced_settings_mode', data);
+    process.env.ADVANCED_SETTINGS_MODE = data;
+  }
 };
 
 ControllerSystem.prototype.getLabelForSelect = function (options, key) {
-    var self=this;
+  var self = this;
 
-    var n = options.length;
-    for (var i = 0; i < n; i++) {
-        if (options[i].value == key)
-            return options[i].label;
+  var n = options.length;
+  for (var i = 0; i < n; i++) {
+    if (options[i].value == key) {
+      return options[i].label;
     }
+  }
 
-    return 'Error';
+  return 'Error';
 };
 
 ControllerSystem.prototype.getHwuuid = function () {
-    var self = this;
-    var defer = libQ.defer();
+  var self = this;
+  var defer = libQ.defer();
 
-    try {
-        var macaddr = fs.readFileSync('/sys/class/net/eth0/address', "utf8");
-        var anonid = macaddr.toString().replace(':','');
-    } catch (e) {
-        var anonid = this.config.get('uuid');
-    }
+  try {
+    var macaddr = fs.readFileSync('/sys/class/net/eth0/address', 'utf8');
+    var anonid = macaddr.toString().replace(':', '');
+  } catch (e) {
+    var anonid = this.config.get('uuid');
+  }
 
-    return crypto.createHash('md5').update(anonid).digest("hex");
+  return crypto.createHash('md5').update(anonid).digest('hex');
 };

--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -5,7 +5,6 @@ var fs = require('fs-extra');
 var config = new (require('v-conf'))();
 var execSync = require('child_process').execSync;
 var exec = require('child_process').exec;
-var spawn = require('child_process').spawn;
 var crypto = require('crypto');
 var calltrials = 0;
 var additionalSVInfo;
@@ -392,42 +391,30 @@ ControllerSystem.prototype.registerCallback = function (callback) {
 };
 
 ControllerSystem.prototype.getSystemVersion = function () {
-  var self = this;
-  var defer = libQ.defer();
-  var file = fs.readFileSync('/etc/os-release').toString().split('\n');
-  var releaseinfo = {
-    'systemversion': null,
-    'builddate': null,
-    'variant': null,
-    'hardware': null
+  const defer = libQ.defer();
+  const osReleaseFile = fs.readFileSync('/etc/os-release').toString();
+  const releaseInfo = {
+    systemversion: 'VOLUMIO_VERSION',
+    builddate: 'VOLUMIO_BUILD_DATE',
+    variant: 'VOLUMIO_VARIANT',
+    hardware: 'VOLUMIO_HARDWARE'
   };
-  // console.log(file);
-  var nLines = file.length;
-  var str;
-  for (var l = 0; l < nLines; l++) {
-    if (file[l].match(/VOLUMIO_VERSION/i)) {
-      str = file[l].split('=');
-      releaseinfo.systemversion = str[1].replace(/\"/gi, '');
-    }
-    if (file[l].match(/VOLUMIO_BUILD_DATE/i)) {
-      str = file[l].split('=');
-      releaseinfo.builddate = str[1].replace(/\"/gi, '');
-    }
-    if (file[l].match(/VOLUMIO_VARIANT/i)) {
-      str = file[l].split('=');
-      releaseinfo.variant = str[1].replace(/\"/gi, '');
-    }
-    if (file[l].match(/VOLUMIO_HARDWARE/i)) {
-      str = file[l].split('=');
-      releaseinfo.hardware = str[1].replace(/\"/gi, '');
+
+  for (const key in releaseInfo) {
+    const needle = releaseInfo[key];
+    const regEx = new RegExp(`^${needle}=(.*)$`, 'gm');
+    const res = regEx.exec(osReleaseFile);
+    // No need to check if we actually captured something, will be null
+    if (res) {
+      releaseInfo[key] = res[1].replace(/^"|"$/g, '');
     }
   }
 
   if (additionalSVInfo) {
-    releaseinfo.additionalSVInfo = additionalSVInfo;
+    releaseInfo.additionalSVInfo = additionalSVInfo;
   }
 
-  defer.resolve(releaseinfo);
+  defer.resolve(releaseInfo);
 
   return defer.promise;
 };


### PR DESCRIPTION
This PR is two fold,

1. Refactor `getSystemVersion()` to be more extendable.
Also speed it up for while we are at it.. (Not super representative, most of the time would probably be spent in reading the file.. - but a test is a test ;-) https://www.measurethat.net/Benchmarks/ShowResult/97767)

2. Keep the parsed information in memory, and re-parse `/etc/os-release` only when required. 
  This is where it gets interesting, 
Currently `versionChangeDetect()` compares against `os-release` and saves `system_version` using `v-conf`. In this PR we still parse `os-release` when this function is called.
From a quick grep,  `versionChangeDetect()` is only called by a timeout function in [`startupSound()`](
https://github.com/volumio/Volumio2/blob/98dec1edae8efb6fce529b2a3d6065657d2e9e79/app/platformSpecific.js#L99-L102) 

The old `getSystemVersion()` that read the file each time on the other hand is a bit more popular (not counting all the times the WebUI calls for it)
```
logsubmit.js
app\index.js
app\plugins\music_service\webradio\index.js
app\plugins\system_controller\updater_comm\index.js
app\plugins\system_controller\system\index.js
app\plugins\user_interface\rest_api\index.js
app\plugins\user_interface\websocket\index.js
app\plugins\user_interface\rest_api\system.js
```
a. Can we assume that all these calls will be happy with the version from memory? 
b. I feel `versionChangeDetect` is redundant and can done in a less roundabout manor, by directly setting `system_version` during startup in `CoreCommandRouter`. Or am I missing something?

PS: There seems to a be quite some redundancy in `startupSound()` that can be moved into `CoreCommandRouter` instead. 
 


