### PR TITLE
Simple bench/metrics framework to time events

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -11,6 +11,7 @@ var vconf = require('v-conf');
 // Define the CoreCommandRouter class
 module.exports = CoreCommandRouter;
 function CoreCommandRouter(server) {
+	metrics.time('CommandRouter');
 
 	var logfile = '/var/log/volumio.log';
 
@@ -68,10 +69,11 @@ function CoreCommandRouter(server) {
     this.platformspecific = new (require(__dirname + '/platformSpecific.js'))(this);
 
     this.pushConsoleMessage('BOOT COMPLETED');
+    metrics.log('CommandRouter');
 
     this.startupSound();
 	this.closeModals();
-
+	
 }
 
 // Methods usually called by the Client Interfaces ----------------------------------------------------------------------------

--- a/index.js
+++ b/index.js
@@ -4,11 +4,28 @@ var fs = require('fs-extra');
 var expressInstance = require('./http/index.js');
 var expressApp = expressInstance.app;
 var path = require('path');
+
+global.metrics = {
+  start: {}, 
+  time: (label) => {
+    metrics.start[label] = process.hrtime();
+  },
+  end: {},
+  log: (label) => {
+    metrics.end[label] = process.hrtime(metrics.start[label]);
+    console.log(`\u001b[34m [Metrics] \u001b[39m ${label}: \u001b[31m ${metrics.end[label][0]}s ${(metrics.end[label][1] / 1000000).toFixed(2)}ms \u001b[39m`)
+  }
+};
+  
+// metrics.start.WebUI = process.hrtime();
+metrics.time('WebUI');
+
 // Using port 3000 for the debug interface
 expressApp.set('port', 3000);
 
 var httpServer = expressApp.listen(expressApp.get('port'), function () {
   console.log('Express server listening on port ' + httpServer.address().port);
+  metrics.log('WebUI');
 });
 
 var albumart = require(__dirname + '/app/plugins/miscellanea/albumart/albumart.js');


### PR DESCRIPTION
##### Rationale:
We should have a way to keep track/time certain events, to gain insight into the system. As we add new features this becomes vital for user experience, and moreover gives the devs an idea on where to focus to improve things. 
Ideally, this data should also exposed to the `/dev` page and/or ultimately into the `downloader-v1` remote api. 


Not sure if this is the best way to do this, but it's a start (and requires no external dependencies..) 
I am also aware that given the async nature plugin manager, this doesn't represent true boot times - but that is a different matter.. 
