### PR TITLE
Fix airplay / shairport low volume output

### DIFF
--- a/app/plugins/music_service/airplay_emulation/shairport-sync.conf.tmpl
+++ b/app/plugins/music_service/airplay_emulation/shairport-sync.conf.tmpl
@@ -11,6 +11,7 @@ diagnostics =
 alsa =
 {
   output_device = "${device}";
+  mixer_control_name = "${mixer}";
   ${buffer_size_line}
 };
 


### PR DESCRIPTION
Shairplay does not use the hardware mixer (at least with my external Raspberry Pi DAC) and as a result the volume is very low.

This fix inserts the 'mixer_control_name' setting in shairport.conf. Notably, the 'mixer' variable is exported in `airplay_emulation/index.js` (line 150) but not yet used in the config file.

Please include this fix -- or at least a commented line (`// mixer_control_name = ...`) in the config file to give a hint on how to set the hardware mixer.