### PR TITLE
Refactor `volumioPlay` to combine `play` and `volatilePlay`

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1295,12 +1295,7 @@ CoreCommandRouter.prototype.explodeUriFromService = function (service, uri) {
 // Volumio Play
 CoreCommandRouter.prototype.volumioPlay = function (N) {
   this.pushConsoleMessage('CoreCommandRouter::volumioPlay');
-
-  this.stateMachine.unSetVolatile();
-
-  if (N === undefined) { return this.stateMachine.play(); } else {
-    return this.stateMachine.play(N);
-  }
+  return this.stateMachine.volumioPlay(N);
 };
 
 // Volumio Play

--- a/app/index.js
+++ b/app/index.js
@@ -1313,7 +1313,8 @@ CoreCommandRouter.prototype.volumioToggle = function () {
 
   if (state.status != undefined) {
     if (state.status === 'stop' || state.status === 'pause') {
-      return this.stateMachine.play();
+      // Use volumioPlay to account for volatile services
+      return this.stateMachine.volumioPlay();
     } else {
       if (state.trackType == 'webradio') {
         return this.stateMachine.stop();

--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -932,6 +932,26 @@ CoreStateMachine.prototype.getTrack = function (position) {
   return track;
 };
 
+/**
+ * wrapper for play and volatilePlay that maps to commandRouter.volumioPlay
+ * @param  {[Integer]} index         [track index]
+ * @param  {[boolean]} unSetVolatile [flag to force unSetVolatile]
+ * @return {[Promise]}               [description]
+ */
+CoreStateMachine.prototype.volumioPlay = function (index, unSetVolatile) {
+  this.commandRouter.pushConsoleMessage(`CoreStateMachine::volumioPlay<${index}>`);
+  if (this.isVolatile) {
+    // Force the volatile service to release the audio sink
+    if (index !== undefined || unSetVolatile) {
+      this.unSetVolatile();
+      return this.play(index);
+    }
+    return this.volatilePlay();
+  } else {
+    return this.play(index);
+  }
+};
+
 // Volumio Play Command
 CoreStateMachine.prototype.play = function (index) {
   var self = this;


### PR DESCRIPTION
Should fix #1937 and related upstream issues. 
The logic is if the current service is volatile and a track `index` is provided to `volumioPlay` we unset the volatile, and proceed to call `play`, other wise it just maps accordingly. 
We could then refactor the volatilePlay calls from the WebUI out at a later stage. 


PS: Not extensively tested (with myVolumio stuff), 

