### PR TITLE
Move `modclean` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "libxmljs": "^0.18.4",
     "linux-mountutils": "^1.0.2",
     "mdns": "^2.3.3",
-    "modclean": "^2.1.2",
     "moment": "^2.18.1",
     "mqtt": "^3.0.0",
     "music-metadata": "^6.3.7",
@@ -62,6 +61,7 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
+    "modclean": "^2.1.2",
     "fs-extra": "^3.0.1",
     "lint-staged": "^7.2.2",
     "mocha": "^3.2.0",


### PR DESCRIPTION


There are still a few packages that aren't used anywhere (tested with this little snippet)
```bash
#!/usr/bin/env bash
# check_unsed.sh
echo "Checking for un(required) node_modules"

for row in $(jq -r '.dependencies | keys' package.json); do
  if [[ ${#row} > 1 ]]; then
    pkg=${row:1:-2} # Meh, we know what it is
    echo "Checking for <$pkg>"
    if ! git grep -q "require('${pkg}')"; then
      echo ${pkg} is not used!
      unused+=(${pkg})
    fi
  fi
done
echo -e "\n\nUnused modules:\n${unused[@]}"
```
```
Unused modules:
ejs firebase mqtt node-cache require-from-string timsort yarg
```
Other than `ejs` (express view-engine), and `firebase` (myVolumio), not sure if the rest are leftovers or used again for myVolumio.  

Maybe it's a good idea to keep myVolumio dependencies in a separate  file and inject them when building modules with the  [`install-modules.sh`](https://github.com/volumio/Volumio2/blob/master/utils/misc/install-modules.sh) script? 