### PR TITLE
Add missing `fs-extra` package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "nodejs ./index.js",
     "lint": "semistandard \"./**/*.js\" --fix --verbose",
     "lint-staged": "lint-staged",
-    "test": "npm install fs-extra && npm install --only=dev && ./node_modules/.bin/mocha --reporter spec"
+    "test": "npm install --only=dev && ./node_modules/.bin/mocha --reporter spec"
   },
   "lint-staged": {
     "*.js": [
@@ -29,6 +29,7 @@
     "express": "^4.15.3",
     "fast.js": "^0.1.1",
     "firebase": "^7.14.1",
+    "fs-extra": "^9.0.0",
     "hashmap": "^2.1.0",
     "html-entities": "^1.2.1",
     "inotify": "^1.4.1",
@@ -62,7 +63,6 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "fs-extra": "^3.0.1",
     "lint-staged": "^7.2.2",
     "mocha": "^3.2.0",
     "semistandard": "^14.2.0"


### PR DESCRIPTION
This was breaking new builds, as it used everywhere, but listed as a dev dependency only. 

