### PR TITLE
Add a language string helper util

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint-staged": "lint-staged",
     "lint-lang": "jsonlint -qD ./app/i18n", 
     "lint-JSON": "jsonlint -qD ./app/plugins", 
-    "test": "npm install --only=dev --no-package-lock && ./node_modules/.bin/mocha --reporter spec"
+    "test": "npm install --only=dev --no-package-lock && ./node_modules/.bin/mocha --reporter spec",
+    "addLangString": "node ./utils/addlangstring.js"
   },
   "lint-staged": {
     "*.js": [

--- a/utils/addlangstring.js
+++ b/utils/addlangstring.js
@@ -1,0 +1,63 @@
+/**
+ * This little helper is written to make translations more streamlined
+ * it is written in node to make it cross platform
+ *
+ * Useage:
+ * addLangString rootKey langKey "String to add"
+ * npm run addLangString -- ALARM TEST 'This is my test string'
+ * npm run addLangString -- COMMON MYSETTING 'This is my setting string'
+ * Could be as simple as:
+ ───────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+        │ File: .\addnewstring.sh
+ ───────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+    1   │ #!/bin/bash
+    2   │
+    3   │ ROOT="$1"
+    4   │ KEY="$2"
+    5   │ STRING="$3"
+    6   │ printf -v jq_cmd ".%s += {%s:\"%s\"}" "${ROOT}" "${KEY}" "${STRING}"
+    7   │ for filename in ./app/i18n/*.json; do
+    8   │   jq "$jq_cmd" $filename | sponge $filename
+    9   │ done
+ */
+const fs = require('fs');
+const path = require('path');
+
+const readline = require('readline').createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+const args = process.argv.slice(2);
+const [rootKey, langKey, langString] = args;
+readline.question('Beware, this assumes you know what your doing!\nContinue?[Y/n] ', (line) => {
+  if (line !== '' || line !== 'Y') {
+    process.exit();
+  }
+});
+
+function addLangString (langDirPath) {
+  const langENFile = fs.readFileSync(path.join(langDirPath, 'strings_en.json'));
+  const langEN = JSON.parse(langENFile);
+
+  if (Object.keys(langEN).includes(rootKey)) {
+    console.log(`Adding ${rootKey}.${langKey}`);
+    langEN[rootKey][langKey] = langString;
+  } else {
+    console.error(`${rootKey} not found! in strings_en`);
+  }
+
+  const files = fs.readdirSync(langDirPath);
+  files.forEach((file) => {
+    const fullFile = path.join(langDirPath, file);
+    if (path.extname(file) === 'json' && path.basename(file, '.json') !== 'strings_en') {
+      const langJSON = JSON.parse(fs.readFileSync(fullFile));
+      langJSON[rootKey][langKey] = '';
+      fs.writeFileSync(fullFile, JSON.stringify(langJSON, null, 2));
+    } else {
+      console.warn('Skipping file: ', file);
+    }
+  });
+}
+
+addLangString('./app/i18n/');

--- a/utils/addlangstring.js
+++ b/utils/addlangstring.js
@@ -31,9 +31,12 @@ const readline = require('readline').createInterface({
 const args = process.argv.slice(2);
 const [rootKey, langKey, langString] = args;
 readline.question('Beware, this assumes you know what your doing!\nContinue?[Y/n] ', (line) => {
-  if (line !== '' || line !== 'Y') {
+  if (line.toUpperCase() !== 'Y' && line !== '') {
+    console.log('Exiting!');
     process.exit();
   }
+  readline.close();
+  addLangString('./app/i18n/');
 });
 
 function addLangString (langDirPath) {
@@ -41,7 +44,7 @@ function addLangString (langDirPath) {
   const langEN = JSON.parse(langENFile);
 
   if (Object.keys(langEN).includes(rootKey)) {
-    console.log(`Adding ${rootKey}.${langKey}`);
+    console.log(`Adding ${rootKey}.${langKey} = ${langString}`);
     langEN[rootKey][langKey] = langString;
   } else {
     console.error(`${rootKey} not found! in strings_en`);
@@ -50,14 +53,15 @@ function addLangString (langDirPath) {
   const files = fs.readdirSync(langDirPath);
   files.forEach((file) => {
     const fullFile = path.join(langDirPath, file);
-    if (path.extname(file) === 'json' && path.basename(file, '.json') !== 'strings_en') {
+    if (path.extname(file) === '.json' && path.basename(file, '.json') !== 'strings_en') {
+      console.log(`Processing: ${file}`);
       const langJSON = JSON.parse(fs.readFileSync(fullFile));
       langJSON[rootKey][langKey] = '';
+      langJSON[rootKey] = Object.fromEntries(Object.entries(langJSON[rootKey]).sort());
       fs.writeFileSync(fullFile, JSON.stringify(langJSON, null, 2));
     } else {
       console.warn('Skipping file: ', file);
     }
   });
+  console.log('Finished');
 }
-
-addLangString('./app/i18n/');


### PR DESCRIPTION
Makes adding new language strings a bit simpler - it adds the given string to the default (English) file  and empty strings to the rest of the languages.

```shell
npm run addLangString -- ALARM TEST 'This is my test string'
npm run addLangString -- COMMON MY_SETTING 'This is my setting string'
npm run addLangString -- COMMON MY_SETTING_DESC 'This is my setting description string'
```

It has very rudimentary error handling, so ensure the files are checked in so you can `git checkout .\app\i18n\*.json` to recover from mishaps..

