### PR TITLE
Remove dedicated logging to `/var/log/volumio.log`

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -12,17 +12,10 @@ module.exports = CoreCommandRouter;
 function CoreCommandRouter (server) {
   metrics.time('CommandRouter');
 
-  var logfile = '/var/log/volumio.log';
-
-  fs.ensureFileSync(logfile);
   this.logger = winston.createLogger({
     format: winston.format.simple(),
     transports: [
-      new (winston.transports.Console)(),
-      new (winston.transports.File)({
-        filename: logfile,
-        json: false
-      })
+      new (winston.transports.Console)()
     ]
   });
 


### PR DESCRIPTION
As we already log to console. 
Use `journalctl -o cat -u volumio.service` if required instead..