### PR TITLE
Fix regression with volumecontroller 

### DIFF
--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -88,8 +88,8 @@ function CoreVolumeController (commandRouter) {
     });
   };
 
-  var reInfo = /[a-z][a-z ]*\: Playback [0-9-]+ \[([0-9]+)\%\] (?:[[0-9\.-]+dB\] )?\[(on|off)\]/i;
-  var reInfoOnlyVol = /[a-z][a-z ]*\: Playback [0-9-]+ \[([0-9]+)\%\] (?:[[0-9\.-]+dB\] )?\[/i;
+  var reInfo = /[a-z][a-z ]*: Playback [0-9-]+ \[([0-9]+)%\] (?:[[0-9.-]+dB\] )?\[(on|off)\]/i;
+  var reInfoOnlyVol = /[a-z][a-z ]*: Playback [0-9-]+ \[([0-9]+)%\] (?:[[0-9.-]+dB\] )?\[/i;
   var getInfo = function (cb) {
     if (volumescript.enabled) {
       try {

--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -131,6 +131,7 @@ function CoreVolumeController (commandRouter) {
           if (res === null) {
             var resOnlyVol = reInfoOnlyVol.exec(data);
             if (resOnlyVol === null) {
+              console.warn('Unable to parse:\n', data);
               cb(new Error('Alsa Mixer Error: failed to parse output'));
             } else {
               hasHWMute = false;
@@ -331,7 +332,7 @@ CoreVolumeController.prototype.alsavolume = function (VolumeInteger) {
             if (err) {
               self.logger.error('Cannot get ALSA Volume: ' + err);
             }
-            if (vol === null) {
+            if (!vol) {
               vol = currentvolume;
             }
             currentmute = true;
@@ -387,7 +388,7 @@ CoreVolumeController.prototype.alsavolume = function (VolumeInteger) {
             if (err) {
               self.logger.error('Cannot get ALSA Volume: ' + err);
             }
-            if (vol === null || currentmute) {
+            if (!vol || currentmute) {
               vol = currentvolume;
             }
             VolumeInteger = Number(vol) + Number(volumesteps);
@@ -415,7 +416,7 @@ CoreVolumeController.prototype.alsavolume = function (VolumeInteger) {
             if (err) {
               self.logger.error('Cannot get ALSA Volume: ' + err);
             }
-            if (vol === null || currentmute) {
+            if (!vol || currentmute) {
               vol = currentvolume;
             }
             VolumeInteger = Number(vol) - Number(volumesteps);
@@ -513,7 +514,7 @@ CoreVolumeController.prototype.retrievevolume = function () {
           }
           // Log volume control
           self.logger.info('VolumeController:: Volume=' + vol + ' Mute =' + mute);
-          if (vol === null) {
+          if (!vol) {
             vol = currentvolume;
             mute = currentmute;
           } else {


### PR DESCRIPTION
I seem to have introduced issues with the software mixer with dd3f21a, sorry!
This is just fixing the symptoms, as I believe the linting has unearthed the real error which was just being silently ignored.
The error comes from [these comparisons](https://github.com/volumio/Volumio2/commit/dd3f21a6e5152129a7355e3f40e57728accc614c#diff-b98fabba6904d236aaed2fa990bc5281L324-R334):
```diff
         case 'mute':
           // Mute
           self.getVolume(function (err, vol) {
-            if (vol == null) {
+            if (err) {
+              self.logger.error('Cannot get ALSA Volume: ' + err);
+            }
+            if (vol === null) {
```
The problem was that `vol` was never `null` when the parsing failed, but instead was `undefined`. 
Thus `undefined == null => true` but `undefined === null => false`  

**Now this brings to light the actual underlying issue.** 

Both the [regular expressions](https://github.com/ashthespy/Volumio2/blob/dd3f21a6e5152129a7355e3f40e57728accc614c/app/volumecontrol.js#L91-L92), fails to parse software mixer output, which doesn't contain `Playback` 
```
  Simple mixer control 'SoftMaster',0
  Capabilities: volume
  Playback channels: Front Left - Front Right
  Capture channels: Front Left - Front Right
  Limits: 0 - 99
  Front Left: 10 [10%]
  Front Right: 10 [10%]
# Compared to Hardware mixer
  Simple mixer control 'PCM',0
  Capabilities: pvolume pswitch pswitch-joined
  Playback channels: Front Left - Front Right
  Limits: Playback 0 - 110
  Mono:
  Front Left: Playback 0 [0%] [-55.00dB] [on]
  Front Right: Playback 0 [0%] [-55.00dB] [on]
```
If you give me a few samples of different mixer outputs, we can write some tests as well..

