### PR TITLE
Add a simple test for ALSA volume parsing Regex

### DIFF
--- a/test/volume_controller.js
+++ b/test/volume_controller.js
@@ -1,0 +1,96 @@
+
+// const winston = require('winston');
+// const VolumeControl = require('../app/volumecontrol');
+const { execSync } = require('child_process');
+
+class VolumeControlTester {
+  constructor (context) {
+    // Regex to capture Volume [%] and possible mute status[on|off]
+    /*
+      /
+      \w+\s?\w+:(?:\s|\sPlayback\s)[-0-9]+\s\[([0-9]+)%\](?:[\n\r]|\s(?:[[0-9.-]+dB\]\s)?\[(on|off)\])
+      \w+
+      matches any word character (equal to [a-zA-Z0-9_])
+      \s?
+      matches any whitespace character (equal to [\r\n\t\f\v ])
+      \w+
+      matches any word character (equal to [a-zA-Z0-9_])
+      : matches the character : literally (case sensitive)
+      Non-capturing group (?:\s|\sPlayback\s)
+      Match a single character present in the list below [-0-9]+
+      \s matches any whitespace character (equal to [\r\n\t\f\v ])
+      \[ matches the character [ literally (case sensitive)
+      1st Capturing Group ([0-9]+)
+      % matches the character % literally (case sensitive)
+      \] matches the character ] literally (case sensitive)
+      Non-capturing group (?:[\n\r]|\s(?:[[0-9.-]+dB\]\s)?\[(on|off)\])
+      1st Alternative [\n\r]
+      2nd Alternative \s(?:[[0-9.-]+dB\]\s)?\[(on|off)\]
+      \s matches any whitespace character (equal to [\r\n\t\f\v ])
+      Non-capturing group (?:[[0-9.-]+dB\]\s)?
+      \[ matches the character [ literally (case sensitive)
+      2nd Capturing Group (on|off)
+      \] matches the character ] literally (case sensitive)
+     */
+    this.volRegx = new RegExp(/\w+\s?\w+:(?:\s|\sPlayback\s)[-0-9]+\s\[([0-9]+)%\](?:[\n\r]|\s(?:[[0-9.-]+dB\]\s)?\[(on|off)\])/);
+  }
+
+  /**
+   * [parseVolumeString description]
+   * @param  {[String]} string
+   * @return {[{ volume: String, mute: String }]}
+   */
+  parseVolumeString (string) {
+    const res = this.volRegx.exec(string);
+    if (res) {
+      return { volume: res[1], mute: res[2] };
+    }
+    return { volume: null, mute: null };
+  }
+
+  /**
+   * [getVolume description]
+   * @param  {[String]} string
+   * @return {[{ volume: Int, mute: Bool }]}
+   */
+  getVolume (string) {
+    let { volume, mute } = this.parseVolumeString(string);
+    volume = parseInt(volume, 10);
+    if (isNaN(volume)) {
+      volume = 0; // Safe defualt
+    }
+    console.log('mute: ', mute);
+    if (!mute) { // No mute parsed, check volume
+      mute = volume === 0;
+    } else {
+      mute = mute === 'on';
+    }
+    return { volume, mute };
+  }
+}
+
+const vc = new VolumeControlTester();
+
+const testSimple = () => {
+  // Load examples from a file?
+  const amixerDataString = `Simple mixer control 'SoftMaster',0
+    Capabilities: volume
+    Playback channels: Front Left - Front Right
+    Capture channels: Front Left - Front Right
+    Limits: 0 - 99
+    Front Left: 10 [10%]
+    Front Right: 10 [10%]`;
+  console.log('\n:::Input:::\n', amixerDataString);
+  console.log(vc.getVolume(amixerDataString));
+};
+
+const testAmixer = (device, mixer) => {
+  // Read amxier directly
+  const amixerParams = ['-M', 'get', '-c', device, mixer];
+  const amixerDataString = execSync(`amixer ${amixerParams.join(' ')}`).toString();
+  console.log('\n:::Input:::\n', amixerDataString);
+  console.log(vc.getVolume(amixerDataString));
+};
+
+testSimple();
+testAmixer('1', 'PCM');


### PR DESCRIPTION
Follow up to #1961
We could refactor `getInfo` to use a single Regex and handle more cases. 

As a first step, here is a simple testing framework.  A good idea would be to collect multiple typical inputs, and also some edge cases.  Once we are happy with the regex, can refactor `getInfo` to use it.

```shell
volumio@volumio:/volumio$ node ./test/volume_controller.js

:::Input:::
 Simple mixer control 'SoftMaster',0
    Capabilities: volume
    Playback channels: Front Left - Front Right
    Capture channels: Front Left - Front Right
    Limits: 0 - 99
    Front Left: 10 [10%]
    Front Right: 10 [10%]
mute:  undefined
{ volume: 10, mute: false }

:::Input:::
 Simple mixer control 'PCM',0
  Capabilities: pvolume pswitch pswitch-joined
  Playback channels: Front Left - Front Right
  Limits: Playback 0 - 110
  Mono:
  Front Left: Playback 110 [100%] [0.00dB] [on]
  Front Right: Playback 110 [100%] [0.00dB] [on]

mute:  on
{ volume: 100, mute: true }
```

PS: *Unfortunately I can't get directly require and test with `volumecontroller` as it needs a proper framework with `commandRouter` and everything. It would amazing to have that, but don't have the time now to implement a full test harness...*


