### PR TITLE
Convert `unSetVolatile` to a Promise to avoid Sink races

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1296,11 +1296,16 @@ CoreCommandRouter.prototype.explodeUriFromService = function (service, uri) {
 CoreCommandRouter.prototype.volumioPlay = function (N) {
   this.pushConsoleMessage('CoreCommandRouter::volumioPlay');
 
-  this.stateMachine.unSetVolatile();
-
-  if (N === undefined) { return this.stateMachine.play(); } else {
-    return this.stateMachine.play(N);
-  }
+  return this.stateMachine.unSetVolatile().then((res) => {
+    if (res) {
+      this.commandRouter.logger.info(`unSetVolatile:: ${res}`);
+    }
+    if (N === undefined) { return this.stateMachine.play(); } else {
+      return this.stateMachine.play(N);
+    }
+  }).catch((e) => {
+    console.error('unSetVolatile Error: ', e);
+  });
 };
 
 // Volumio Play


### PR DESCRIPTION
With the recent performance boost I've been seeing with Buster/Node12, I've been running into frequent issues with volatile services not having enough time to release the ALSA source. 
By converting `unSetVol` into a Promise, this should be be alleviated. 

However, if a service provides a callback, it will still be fire and forget as previously, thought we should encourage other services to shift to a Promise as well. I hope we can (slowly) transition the codebase to native promises/Async/Await, but this is not a once shot thing.  Thus rationalised since it's an addition, it would be fine to use native Promises, and not `kew` here. 

I have only tested this with SpotifyConnect, please let me know how it works with the others..

PS: WIP, please don't merge yet! Have to work in #1938 here, or this there, depending on what ever you merge first ;-)

