### PR TITLE
Add methods to set/get devices time zone

### DIFF
--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -1074,7 +1074,7 @@ ControllerSystem.prototype.setTimeZone = function (data) {
   const defer = libQ.defer();
   const tz = data.name || 'UTC' // Fall back to UTC if nothing is provided
   this.logger.info(`Setting time zone to ${tz}`);
-  const tzcmd = 'echo volumio | sudo -S timedatectl set-timezone'
+  const tzcmd = 'timedatectl --no-ask-password set-timezone'
   exec(`${tzcmd} ${tz}`, (err, response) => {
     if (err) {
       this.logger.error(`Cannot set TimeZone: ${err}`);

--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -1074,7 +1074,7 @@ ControllerSystem.prototype.setTimeZone = function (data) {
   const defer = libQ.defer();
   const tz = data.name || 'UTC' // Fall back to UTC if nothing is provided
   this.logger.info(`Setting time zone to ${tz}`);
-  const tzcmd = 'timedatectl --no-ask-password set-timezone'
+  const tzcmd = 'sudo timedatectl set-timezone'
   exec(`${tzcmd} ${tz}`, (err, response) => {
     if (err) {
       this.logger.error(`Cannot set TimeZone: ${err}`);

--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -1046,3 +1046,41 @@ ControllerSystem.prototype.getCPUCoresNumber = function () {
       return 1
     }
 };
+
+ControllerSystem.prototype.getTimeZone = function () {
+  const defer = libQ.defer();
+  // Parse timedatectl's output
+  const timeZoneRegex = /(?:Time\szone):\s(\w+.\w+)\s\((\w+),\s([-+0-9]+)\)/gi
+  // Alternatively, we can just get the offset and acronym using 
+  // `date +"%Z %z"`
+  const tzcmd = 'timedatectl'
+  exec(tzcmd, (err, response) => {
+    if (err) {
+      this.logger.error(`Cannot get TimeZone: ${err}`);
+      return defer.resolve(err);
+    }
+    const match = timeZoneRegex.exec(response);
+    const [, name, acronym, offset] = match;
+    defer.resolve({
+      name: name,
+      acronym: acronym,
+      offset: offset
+    });
+  });
+  return defer.promise;
+};
+
+ControllerSystem.prototype.setTimeZone = function (data) {
+  const defer = libQ.defer();
+  const tz = data.name || 'UTC' // Fall back to UTC if nothing is provided
+  this.logger.info(`Setting time zone to ${tz}`);
+  const tzcmd = 'echo volumio | sudo -S timedatectl set-timezone'
+  exec(`${tzcmd} ${tz}`, (err, response) => {
+    if (err) {
+      this.logger.error(`Cannot set TimeZone: ${err}`);
+      return defer.resolve(err);
+    } 
+    defer.resolve(response);    
+  })
+  return defer.promise;
+};

--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -1744,6 +1744,28 @@ function InterfaceWebUI (context) {
           });
       }
     });
+    
+    // Method to get time zone of the device
+    connWebSocket.on('getTimeZone', function (data) {
+      self.commandRouter.executeOnPlugin('system_controller', 'system', 'getTimeZone','').then(tz => {
+        if (tz instanceof Error) {
+          console.error('Error getting timezone: ', tz);
+        } else {
+          // Not checking if object keys are as expected!
+          this.emit('pushTimeZone', tz)
+        }
+      });
+    });
+    
+    // Method to set time zone of the device
+    connWebSocket.on('setTimeZone', function (data) {
+      self.logger.info('setting timezone ' + JSON.stringify(data));
+      self.commandRouter.executeOnPlugin('system_controller', 'system', 'setTimeZone', data).then(res => {
+        // SocketIO serialises to JSON, and can't handle Error objects,
+        // so we coerce the possible Error into a string
+        this.emit('pushsetTimeZone',`${res || 'success'}`);
+      });
+    });
   });
 }
 

--- a/test/check_TimeZone.js
+++ b/test/check_TimeZone.js
@@ -1,0 +1,36 @@
+// Ondevice test script to check and set time zones
+const io = require('socket.io-client');
+const socket = io.connect('http://localhost:3000');
+
+const cmd = 'TimeZone';
+const tz = { name: 'Europe/Rome' }; // Set by name
+console.log(`Emitting get${cmd}`);
+socket.emit(`get${cmd}`);
+socket.on(`push${cmd}`, data => {
+  console.log(`Response push${cmd}\n`, data);
+});
+
+socket.on(`pushset${cmd}`, res => {
+  console.log(`Response pushset ${cmd}`);
+  if (res !== 'success') {
+    console.error(`Error setting time zone: ${res}`);
+  } else {
+    console.info(res);
+  }
+});
+
+// TODO: Refactor out these timeouts for something more reliable
+setTimeout(() => {
+  console.log(`Emitting set${cmd} --> ${tz.name}`);
+  socket.emit(`set${cmd}`, tz);
+}, 2000);
+
+// Attempt to Set by acronym, which will fail
+const tzAcro = { name: 'CEST' };
+setTimeout(() => {
+  console.log(`Emitting set${cmd} --> ${tzAcro.name}`);
+  socket.emit(`set${cmd}`, tzAcro);
+}, 2000);
+
+// Exit after 5 seconds
+setTimeout(() => { console.log('Exiting'); process.exit(); }, 5000);


### PR DESCRIPTION
Added some methods to set and get the current time zone.
~There is lot of scope of improvement, as `timedatectl` requires currently needs `sudo` perms.~
~If only I had read the docs, instead of skimming down to what I needed. [`--no-ask-password`](https://manpages.debian.org/buster/systemd/timedatectl.1.en.html)~ 
That also doesn't work, we just have to use the tried and tested `NOPASSWD`

<details>
<summary>  Roundabout method </summary>

We could set up `policykit` to allow the volumio user to use `timedatectl`, but I need to explore that more. Something along these lines *should* work..

```bash
$ sudo cat /etc/polkit-1/localauthority/10-vendor.d/10-time-policy.pkla
[Allow volumio user to set time zone]
Identity=unix-user:volumio
Action=org.freedesktop.timedate1.set-timezone
ResultActive=yes
```
</details>

On the FE side, we could pick up the current time zone from the browser in the wizard with 
[`Intl.DateTimeFormat().resolvedOptions().timeZone`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions). Or, for a more wholesome experience, I am sure we can also find some angular lib for time zone selection..

Partially fixes #373 #741

PS: Also included preliminary tests that can be run on the device (with Volumio running) 