### PR TITLE
Add an entry in the dev page to tail logs

### DIFF
--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -1053,7 +1053,7 @@ ControllerSystem.prototype.enableLiveLog = function (data) {
     try {
       this.logger.info('Launching a new LiveLog session');
       const format = 'cat'; // json is also an option for more serious logging/filtering
-      const args = ['/bin/journalctl','--output', format, '-f'];
+      const args = ['--output', format, '-f'];
       const defaults = {
         cwd: undefined,
         env: process.env
@@ -1066,7 +1066,7 @@ ControllerSystem.prototype.enableLiveLog = function (data) {
       if (this.livelogchild) {
         this.livelogchild.kill();
       }
-      this.livelogchild = spawn('/usr/bin/sudo',args, defaults);
+      this.livelogchild = spawn('/bin/journalctl',args, defaults);
 
       this.livelogchild.stdout.on('data', (d) => {
         liveLogData.message = d.toString();

--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -4,7 +4,7 @@ var libQ = require('kew');
 var fs = require('fs-extra');
 var config = new (require('v-conf'))();
 var execSync = require('child_process').execSync;
-const { spwan } = require('child_process');
+var spawn = require('child_process').spawn;
 var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
 var crypto = require('crypto');
@@ -1066,7 +1066,7 @@ ControllerSystem.prototype.enableLiveLog = function (data) {
       if (this.livelogchild) {
         this.livelogchild.kill();
       }
-      this.livelogchild = spawn('journalctl', args, defaults); // sudo or not?
+      this.livelogchild = spawn('/usr/bin/sudo /bin/journalctl', args, defaults);
 
       this.livelogchild.stdout.on('data', (d) => {
         liveLogData.message = d.toString();

--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -1064,10 +1064,17 @@ ControllerSystem.prototype.enableLiveLog = function (data) {
       this.commandRouter.broadcastMessage('LLogOpen', liveLogData);
       
       if (this.livelogchild) {
+        this.logger.info('Killing previous LiveLog session');
         this.livelogchild.kill();
       }
       this.livelogchild = spawn('/bin/journalctl',args, defaults);
-
+      
+      this.livelogchild.on('error', (d) => {
+        this.logger.info('Error spawning LiveLog session');
+        liveLogData.message = d.toString();
+        this.commandRouter.broadcastMessage('LLogProgress', liveLogData);
+      });
+      
       this.livelogchild.stdout.on('data', (d) => {
         liveLogData.message = d.toString();
         this.commandRouter.broadcastMessage('LLogProgress', liveLogData);

--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -1053,7 +1053,7 @@ ControllerSystem.prototype.enableLiveLog = function (data) {
     try {
       this.logger.info('Launching a new LiveLog session');
       const format = 'cat'; // json is also an option for more serious logging/filtering
-      const args = ['--output', format, '-f'];
+      const args = ['/bin/journalctl','--output', format, '-f'];
       const defaults = {
         cwd: undefined,
         env: process.env
@@ -1066,7 +1066,7 @@ ControllerSystem.prototype.enableLiveLog = function (data) {
       if (this.livelogchild) {
         this.livelogchild.kill();
       }
-      this.livelogchild = spawn('/usr/bin/sudo /bin/journalctl', args, defaults);
+      this.livelogchild = spawn('/usr/bin/sudo',args, defaults);
 
       this.livelogchild.stdout.on('data', (d) => {
         liveLogData.message = d.toString();

--- a/http/dev/dev.js
+++ b/http/dev/dev.js
@@ -12,6 +12,9 @@ document.getElementById('button-testtrue').onclick = function () { socket.emit('
 document.getElementById('button-testfalse').onclick = function () { socket.emit('callMethod', {endpoint: 'system_controller/system', method: 'setTestSystem', data: 'false'}); };
 document.getElementById('button-sshenable').onclick = function () { socket.emit('callMethod', {endpoint: 'system_controller/system', method: 'enableSSH', data: 'true'}); };
 document.getElementById('button-sshdisable').onclick = function () { socket.emit('callMethod', {endpoint: 'system_controller/system', method: 'enableSSH', data: 'false'}); };
+document.getElementById('button-livelog-enable').onclick = function () { socket.emit('callMethod', {endpoint: 'system_controller/system', method: 'enableLiveLog', data: 'true'}); };
+document.getElementById('button-livelog-disable').onclick = function () { socket.emit('callMethod', {endpoint: 'system_controller/system', method: 'enableLiveLog', data: 'false'}); };
+document.getElementById('button-clearconsole').onclick = function() { clearConsole()};
 
 // Create listeners for websocket events--------------------------------
 socket.on('connect', function () {
@@ -39,8 +42,8 @@ socket.on('disconnect', function () {
   playlistHistory = new Array();
   nPlaylistHistoryPosition = 0;
   clearPlayQueue();
-  clearBrowseView();
-  clearPlaylistView();
+  // clearBrowseView();
+  // clearPlaylistView();
   clearPlayerStateDisplay();
 });
 
@@ -77,13 +80,24 @@ socket.on('pushDeviceHWUUID', function (data) {
   document.getElementById('hwuuid-copy-button').style.display = 'inline';
 });
 
+
+socket.on('LLogOpen',data => {
+  document.getElementById('console').innerHTML += data.message;
+})
+socket.on('LLogProgress',data => {
+  document.getElementById('console').innerHTML += data.message;
+})
+socket.on('LLogDone',data => {
+  document.getElementById('console').innerHTML += data.message;
+})
+
 // Define internal functions ----------------------------------------------
 function clearConsole () {
   var nodeConsole = document.getElementById('console');
-
-  while (nodeConsole.firstChild) {
-    nodeConsole.removeChild(nodeConsole.firstChild);
-  }
+  nodeConsole.innerHTML = '';
+  // while (nodeConsole.firstChild) {
+  //   nodeConsole.removeChild(nodeConsole.firstChild);
+  // }
 }
 
 function enableControls () {

--- a/http/dev/dev.js
+++ b/http/dev/dev.js
@@ -85,7 +85,7 @@ socket.on('LLogOpen',data => {
   document.getElementById('console').innerHTML += data.message;
 })
 socket.on('LLogProgress',data => {
-  document.getElementById('console').innerHTML += data.message;
+  document.getElementById('console').innerHTML += data.message.replace(/verbose:.*$/gm,"\b");
 })
 socket.on('LLogDone',data => {
   document.getElementById('console').innerHTML += data.message;

--- a/http/dev/views/index.ejs
+++ b/http/dev/views/index.ejs
@@ -6,10 +6,25 @@
 		<style>
 			#div-console {
 				border: 1px solid black;
-				height: 400px;
-				overflow-y: scroll;
+				overflow-y: auto;
+				height: 98%;
+				width: 98%;
+				/* height: 400px; */
+				max-height:650px;
+				/* <pre> formatting */
+				display: block;
+				padding: 9.5px;
+				margin: 0 0 10px;
+				font-size: 13px;
+				line-height: 1.42857143;
+				color: #333;
+				word-break: break-all;
+				word-wrap: break-word;
+				background-color: #f5f5f5;
+				border: 1px solid #ccc;
+				border-radius: 4px;
 			}
-			#div-console ul {
+			/* #div-console ul {
 				list-style-type: none;
 				padding: 0px;
 				margin: 0px;
@@ -17,7 +32,7 @@
 			#div-console ul li pre {
 				padding: 0px;
 				margin: 0px;
-			}
+			} */
 			#div-browser li, #div-playqueue li {
 				clear: both;
 			}
@@ -64,6 +79,15 @@
 
 		<h3>Play Queue</h3>
 		<ol id='div-playqueue' start='0'></ol>
+
+		<h3>Live Log</hr>
+		<button id='button-clearconsole'>Clear</button>
+		<button id='console-copy-button' type="button" data-clipboard-demo data-clipboard-target="#console">Copy</button>
+		<div id='div-console' style='div-console'>
+			<pre id='console'></pre>
+		</div>
+		<button id='button-livelog-enable' class='control-websocket' disabled>ENABLE</button>
+		<button id='button-livelog-disable' class='control-websocket' disabled>DISABLE</button>
 
 		<script src="./assets/socket.io-2.0.3.js"></script>
 		<script src="./dev.js"></script>


### PR DESCRIPTION
Added a way to tail logs (via `journalctl -f`) to the dev page. This should make it easier for non console people to quickly get info that helps with debugging. There is a bit of overlap b/w this and the submit a log feature, but this can also help users debug stuff quickly. 
There is no max limit on the number of lines, but considering this is client side, should be fine?
Looks something like this:
![image](https://user-images.githubusercontent.com/16233271/82473117-67468400-9ac9-11ea-84b4-eb65e46853f2.png)
