### PR TITLE
Allow plugins to contribute ALSA config

### DIFF
--- a/app/platformSpecific.js
+++ b/app/platformSpecific.js
@@ -86,10 +86,7 @@ PlatformSpecific.prototype.startupSound = function () {
   var startupSound = self.coreCommand.executeOnPlugin('system_controller', 'system', 'getConfigParam', 'startupSound');
 
   if (startupSound) {
-    	var hwdev = '--device=plughw:' + outdev + ',0';
-    	if (outdev === 'softvolume') {
-    		hwdev = '-D softvolume';
-    	}
+    	var hwdev = '-D ' + outdev;
     try {
       execSync('/usr/bin/aplay ' + hwdev + ' /volumio/app/startup.wav');
     } catch (e) {

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -7,6 +7,7 @@ var S = require('string');
 var vconf = require('v-conf');
 var libQ = require('kew');
 var http = require('http');
+var exec = require('child_process').exec;
 var execSync = require('child_process').execSync;
 var Tail = require('tail').Tail;
 var compareVersions = require('compare-versions');
@@ -81,16 +82,92 @@ function PluginManager (ccommand, server) {
 }
 
 PluginManager.prototype.startPlugins = function () {
-  this.logger.info('-------------------------------------------');
-  this.logger.info('-----      Core plugins startup        ----');
-  this.logger.info('-------------------------------------------');
+  var self = this;
+  self.logger.info('-------------------------------------------');
+  self.logger.info('-----      Core plugins startup        ----');
+  self.logger.info('-------------------------------------------');
 
-  this.loadCorePlugins();
-  this.startCorePlugins();
-
-  if (this.myVolumioPluginManager !== undefined) {
-    this.myVolumioPluginManager.startPlugins();
-  }
+  var loadPromise = self.loadCorePlugins();
+  
+  var loadComplete = false;
+  
+  var loadDefer = libQ.defer();
+  
+  loadPromise.fin(() => {
+    if(!loadComplete) {
+      self.logger.info("Completed loading Core Plugins");
+      loadComplete = true;
+      loadDefer.resolve({});
+    } 
+  });
+  
+  // 30 second delay to continue startup if one or more plugins freeze in onVolumioStart
+  libQ.delay(30000)
+    .then(() => {
+      if(!loadComplete) {
+        loadComplete = true;
+        
+        var plugins = self.corePlugins.values();
+        for(var i = 0; i < plugins.length; i++) {
+          if(!plugins[i].volumioStart) {
+            self.logger.error("Plugin " + plugins[i].category + " " + plugins[i].name + " failed to complete 'onVolumioStart' in a timely fashion");
+          }
+        }
+        
+        loadDefer.resolve({});
+      }
+    });
+  
+  
+  return loadDefer.promise
+  .then(() => {
+    // Once all the plugins are loaded it is time to rebuild 
+    // the ALSA config so that the plugins can use it
+    return self.coreCommand.rebuildALSAConfiguration();
+  })
+  .then(() => {
+    var startDefer = libQ.defer();
+    var startPromise = self.startCorePlugins();
+    
+    var startComplete = false;
+    
+    startPromise.fin(() => {
+      if(!startComplete) {
+        startComplete = true;
+        self.logger.info("Completed starting Core Plugins");
+        startDefer.resolve({});
+      } 
+    });
+    
+    // 30 second delay to continue startup if one or more plugins freeze in onStart
+    libQ.delay(30000)
+      .then(() => {
+        if(!startComplete) {
+          startComplete = true;
+          
+          var plugins = self.corePlugins.values();
+          for(var i = 0; i < plugins.length; i++) {
+            var status = self.config.get(plugins[i].category + '.' + plugins[i].name + '.status');
+            
+            if(status != 'STARTED') {
+              self.logger.error("Plugin " + plugins[i].category + " " + plugins[i].name + " failed to complete 'onStart' in a timely fashion");
+            }
+          }
+          
+          startDefer.resolve({});
+        }
+      });
+    return startDefer.promise;
+  })
+  .then(() => {
+    // If the myVolumioPluginManager starts asynchronously then wait for it
+    var myVolumioStartPromise = null;
+    if (this.myVolumioPluginManager !== undefined) {
+      myVolumioStartPromise = this.myVolumioPluginManager.startPlugins();
+    } else {
+      myVolumioStartPromise = libQ.resolve({});
+    }
+  });
 };
 
 PluginManager.prototype.initializeConfiguration = function (package_json, pluginInstance, folder) {
@@ -158,7 +235,8 @@ PluginManager.prototype.loadCorePlugin = function (folder) {
       name: name,
       category: category,
       folder: folder,
-      instance: pluginInstance
+      instance: pluginInstance,
+      volumioStart: false
     };
 
     if (pluginInstance && pluginInstance.onVolumioStart !== undefined) {
@@ -174,9 +252,13 @@ PluginManager.prototype.loadCorePlugin = function (folder) {
       self.corePlugins.set(key, pluginData); // set in any case, so it can be started/stopped
 
       defer.resolve();
-      return myPromise;
+      return myPromise
+        .then(() => {
+          pluginData.volumioStart = true;
+        });
     } else {
       self.corePlugins.set(key, pluginData);
+      pluginData.volumioStart = true;
       defer.resolve();
     }
   } else {
@@ -1203,7 +1285,10 @@ PluginManager.prototype.disablePlugin = function (category, name) {
   var key = category + '.' + name;
   self.config.set(key + '.enabled', false);
 
-  defer.resolve();
+  var package_json = self.getPackageJson(self.findPluginFolder(category, name));
+  if(package_json.volumio_info.has_alsa_contribution) {
+    return self.coreCommand.rebuildALSAConfiguration();
+  }
   return defer.promise;
 };
 
@@ -1559,10 +1644,17 @@ PluginManager.prototype.enableAndStartPlugin = function (category, name) {
   var self = this;
   var defer = libQ.defer();
 
+  var folder = self.findPluginFolder(category, name);
   self.enablePlugin(category, name)
     .then(function (e) {
-      var folder = self.findPluginFolder(category, name);
       return self.loadCorePlugin(folder);
+    })
+    .then(() => {
+    	var package_json = self.getPackageJson(folder);
+    	if(package_json.volumio_info.has_alsa_contribution) {
+    		return self.coreCommand.rebuildALSAConfiguration();
+    	}
+    	return {};
     })
     .then(self.startPlugin.bind(this, category, name))
     .then(function (e) {

--- a/app/plugins/audio_interface/alsa_controller/index.js
+++ b/app/plugins/audio_interface/alsa_controller/index.js
@@ -1818,6 +1818,12 @@ ControllerAlsa.prototype.getPluginALSAContributions = function () {
         
         // Folder will be truthy if found
         if(folder) {
+          // Only get data from plugins that say they want to contribute in their package.json
+          var package_json = self.commandRouter.pluginManager.getPackageJson(folder);
+          if(!package_json || !package_json.volumio_info || !package_json.volumio_info.has_alsa_contribution) {
+        	  continue;
+          }
+        	
           // Check to see if the plugin wants to contribute
           folder += '/asound';
           if(fs.existsSync(folder)) {

--- a/app/plugins/audio_interface/alsa_controller/index.js
+++ b/app/plugins/audio_interface/alsa_controller/index.js
@@ -1210,7 +1210,16 @@ ControllerAlsa.prototype.writeSoftMixerFile = function (data) {
     var device = dataarr[1];
   }
 
+  asoundcontent += '# Convert to 24 bit to avoid unnecessary quality loss for 16 bit audio\n';
   asoundcontent += 'pcm.softvolume {\n';
+  asoundcontent += '    type            plug\n';
+  asoundcontent += '    slave {\n';
+  asoundcontent += '        pcm         "volumioSoftVol"\n';
+  asoundcontent += '        format      "S24_3LE"\n';  
+  asoundcontent += '    }\n';
+  asoundcontent += '}\n\n';
+  
+  asoundcontent += 'pcm.volumioSoftVol {\n';
   asoundcontent += '    type            softvol\n';
   asoundcontent += '    slave {\n';
   asoundcontent += '        pcm         "postVolume"\n';
@@ -1689,7 +1698,7 @@ ControllerAlsa.prototype.updateALSAConfigFile = function () {
 
     var asoundcontent = '';
     asoundcontent += 'pcm.!default {\n';
-    asoundcontent += '    type             plug\n';
+    asoundcontent += '    type             copy\n';
     asoundcontent += '    slave.pcm       "volumio"\n';
     asoundcontent += '}\n';
     asoundcontent += '\n';
@@ -1699,7 +1708,7 @@ ControllerAlsa.prototype.updateALSAConfigFile = function () {
       var contribution = contributions[i];
       
       asoundcontent += 'pcm.' + outPCM + ' {\n';
-      asoundcontent += '    type             plug\n';
+      asoundcontent += '    type             copy\n';
       asoundcontent += '    slave.pcm       "' + contribution.snippetDatum.inPCM + '"\n';
       asoundcontent += '}\n';
       asoundcontent += '\n';
@@ -1719,7 +1728,14 @@ ControllerAlsa.prototype.updateALSAConfigFile = function () {
       device = dataarr[1];
     }
     
+    
+    asoundcontent += '# There is always a plug before the hardware to be safe\n';
     asoundcontent += 'pcm.volumioOutput {\n';
+    asoundcontent += '    type plug\n';
+    asoundcontent += '    slave.pcm "volumioHw"\n';    
+    asoundcontent += '}\n\n';
+
+    asoundcontent += 'pcm.volumioHw {\n';
     asoundcontent += '    type hw\n';
     asoundcontent += '    card ' + card + '\n';
     if(device != null) {

--- a/app/plugins/audio_interface/alsa_controller/index.js
+++ b/app/plugins/audio_interface/alsa_controller/index.js
@@ -68,10 +68,9 @@ ControllerAlsa.prototype.onVolumioStart = function () {
     this.updateVolumeSettings();
   }
 
-  self.logger.debug("Creating shared var alsa.outputdevice='" + this.config.get('outputdevice') + "'");
-  this.commandRouter.sharedVars.addConfigValue('alsa.outputdevice', 'string', this.config.get('outputdevice'));
+  self.logger.debug("Creating shared var alsa.outputdevice='volumio'");
+  this.commandRouter.sharedVars.addConfigValue('alsa.outputdevice', 'string', 'volumio');
   this.commandRouter.sharedVars.addConfigValue('alsa.outputdevicemixer', 'string', this.config.get('mixer'));
-  this.commandRouter.sharedVars.registerCallback('alsa.outputdevice', this.outputDeviceCallback.bind(this));
 
   self.checkMixer();
 
@@ -100,8 +99,6 @@ ControllerAlsa.prototype.getUIConfig = function () {
       value = self.config.get('outputdevice');
       if (value == undefined) {
         value = 0;
-      } else if (value == 'softvolume') {
-        value = self.config.get('softvolumenumber');
       }
       var cardnum = value;
 
@@ -467,8 +464,6 @@ ControllerAlsa.prototype.saveDSPOptions = function (data) {
   var value = self.config.get('outputdevice');
   if (value == undefined) {
     value = 0;
-  } else if (value == 'softvolume') {
-    value = self.config.get('softvolumenumber');
   }
 
   var outdevicename = self.config.get('outputdevicename');
@@ -670,8 +665,8 @@ ControllerAlsa.prototype.saveAlsaOptions = function (data) {
 			 */
     }
   }
-
-  self.commandRouter.sharedVars.set('alsa.outputdevice', OutputDeviceNumber);
+  
+  self.config.set('outputdevice', OutputDeviceNumber);
   self.setDefaultMixer(OutputDeviceNumber);
 
   var respconfig = self.commandRouter.getUIConfigOnPlugin('audio_interface', 'alsa_controller', {});
@@ -682,7 +677,17 @@ ControllerAlsa.prototype.saveAlsaOptions = function (data) {
     }
   });
 
-  return defer.promise;
+  var promise = null;
+  if(self.config.get('softvolume')) {
+	  promise = self.writeSoftMixerFile(OutputDeviceNumber);
+  } else {
+	  promise = self.updateALSAConfigFile();
+  }
+
+  return promise.then((x) => {
+    self.commandRouter.sharedVars.set('alsa.outputdevice', 'volumio');
+    return x;
+  })
 };
 
 ControllerAlsa.prototype.saveVolumeOptions = function (data) {
@@ -711,8 +716,6 @@ ControllerAlsa.prototype.saveVolumeOptions = function (data) {
       var value = self.config.get('outputdevice');
       if (value == undefined) {
         value = 0;
-      } else if (value == 'softvolume') {
-        value = self.config.get('softvolumenumber');
       }
       var mixers = self.getMixerControls(value);
       var index = mixers.indexOf('SoftMaster');
@@ -721,24 +724,20 @@ ControllerAlsa.prototype.saveVolumeOptions = function (data) {
       }
       data.mixer.value = mixers[0];
     }
-    var outValue = self.config.get('outputdevice', 'none');
-    if (outValue === 'softvolume') {
-      var currentDeviceNumber = self.config.get('softvolumenumber', 'none');
-      self.disableSoftMixer(currentDeviceNumber);
-      self.config.set('outputdevice', currentDeviceNumber);
-      self.config.delete('softvolumenumber');
-      self.commandRouter.sharedVars.set('alsa.outputdevice', currentDeviceNumber);
+    var softvolume = self.config.get('softvolume');
+    if (softvolume) {
+      self.disableSoftMixer();
+      self.commandRouter.sharedVars.set('alsa.outputdevice', 'volumio');
     }
     self.restorePreviousVolumeLevel(currentVolume, currentMute, false);
     self.setConfigParam({key: 'mixer', value: data.mixer.value});
   } else if (data.mixer_type.value === 'Software') {
     var outdevice = self.config.get('outputdevice');
-    if (outdevice != 'softvolume') {
+    var softvolume = self.config.get('softvolume');
+    if (!softvolume) {
       self.restorePreviousVolumeLevel(currentVolume, currentMute, true);
       self.enableSoftMixer(outdevice);
-      var outdevice = 'softvolume';
-      self.config.set('outputdevice', outdevice);
-      self.commandRouter.sharedVars.set('alsa.outputdevice', outdevice);
+      self.commandRouter.sharedVars.set('alsa.outputdevice', 'volumio');
     } else {
       self.restorePreviousVolumeLevel(currentVolume, currentMute, true);
     }
@@ -747,14 +746,12 @@ ControllerAlsa.prototype.saveVolumeOptions = function (data) {
     var outdevice = self.config.get('outputdevice');
     self.setConfigParam({key: 'volumemax', value: '100'});
     self.restorePreviousVolumeLevel('100', false, false);
-    if (outdevice === 'softvolume') {
-      var outdevice = self.config.get('softvolumenumber');
-      this.config.set('outputdevice', outdevice);
-      self.config.delete('softvolumenumber');
+    var softvolume = self.config.get('softvolume');
+    if (softvolume) {
       self.restartMpd.bind(self);
-      self.disableSoftMixer(outdevice);
+      self.disableSoftMixer();
     }
-    self.commandRouter.sharedVars.set('alsa.outputdevice', outdevice);
+    self.commandRouter.sharedVars.set('alsa.outputdevice', 'volumio');
   }
   self.setConfigParam({key: 'mixer_type', value: data.mixer_type.value});
 
@@ -794,7 +791,9 @@ ControllerAlsa.prototype.saveResamplingOpts = function (data) {
 };
 
 ControllerAlsa.prototype.outputDeviceCallback = function (value) {
-  this.config.set('outputdevice', value);
+  if(value != 'volumio') {
+    self.log.warn('The ALSA output device has been set to ' + value +  ' when it should always be \'volumio\'')
+  }
 };
 
 ControllerAlsa.prototype.getConfigParam = function (key) {
@@ -971,9 +970,7 @@ ControllerAlsa.prototype.getMixerControls = function (device) {
 
   var mixers = [];
   var outdev = this.config.get('outputdevice');
-  if (outdev == 'softvolume') {
-    outdev = this.config.get('softvolumenumber');
-  }
+  
   if (outdev.indexOf(',') >= 0) {
     outdev = outdev.charAt(0);
   }
@@ -1090,7 +1087,10 @@ ControllerAlsa.prototype.setDefaultMixer = function (device) {
             }
           }
         }
-        if (outputdevice === 'softvolume') {
+
+        var softvolume = self.config.get('softvolume');
+
+        if (softvolume) {
           self.logger.info('Setting default mixerSoftMaster for Softvolume device');
           this.mixertype = 'Software';
           defaultmixer = 'SoftMaster';
@@ -1157,7 +1157,7 @@ ControllerAlsa.prototype.checkMixer = function () {
           self.setConfigParam({key: 'softvolumenumber', value: outputdevice});
         }
         self.commandRouter.sharedVars.set('alsa.outputdevicemixer', 'SoftMaster');
-        self.commandRouter.sharedVars.set('alsa.outputdevice', 'softvolume');
+        self.commandRouter.sharedVars.set('alsa.outputdevice', 'volumio');
         self.updateVolumeSettings();
         // Restarting MPD, this seems needed only on first boot
         setTimeout(function () {
@@ -1184,6 +1184,8 @@ ControllerAlsa.prototype.enableSoftMixer = function (data) {
     .then(self.setSoftVolConf.bind(self))
     .then(self.restartMpd.bind(self));
 };
+
+
 ControllerAlsa.prototype.writeSoftMixerFile = function (data) {
   var self = this;
   var defer = libQ.defer();
@@ -1199,60 +1201,42 @@ ControllerAlsa.prototype.writeSoftMixerFile = function (data) {
   }
 
   var asoundcontent = '';
+  var card = data;
+  var device = 0;
+
   if (data.indexOf(',') >= 0) {
     var dataarr = data.split(',');
     var card = dataarr[0];
     var device = dataarr[1];
-
-    asoundcontent += 'pcm.softvolume {\n';
-    asoundcontent += '    type             plug\n';
-    asoundcontent += '    slave.pcm       "softvol"\n';
-    asoundcontent += '}\n';
-    asoundcontent += '\n';
-    asoundcontent += 'pcm.softvol {\n';
-    asoundcontent += '    type            softvol\n';
-    asoundcontent += '    slave {\n';
-    asoundcontent += '        pcm         "plughw:' + data + '"\n';
-    asoundcontent += '    }\n';
-    asoundcontent += '    control {\n';
-    asoundcontent += '        name        "SoftMaster"\n';
-    asoundcontent += '        card        ' + card + '\n';
-    asoundcontent += '        device      ' + device + '\n';
-    asoundcontent += '    }\n';
-    asoundcontent += 'max_dB 0.0\n';
-    asoundcontent += 'min_dB -50.0\n';
-    asoundcontent += 'resolution 100\n';
-    asoundcontent += '}\n';
-  } else {
-    asoundcontent += 'pcm.softvolume {\n';
-    asoundcontent += '    type             plug\n';
-    asoundcontent += '    slave.pcm       "softvol"\n';
-    asoundcontent += '}\n';
-    asoundcontent += '\n';
-    asoundcontent += 'pcm.softvol {\n';
-    asoundcontent += '    type            softvol\n';
-    asoundcontent += '    slave {\n';
-    asoundcontent += '        pcm         "plughw:' + data + ',0"\n';
-    asoundcontent += '    }\n';
-    asoundcontent += '    control {\n';
-    asoundcontent += '        name        "SoftMaster"\n';
-    asoundcontent += '        card        ' + data + '\n';
-    asoundcontent += '        device      0\n';
-    asoundcontent += '    }\n';
-    asoundcontent += 'max_dB 0.0\n';
-    asoundcontent += 'min_dB -50.0\n';
-    asoundcontent += 'resolution 100\n';
-    asoundcontent += '}\n';
   }
 
-  fs.writeFile('/home/volumio/.asoundrc', asoundcontent, 'utf8', function (err) {
+  asoundcontent += 'pcm.softvolume {\n';
+  asoundcontent += '    type            softvol\n';
+  asoundcontent += '    slave {\n';
+  asoundcontent += '        pcm         "postVolume"\n';
+  asoundcontent += '    }\n';
+  asoundcontent += '    control {\n';
+  asoundcontent += '        name        "SoftMaster"\n';
+  asoundcontent += '        card        ' + card + '\n';
+  asoundcontent += '        device      ' + device + '\n';
+  asoundcontent += '    }\n';
+  asoundcontent += 'max_dB 0.0\n';
+  asoundcontent += 'min_dB -50.0\n';
+  asoundcontent += 'resolution 100\n';
+  asoundcontent += '}\n';
+  
+  var folder = self.commandRouter.pluginManager.findPluginFolder('audio_interface', 'alsa_controller');
+  folder += '/asound'
+
+  if(!fs.existsSync(folder)) {
+    fs.mkdirSync(folder);
+  }
+  fs.writeFile(folder + '/softvolume.postVolume.conf', asoundcontent, 'utf8', function (err) {
     if (err) {
-      self.logger.info('Cannot write /etc/asound.conf: ' + err);
+      self.logger.info('Cannot write Software Volume ALSA configuration: ' + err);
     } else {
-      self.logger.info('Asound.conf file written');
-      var mv = execSync('/usr/bin/sudo /bin/mv /home/volumio/.asoundrc /etc/asound.conf', { uid: 1000, gid: 1000, encoding: 'utf8' });
-      var apply = execSync('/usr/sbin/alsactl -L -R nrestore', { uid: 1000, gid: 1000, encoding: 'utf8' });
-      defer.resolve();
+      self.logger.info('Software Volume ALSA configuration written');
+      defer.resolve(self.updateALSAConfigFile());
     }
   });
 
@@ -1263,8 +1247,8 @@ ControllerAlsa.prototype.setSoftParams = function () {
   var self = this;
   var defer = libQ.defer();
 
+  self.setConfigParam({key: 'softvolume', value: true});
   self.setConfigParam({key: 'mixer', value: 'SoftMaster'});
-  self.setConfigParam({key: 'outputdevice', value: 'softvolume'});
 
   defer.resolve();
   return defer.promise;
@@ -1275,7 +1259,7 @@ ControllerAlsa.prototype.apply1 = function () {
   var defer = libQ.defer();
 
   try {
-    var apply2 = execSync('/usr/bin/aplay -D softvolume /volumio/app/silence.wav', { encoding: 'utf8' });
+    var apply2 = execSync('/usr/bin/aplay -D volumio /volumio/app/silence.wav', { encoding: 'utf8' });
   } catch (e) {
 
   }
@@ -1297,8 +1281,9 @@ ControllerAlsa.prototype.setSoftConf = function () {
   var self = this;
   var defer = libQ.defer();
 
+  self.setConfigParam({key: 'softvolume', value: true});
   self.commandRouter.sharedVars.set('alsa.outputdevicemixer', 'SoftMaster');
-  self.commandRouter.sharedVars.set('alsa.outputdevice', 'softvolume');
+  self.commandRouter.sharedVars.set('alsa.outputdevice', 'volumio');
 
   defer.resolve();
   return defer.promise;
@@ -1325,22 +1310,21 @@ ControllerAlsa.prototype.restartMpd = function () {
   return defer.promise;
 };
 
-ControllerAlsa.prototype.disableSoftMixer = function (data) {
+ControllerAlsa.prototype.disableSoftMixer = function () {
   var self = this;
 
   self.logger.info('Disable softmixer device for audio device');
+  
+  self.setConfigParam({key: 'softvolume', value: false});
 
-  var asoundcontent = '';
+  var folder = self.commandRouter.pluginManager.findPluginFolder('audio_interface', 'alsa_controller');
 
-  fs.writeFile('/home/volumio/.asoundrc', asoundcontent, 'utf8', function (err) {
+  fs.unlink(folder + '/asound/softvolume.postVolume.conf', function (err) {
     if (err) {
-      self.logger.info('Cannot write /etc/asound.conf: ' + err);
+      self.logger.info('Cannot delete ' + folder + '/asound/softvolume-postVolume.conf: ' + err);
     } else {
-      self.logger.info('Asound.conf file written');
-      var mv = execSync('/usr/bin/sudo /bin/mv /home/volumio/.asoundrc /etc/asound.conf', { uid: 1000, gid: 1000, encoding: 'utf8' });
-      var apply = execSync('/usr/sbin/alsactl -L -R nrestore', { uid: 1000, gid: 1000, encoding: 'utf8' });
-      self.updateVolumeSettings();
-      var apply3 = execSync('/usr/sbin/alsactl -L -R nrestore', { uid: 1000, gid: 1000, encoding: 'utf8' });
+      self.logger.info('Soft Volume ALSA configuration file deleted');
+      self.updateALSAConfigFile();
     }
   });
 };
@@ -1356,17 +1340,10 @@ ControllerAlsa.prototype.updateVolumeSettings = function () {
   var valmixer = self.config.get('mixer');
   var valmixertype = self.config.get('mixer_type');
 
-  if (valdevice != 'softvolume') {
-    if (cards[valdevice] != undefined) {
-      var outdevicename = cards[valdevice].name;
-    }
-  } else {
-    var outdevicename = 'softvolume';
+  if (cards[valdevice] != undefined) {
+    var outdevicename = cards[valdevice].name;
   }
 
-  if (valmixertype === 'Software') {
-    valdevice = self.config.get('softvolumenumber');
-  }
   var valvolumestart = self.config.get('volumestart');
   var valvolumesteps = self.config.get('volumesteps');
 
@@ -1428,7 +1405,7 @@ ControllerAlsa.prototype.storeAlsaSettings = function () {
     if (error) {
       self.logger.error('Cannot Store Alsa Settings: ' + error);
     } else {
-      self.logger.error('Alsa Settings successfully stored');
+      self.logger.info('Alsa Settings successfully stored');
     }
   });
 };
@@ -1534,9 +1511,7 @@ ControllerAlsa.prototype.checkAudioDeviceAvailable = function () {
   }
   var cards = self.getAlsaCards();
   var outdev = this.config.get('outputdevice');
-  if (outdev === 'softvolume') {
-    outdev = self.config.get('softvolumenumber', 'none');
-  }
+  
   var outdevName = this.config.get('outputdevicename');
   if (cards.length === 0) {
     var responseData = {
@@ -1599,9 +1574,7 @@ ControllerAlsa.prototype.checkCurrentAudioDeviceAvailable = function () {
   var self = this;
 
   var currentDeviceNumber = self.config.get('outputdevice', 'none');
-  if (currentDeviceNumber === 'softvolume') {
-    	currentDeviceNumber = self.config.get('softvolumenumber', 'none');
-  }
+
   var cards = self.getAlsaCards();
   if (cards.length === 0) {
     return false;
@@ -1678,3 +1651,185 @@ ControllerAlsa.prototype.getAlsaCardsWithoutI2SDAC = function (data) {
 
     return cardsWithoutI2S;
 };
+
+// This function regeneratees the ALSA config file, including
+// any contributions from enabled plugins. The main input is 
+// always 'volumio' and the final output 'volumioOutput'
+ControllerAlsa.prototype.updateALSAConfigFile = function () {
+  var self = this;
+
+  self.logger.info('Preparing to generate the ALSA configuration file');
+
+  var snippets = self.getPluginALSAContributions();
+
+  return snippets.then((snippetData) => {
+    if(snippetData.length > 0) {
+      self.logger.info('Reading ALSA contributions from plugins.');
+    }
+    // Read the snippets into memory
+    var pendingReads = [];
+    for(var i = 0; i < snippetData.length; i++) {
+      let defer = libQ.defer();
+      pendingReads.push(defer.promise)
+      let snippetDatum = snippetData[i];
+
+      fs.readFile(snippetDatum.configFile, 'utf8', (failure,snippet) => {
+        if(failure) {
+          self.logger.error('Failed to read ALSA data from ' + snippetDatum.configFile + ' due to ' + failure);
+          defer.resolve(null);
+        } else {
+          defer.resolve({snippetDatum, snippet});
+        }
+      });
+    }
+    return libQ.all(pendingReads)
+  }).then((contributions) => {
+
+    contributions.push({'snippetDatum': {'inPCM': 'volumioOutput'}, 'snippet': ''});
+
+    var asoundcontent = '';
+    asoundcontent += 'pcm.!default {\n';
+    asoundcontent += '    type             plug\n';
+    asoundcontent += '    slave.pcm       "volumio"\n';
+    asoundcontent += '}\n';
+    asoundcontent += '\n';
+    
+    var outPCM = 'volumio'
+    for(var i = 0; i < contributions.length; i++) {
+      var contribution = contributions[i];
+      
+      asoundcontent += 'pcm.' + outPCM + ' {\n';
+      asoundcontent += '    type             plug\n';
+      asoundcontent += '    slave.pcm       "' + contribution.snippetDatum.inPCM + '"\n';
+      asoundcontent += '}\n';
+      asoundcontent += '\n';
+      
+      asoundcontent += contribution.snippet;
+      asoundcontent += '\n';
+      
+      outPCM = contribution.snippetDatum.outPCM;
+    }
+    
+    var card = self.config.get('outputdevice')
+    var device = null;
+    
+    if(card.indexOf(',') >= 0) {
+      var dataarr = card.split(',');
+      card = dataarr[0];
+      device = dataarr[1];
+    }
+    
+    asoundcontent += 'pcm.volumioOutput {\n';
+    asoundcontent += '    type hw\n';
+    asoundcontent += '    card ' + card + '\n';
+    if(device != null) {
+      asoundcontent += '    device ' + device + '\n';
+    }
+    asoundcontent += '}\n';
+
+    return asoundcontent;
+  }).then((asoundcontent) => {
+    var defer = libQ.defer();
+    fs.writeFile('/home/volumio/.asoundrc', asoundcontent, 'utf8', function (err) {
+      if (err) {
+        self.logger.info('Cannot write /etc/asound.conf: ' + err);
+      } else {
+        self.logger.info('Asound.conf file written');
+        var mv = execSync('/usr/bin/sudo /bin/mv /home/volumio/.asoundrc /etc/asound.conf', { uid: 1000, gid: 1000, encoding: 'utf8' });
+        var apply = execSync('/usr/sbin/alsactl -L -R nrestore', { uid: 1000, gid: 1000, encoding: 'utf8' });
+      }
+      defer.resolve();
+    });
+    return defer.promise;
+  });
+};
+
+// Search all enabled plugins for ALSA snippets in /<plugin path>/asound/<contribution>.conf
+//
+// Contributions are in the form <in pcm>-<out pcm>.conf or <in pcm>-<out pcm>-<rank>.conf
+// which allows us to construct a complete config file wiring the contributions together.
+ControllerAlsa.prototype.getPluginALSAContributions = function () {
+  
+  var self = this;
+  
+  var alsaSnippetChecks = [];
+
+  var plugins = this.commandRouter.pluginManager.getPluginsMatrix();
+  
+  for (var i = 0; i < plugins.length; i++) {
+
+    let category = plugins[i].cName;
+    
+    for(var j = 0; j < plugins[i].catPlugin.length; j++) {
+
+      let plugin = plugins[i].catPlugin[j];
+  
+      if(plugin.enabled === true) {
+        // Check to see if there is an ALSA contribution from this plugin
+        let folder = self.commandRouter.pluginManager.findPluginFolder(category, plugin.name);
+        
+        // Folder will be truthy if found
+        if(folder) {
+          // Check to see if the plugin wants to contribute
+          folder += '/asound';
+          if(fs.existsSync(folder)) {
+            
+            let dirDefer = libQ.defer();
+            alsaSnippetChecks.push(dirDefer.promise);
+            
+            fs.readdir(folder, function (err, files) {
+              if (err) {
+                self.logger.warn('Unable to scan plugin ' + plugin.name + ' for ALSA configuration: ' + err);
+                dirDefer.resolve(null);
+                return;
+              } 
+              var fileData = [];
+              // Get the contribution file(s)
+              files.forEach(function (file) {
+                // Skip hidden files and non config files
+                if(file.startsWith('.') || !file.endsWith('.conf')) {
+                  return;
+                }
+                // Expected file name syntax is <in pcm>.<out pcm>.conf or <in pcm>.<out pcm>.<rank>.conf
+                var tokens = file.substring(0, file.length - 5).split('.');
+                
+                if(tokens.length < 2 || tokens.length > 3) {
+                  self.logger.warn('The plugin ' + plugin.name + 
+                      ' is trying to supply ALSA configuration but the file ' + file +
+                      ' does not meet the expected name syntax');
+                }
+                
+                self.logger.info('The plugin ' + plugin.name + ' has an ALSA contribution file ' + file);
+                
+                var pluginName = plugin.name;
+                var configFile = folder + "/" + file;
+                var inPCM = tokens[0];
+                var outPCM = tokens[1];
+                var priority = tokens.length == 3 ? parseInt(tokens[2]) : 0;
+  
+                fileData.push({pluginName, configFile, inPCM, outPCM, priority})
+              });
+  
+              dirDefer.resolve(fileData);
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return libQ.all(alsaSnippetChecks).then((snippetData) => {
+    // Clear any failed values, flatten the lists, and then sort highest priority data first
+    var cleanedArray = snippetData.filter((datum) => {
+      return datum != null;
+    });
+
+    cleanedArray = [].concat.apply([], cleanedArray);
+    
+    return cleanedArray.sort((a,b) => {
+      return b.priority - a.priority;
+    });
+  }, (error) => {
+    self.logger.error('Failed to gather ALSA contribution files. ' + error);
+  });
+} 

--- a/app/plugins/audio_interface/alsa_controller/package.json
+++ b/app/plugins/audio_interface/alsa_controller/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "volumio_info": {
     "plugin_type": "audio_interface",
-    "boot_priority":4
+    "boot_priority":4,
+    "has_alsa_contribution":true
   }
 }

--- a/app/plugins/music_service/airplay_emulation/index.js
+++ b/app/plugins/music_service/airplay_emulation/index.js
@@ -115,14 +115,6 @@ AirPlayInterface.prototype.startShairportSync = function () {
   var self = this;
   // Loading Configured output device
   var outdev = this.commandRouter.sharedVars.get('alsa.outputdevice');
-  if (outdev == 'softvolume') {
-    outdev = self.getAdditionalConf('audio_interface', 'alsa_controller', 'softvolumenumber');
-  }
-  if (outdev.indexOf(',') >= 0) {
-    outdev = 'plughw:' + outdev;
-  } else {
-    outdev = 'plughw:' + outdev + ',0';
-  }
 
   var buffer_size_line;
   var mixer = this.commandRouter.sharedVars.get('alsa.outputdevicemixer');

--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -944,8 +944,10 @@ ControllerMpd.prototype.createMPDFile = function (callback) {
       if (err) {
         return self.logger.error(err);
       }
-      var outdev = self.getAdditionalConf('audio_interface', 'alsa_controller', 'outputdevice');
+      var outdev = self.commandRouter.sharedVars.get('alsa.outputdevice');
+      var realDev = self.getAdditionalConf('audio_interface', 'alsa_controller', 'outputdevice');
       var mixer = self.getAdditionalConf('audio_interface', 'alsa_controller', 'mixer');
+      var softvolume = self.getAdditionalConf('audio_interface', 'alsa_controller', 'softvolume');
 
       var resampling = self.getAdditionalConf('audio_interface', 'alsa_controller', 'resampling');
       var resampling_bitdepth = self.getAdditionalConf('audio_interface', 'alsa_controller', 'resampling_target_bitdepth');
@@ -955,18 +957,14 @@ ControllerMpd.prototype.createMPDFile = function (callback) {
 
       var mixerdev = '';
       var mixerstrings = '';
-      if (outdev != 'softvolume') {
-        var realDev = outdev;
-        if (outdev.indexOf(',') >= 0) {
-          mixerdev = 'hw:' + outdev;
-          outdev = 'hw:' + outdev;
+      if (!softvolume) {
+        if (realDev.indexOf(',') >= 0) {
+          mixerdev = 'hw:' + realDev;
         } else {
-          mixerdev = 'hw:' + outdev;
-          outdev = 'hw:' + outdev + ',0';
+          mixerdev = 'hw:' + realDev;
         }
       } else {
         mixerdev = 'SoftMaster';
-        var realDev = self.getAdditionalConf('audio_interface', 'alsa_controller', 'softvolumenumber');
       }
 
       var mpdvolume = self.getAdditionalConf('audio_interface', 'alsa_controller', 'mpdvolume');

--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -34,18 +34,15 @@ function CoreVolumeController (commandRouter) {
   self.logger = self.commandRouter.logger;
 
   device = this.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getConfigParam', 'outputdevice');
-  if (device === 'softvolume') {
-    device = this.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getConfigParam', 'softvolumenumber');
-    devicename = 'softvolume';
-  } else {
-    if (device.indexOf(',') >= 0) {
-      device = device.charAt(0);
-    }
-    var cards = this.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getAlsaCards', '');
-    if ((cards[device] !== undefined) && (cards[device].name !== undefined)) {
-      devicename = cards[device].name;
-    }
+
+  if (device.indexOf(',') >= 0) {
+    device = device.charAt(0);
   }
+  var cards = this.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getAlsaCards', '');
+  if ((cards[device] !== undefined) && (cards[device].name !== undefined)) {
+    devicename = cards[device].name;
+  }
+  
   var mixerdev = this.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getConfigParam', 'mixer');
 
   if (mixerdev.indexOf(',') >= 0) {


### PR DESCRIPTION
This pull request makes a relatively simple but significant change to the ALSA config used in Volumio. 

Rather than having each audio component write directly to the audio hardware using `plughw:X,Y`, with special exceptions made in lots of places for `softvolume` when Software volume control is enabled, this solution always creates a PCM called `volumio` which is a `plug` intended to be used for audio output by everything.

The default ALSA config ends up looking like:

```
pcm.volumio {
    type        plug
    slave.pcm   volumioOut
}

pcm.volumioOut {
    type        hw
    card        X
    device      Y
}
```

This is identical in behaviour to `plughw:X,Y`, however it allows for plugins to contribute to the ALSA file in a simple, reliable way. For example the software volume control plugin can have the snippet:

```
pcm.softvolume {
    type        softvol
    slave {
        pcm   postVolume
    }
    control {
        name        "SoftMaster"
        card        X
    }
}
```

The overall generated ALSA config file ends up looking like:

```
pcm.volumio {
    type        plug
    slave.pcm   softVolume
}

pcm.softvolume {
    type        softvol
    slave {
        pcm   postVolume
    }
    control {
        name        "SoftMaster"
        card        X
    }
}

pcm.postVolume {
    type        plug
    slave.pcm   volumioOut
}

pcm.volumioOut {
    type        hw
    card        X
    device      Y
}
```

This has two significant advantages:

1. That *any* plugin can contribute to the ALSA configuration while still playing nicely with other plugins (e.g. The equaliser plugin doesn't work with software volume control)
2. That all audio inputs (e.g. shairport-sync) will reliably work with the expected audio configuration as they point at `volumio` not directly at the hardware

This PR makes it much simpler to fix issue #1973 - a "dmix volumio plugin" would be trivial to create which adds in a dmix pcm to the volumio chain, and an "on/off" slider can enable/disable the background silent audio. (I'm planning to work on a plugin for this next).

This PR also makes it much simpler to provide things like working SnapCast integration. The current plugin relies on "patching" the ALSA and MPD configuration in ways that don't work reliably (re-patching buttons have been added). Any time a configuration change touches the ALSA config then SnapCast breaks.

I've done my best to verify that this works in all directions (to/from softvolume, to/from dac, volume changes etc). Let me know if I can do anything more to help with it.
