### PR TITLE
Remove From Favourites

### DIFF
--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -217,12 +217,17 @@ PlaylistManager.prototype.removeFromFavourites = function (name, service, uri) {
   if (service === 'webradio') {
     return self.commonRemoveFromPlaylist(self.favouritesPlaylistFolder, 'radio-favourites', service, uri);
   } else {
-    self.commandRouter.executeOnPlugin('music_service', service, 'removeFromFavourites', {uri: uri, service: service});
-    return self.commonRemoveFromPlaylist(self.favouritesPlaylistFolder, 'favourites', service, uri)
+    var plugin = this.commandRouter.pluginManager.getPlugin('music_service', service);
+    if (plugin && typeof (plugin.removeFromFavourites) === typeof (Function)) {
+      self.logger.info('Removing ' + uri + ' from favourites with specific ' + service + ' method');
+      return plugin.removeFromFavourites({uri: uri, service: service});
+    } else {
+      return self.commonRemoveFromPlaylist(self.favouritesPlaylistFolder, 'favourites', service, uri)
       .then(function (data) {
         if (data.success !== false) { self.commandRouter.emitFavourites({service: service, uri: uri, favourite: false}); }
         return data;
       });
+    }
   }
 };
 

--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -613,6 +613,20 @@ function InterfaceWebUI (context) {
                 });
             }
           }, 600);
+        } else if (data.service === 'tidal') {
+          //TODO: Find a more elegant wait of handling this
+          setTimeout(() => {
+            var uri = data.uri.substring(0, data.uri.lastIndexOf('/'));
+            response = self.musicLibrary.executeBrowseSource(uri);
+            if (response != undefined) {
+              response.then(function (result) {
+                selfConnWebSocket.emit('pushBrowseLibrary', result);
+              })
+              .fail(function () {
+                self.printToastMessage('error', self.commandRouter.getI18nString('COMMON.ERROR'), self.commandRouter.getI18nString('COMMON.REMOVE_FAIL'));
+              });
+            }
+          }, 600);
         } else {
           var response = self.commandRouter.playListManager.listFavourites();
           if (response != undefined) {


### PR DESCRIPTION
RemoveFromFavourites now checks for the correspondent method on plugin. If found the method is called. Otherwise the Common Method is called to handle the request.

Enhanced to push an update of the browse library.

WHAT SHALL BE DONE: Check if the favourite mechanism through the common method has been broken (couldn't do right now)

WHAT SHALL BE ANALYZED AND DONE IN THE FUTURE: When the Browse is pushed the user can click the back button. This loads the page where the removed song is present. Check why this happens.