### PR TITLE
adding BassOwl-HAT to DAC list

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -9,6 +9,7 @@
     {"id":"piano-dac-plus","name":"Allo Piano 2.1","overlay":"allo-piano-dac-plus-pcm512x-audio","alsanum":"2","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"applepi-dac","name":"ApplePi DAC","overlay":"applepi-dac","alsanum":"2","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"audiophonics-es9028q2m-dac","name":"Audiophonics I-Sabre ES9028Q2M","overlay":"i-sabre-q2m","alsanum":"2","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
+    {"id":"bassowl","name":"BassOwl-HAT","overlay":"bassowl","alsanum":"2","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
     {"id":"fe-pi-audio","name":"Fe-Pi Audio","overlay":"fe-pi-audio","alsanum":"2","mixer":"PCM","modules":"","script":"","needsreboot":"yes"},
     {"id":"generic-dac","name":"Generic I2S DAC","overlay":"hifiberry-dac","alsanum":"2","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"hifiberry-amp","name":"HiFiBerry Amp","overlay":"hifiberry-amp","alsanum":"2","mixer":"Master","modules":"","script":"","needsreboot":"yes"},


### PR DESCRIPTION
Note: drivers are still being mainlined - it should not effect other functionality even if the drivers aren’t mainlined yet.
Compiled binaries for most recent kernel are already available, they could be integrated in build script.

Driver have been already included in experimental Buster build
