### PR TITLE
Adds support for the AudioInjector.net Isolated & Ultra 2 soundcards.

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -5,6 +5,8 @@
     {"id":"allo-boss-dac","name":"Allo BOSS","overlay":"allo-boss-dac-pcm512x-audio","alsanum":"2","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"allo-digione","name":"Allo DigiOne","overlay":"allo-digione","alsanum":"2","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"allo-katana-dac","name":"Allo Katana","overlay":"allo-katana-dac-audio","alsanum":"2","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
+    {"id":"audio-injector-isolated","name":"AudioInjector Isolated","overlay":"audioinjector-isolated-soundcard","alsanum":"2","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
+    {"id":"audio-injector-ultra","name":"AudioInjector Ultra 2","overlay":"audioinjector-ultra","alsanum":"2","mixer":"DAC","modules":"","script":"","needsreboot":"yes"},
     {"id":"piano-dac","name":"Allo Piano","overlay":"allo-piano-dac-pcm512x-audio","alsanum":"2","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"piano-dac-plus","name":"Allo Piano 2.1","overlay":"allo-piano-dac-plus-pcm512x-audio","alsanum":"2","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"applepi-dac","name":"ApplePi DAC","overlay":"applepi-dac","alsanum":"2","mixer":"","modules":"","script":"","needsreboot":"yes"},


### PR DESCRIPTION
These are our high end soundcards - will add budget soundcards later.

Isolated requires kernel after 17th June 2020, e.g. kernel 5.4.58 or an 
equivalent 4.19.xx kernel. 5.4.58 or later is preferred.

https://github.com/Hexxeh/rpi-firmware/commit/23141000a5eae7ddbe11d4ac283198afd3031263