### PR TITLE
Add all items in explodeUri when adding to playlist

### DIFF
--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -562,15 +562,18 @@ PlaylistManager.prototype.commonAddToPlaylist = function (folder, name, service,
         var explodedUri = self.commandRouter.executeOnPlugin('music_service', service, 'explodeUri', uri);
         explodedUri.then(function (info) {
           var entries = [];
-          var track = info[0];
-          entries.push({
-            service: service,
-            uri: uri,
-            title: track.name,
-            artist: track.artist,
-            album: track.album,
-            albumart: track.albumart
-          });
+          
+          info.map(track => {
+            entries.push({
+              service: service,
+              uri: track.uri,
+              title: track.name,
+              artist: track.artist,
+              album: track.album,
+              albumart: track.albumart
+            });
+          })
+          
           fs.readJson(filePath, function (err, data) {
             if (err) { defer.resolve({success: false}); } else {
               if (!data) { data = []; }


### PR DESCRIPTION
Go through all items of the explodeUri instead of limiting to the first item