### PR TITLE
Send empty array if no urls are defined

### DIFF
--- a/app/plugins/user_interface/rest_api/index.js
+++ b/app/plugins/user_interface/rest_api/index.js
@@ -226,7 +226,7 @@ interfaceApi.prototype.getPushNotificationUrls = function (req, res) {
   if (pushNotificationsUrls && pushNotificationsUrls.length) {
     res.send(pushNotificationsUrls);
   } else {
-    res.send('No URLs defined for push notifications');
+    res.send('[]');
   }
 };
 


### PR DESCRIPTION
Sending back an empty arrary string is better than sending an error string in the body of the response. 

When writing a client application, one assumes that a string array of URLs will be sent as a response. If instead a custom message is sent as a response when no URLs have been entered, this message must be handled separately in the client, which is extremely unpleasant.