### PR TITLE
Adding support for BassMantis-uHAT

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -13,6 +13,8 @@
     {"id":"audiophonics-es9028q2m-dac","name":"Audiophonics I-Sabre ES9028Q2M","overlay":"i-sabre-q2m","alsanum":"2","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"bassfly","name":"BassFly-uHAT","overlay":"hifiberry-dac","alsanum":"2","mixer":"","modules":"","script":"bassfly-init.sh","needsreboot":"yes"},
     {"id":"bassfly-mic","name":"BassFly-uHAT with I2S Mic","overlay":"googlevoicehat-soundcard","alsanum":"2","mixer":"","modules":"","script":"bassfly-init.sh","needsreboot":"yes"},
+    {"id":"bassmantis","name":"BassMantis-uHAT","overlay":"rpi-dac","alsanum":"2","mixer":"","modules":"","script":"bassmantis-init.sh","needsreboot":"yes"},
+    {"id":"bassmantis-mic","name":"BassMantis-uHAT with I2S Mic","overlay":"googlevoicehat-soundcard","alsanum":"2","mixer":"","modules":"","script":"bassmantis-init.sh","needsreboot":"yes"},
     {"id":"bassowl","name":"BassOwl-HAT","overlay":"bassowl","alsanum":"2","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
     {"id":"fe-pi-audio","name":"Fe-Pi Audio","overlay":"fe-pi-audio","alsanum":"2","mixer":"PCM","modules":"","script":"","needsreboot":"yes"},
     {"id":"generic-dac","name":"Generic I2S DAC","overlay":"hifiberry-dac","alsanum":"2","mixer":"","modules":"","script":"","needsreboot":"yes"},

--- a/app/plugins/system_controller/i2s_dacs/scripts/bassmantis-init.sh
+++ b/app/plugins/system_controller/i2s_dacs/scripts/bassmantis-init.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+### AWINIC AMPLIFIERS I2C ADDRESS
+AW_LEFT=0x34
+AW_RIGHT=0x35
+
+
+echo "INIT BASSMANTIS-uHAT"
+# soft Reset
+sudo i2cset -y 1 $AW_LEFT 0x00 0xAA55 w
+sudo i2cset -y 1 $AW_RIGHT 0x00 0xAA55 w
+# PWDN=0/I2SEN=1
+sudo i2cset -y 1 $AW_LEFT 0x04 0x4400 w
+sudo i2cset -y 1 $AW_RIGHT 0x04 0x4400 w
+# INPLEV=1/44.1kHz/64FS/Left
+sudo i2cset -y 1 $AW_LEFT 0x05 0xE724 w
+# INPLEV=1/44.1kHz/64FS/Right
+sudo i2cset -y 1 $AW_RIGHT 0x05 0xE728 w
+
+sudo i2cset -y 1 $AW_LEFT 0x09 0x4A42 w
+sudo i2cset -y 1 $AW_RIGHT 0x09 0x4A42 w
+sudo i2cset -y 1 $AW_LEFT 0x0A 0xC203 w
+sudo i2cset -y 1 $AW_RIGHT 0x0A 0xC203 w
+sudo i2cset -y 1 $AW_LEFT 0x0B 0xC203 w
+sudo i2cset -y 1 $AW_RIGHT 0x0B 0xC203 w
+sudo i2cset -y 1 $AW_LEFT 0x0C 0x0770 w
+sudo i2cset -y 1 $AW_RIGHT 0x0C 0x0770 w
+
+# HAGCE=0
+sudo i2cset -y 1 $AW_LEFT 0x0D 0x1B00 w
+sudo i2cset -y 1 $AW_RIGHT 0x0D 0x1B00 w
+
+sudo i2cset -y 1 $AW_LEFT 0x0E 0x2903 w
+sudo i2cset -y 1 $AW_RIGHT 0x0E 0x2903 w
+sudo i2cset -y 1 $AW_LEFT 0x20 0x0100 w
+sudo i2cset -y 1 $AW_RIGHT 0x20 0x0100 w
+
+# BSTEN=1 | BSTLIMIT=0 (2.75A) | BSTVOUT=4 (7.5V)
+sudo i2cset -y 1 $AW_LEFT 0x60 0x841C w
+sudo i2cset -y 1 $AW_RIGHT 0x60 0x841C w
+
+sudo i2cset -y 1 $AW_LEFT 0x61 0x0E0F w
+sudo i2cset -y 1 $AW_RIGHT 0x61 0x0E0F w
+
+# BST_MODE=1 (Force Boost)
+sudo i2cset -y 1 $AW_LEFT 0x62 0x8EF5 w
+sudo i2cset -y 1 $AW_RIGHT 0x62 0x8EF5 w
+
+sudo i2cset -y 1 $AW_LEFT 0x63 0x7F30 w
+sudo i2cset -y 1 $AW_RIGHT 0x63 0x7F30 w
+
+sudo i2cset -y 1 $AW_LEFT 0x67 0x7C00 w
+sudo i2cset -y 1 $AW_RIGHT 0x67 0x7C00 w
+
+sudo i2cset -y 1 $AW_LEFT 0x69 0x4102 w
+sudo i2cset -y 1 $AW_RIGHT 0x69 0x4102 w
+
+# HMUTE=0
+sudo i2cset -y 1 $AW_LEFT 0x08 0x0E20 w
+sudo i2cset -y 1 $AW_RIGHT 0x08 0x0E20 w
+
+echo "BASSMANTIS-uHAT INIT DONE!"


### PR DESCRIPTION
Add entry in dacs.json and startup script, for supporting BassMantis-uHAT within Volumio for Raspberry Pi.