### PR TITLE
Prevent volume slider from springing back

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -183,7 +183,7 @@ CoreCommandRouter.prototype.writeVolumeStatusFiles = function (vol) {
 };
 
 CoreCommandRouter.prototype.executeWriteVolumeStatusFiles = function (value) {
-  fs.writeFile('/tmp/volume', value, function (err) {
+  fs.writeFile('/tmp/volume', value.toString(), function (err) {
     if (err) {
         	this.logger.error('Could not save Volume value to status file: ' + err);
     }


### PR DESCRIPTION
Must be a change in Node.JS to make fs.writeFile more picky about input...