### PR TITLE
Playlist optimization

### DIFF
--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -715,10 +715,13 @@ PlaylistManager.prototype.commonPlayPlaylist = function (folder, name) {
             }
           }
 
-          self.commandRouter.addQueueItems(uris)
+          var firstItem=uris.splice(0,1)
+          self.commandRouter.addQueueItems(firstItem)
             .then(function () {
               self.commandRouter.volumioPlay(0);
-              defer.resolve();
+              self.commandRouter.addQueueItems(uris).then(function() {
+                defer.resolve();
+              })
             })
             .fail(function () {
               defer.reject(new Error());


### PR DESCRIPTION
When playing a local playlist queues the first item and starts playback. The remaining items are then queued. This should introduce a lot better performances for long playlists with items from services llike Qobuz and Tidal