### PR TITLE
System player name configuration

### DIFF
--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -189,7 +189,7 @@ ControllerSystem.prototype.setConf = function (varName, varValue) {
   var defer = libQ.defer();
 
   self.config.set(varName, varValue);
-  if (varName = 'player_name') {
+  if (varName === 'player_name') {
     var player_name = varValue;
 
     for (var i in self.callbacks) {


### PR DESCRIPTION
Set the system player name correctly when it is changed, rather than always regardless of what config value is being set