### PR TITLE
Remove the special case for moving Raspberry Pi I2S DAC numbers

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/index.js
+++ b/app/plugins/system_controller/i2s_dacs/index.js
@@ -44,10 +44,6 @@ ControllerI2s.prototype.onVolumioStart = function () {
 
   self.forceConfigTxtBannerCompat();
 
-  setTimeout(()=>{
-      self.checkUpdatedI2SNumberonRaspbberyPI();
-  }, 5000)
-
   return libQ.resolve();
 };
 
@@ -643,35 +639,4 @@ ControllerI2s.prototype.writeModulesFile = function (modules) {
       ws.end();
     }
   });
-};
-
-ControllerI2s.prototype.checkUpdatedI2SNumberonRaspbberyPI = function () {
-    var self = this;
-
-    // Raspberry PI Kernel 5.4 onwards changed the numbering of i2s dacs
-    // We check and fix on start
-    // IF PI && I2S DAC && OUTPUT DEVICE = 1, we fix and restart audio card
-
-    var softvolume = false;
-    var devicename = self.getAdditionalConf('system_controller', 'system', 'device');
-    if (devicename === 'Raspberry PI') {
-        var i2senabled = self.getConfigParam('i2s_enabled');
-        var outputDevice = self.getAdditionalConf('audio_interface', 'alsa_controller', 'outputdevice');
-        if (outputDevice === 'softvolume') {
-            softvolume = true;
-            outputDevice = self.getAdditionalConf('audio_interface', 'alsa_controller', 'softvolumenumber');
-        }
-        if (i2senabled && outputDevice !== '2') {
-            self.logger.info('I2S DAC Found on wrong device number, changing it to device 2');
-            if (softvolume === false) {
-                self.commandRouter.sharedVars.set('alsa.outputdevice', '2');
-                setTimeout(()=>{
-                    self.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'setDefaultMixer', '2');
-                }, 1000)
-            } else {
-                self.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'enableSoftMixer', '2');
-            }
-
-        }
-    }
 };


### PR DESCRIPTION
This is unnecessary now that we use the alsa card name instead of the card number to keep track, and syncrhonise the config on volumio start