### PR TITLE
Fix `Volume.vol` type when parsing Software mixer

### DIFF
--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -497,8 +497,8 @@ CoreVolumeController.prototype.retrievevolume = function () {
           self.logger.error('Cannot read softvolume: ' + error);
         } else {
           var volume = stdout.replace('\n', '');
-          currentvolume = volume;
-          if (currentvolume === '0') {
+          currentvolume = parseInt(volume);
+          if (currentvolume === 0) {
             currentmute = true;
           } else {
             currentmute = false;


### PR DESCRIPTION
Was a `String`, should be a `Number` as per rest of the code in this module.. 

