### PR TITLE
Add fast installToDisk feature to x86 devices

### DIFF
--- a/app/plugins/audio_interface/alsa_controller/cards.json
+++ b/app/plugins/audio_interface/alsa_controller/cards.json
@@ -36,7 +36,7 @@
     {"name": "HDA Intel", "multidevice": true, "devices":[{"number":0, "prettyname": "Analog Out", "defaultmixer": ""},{"number":1, "prettyname": "SPDIF", "defaultmixer": ""},{"number":3, "prettyname": "HDMI", "defaultmixer": ""}]},
     {"name": "Intel ICH6", "multidevice": true, "devices":[{"number":0, "prettyname": "HDMI", "defaultmixer": ""},{"number":4, "prettyname": "SPDIF", "defaultmixer": ""}]},
     {"name": "bytcr-rt5651", "multidevice": false, "prettyname": "Headphone Jack", "defaultmixer": "HP","type":"integrated"},
-    {"name": "Intel HDMI/DP LPE Audio", "multidevice": true, "devices":[{"number":2, "prettyname": "HDMI", "defaultmixer": ""}],"type":"integrated"},
+    {"name": "Intel HDMI/DP LPE Audio", "multidevice": true, "devices":[{"number":0, "prettyname": "HDMI 0", "defaultmixer": ""},{"number":1, "prettyname": "HDMI 1", "defaultmixer": ""},{"number":2, "prettyname": "HDMI 2", "defaultmixer": ""}],"type":"integrated"},
     {"name": "AML-AUGESOUND", "multidevice": true, "devices":[{"number":0, "prettyname": "HDMI Audio", "defaultmixer": ""}, {"number":1, "prettyname": "Line Out/ Headphones", "defaultmixer": "DAC Digital"}, {"number":2, "prettyname": "SPDIF", "defaultmixer": ""}],"type":"integrated"},
     {"name": "AML-AUGESOUND-MP1", "multidevice": true, "devices":[{"number":2, "prettyname": "S/PDIF", "defaultmixer": ""}],"type":"integrated"},
     {"name": "AML-AUGESOUND-V", "multidevice": true, "devices":[{"number":0, "prettyname": "I2S + SPDIF + HDMI", "defaultmixer": "DAC Digital"}, {"number":1, "prettyname": "HDMI only", "defaultmixer": "DAC Digital"}, {"number":2, "prettyname": "SPDIF + HDMI", "defaultmixer": "DAC Digital"}],"type":"integrated"},


### PR DESCRIPTION
This features add a faster installToDisk to x86 devices.
Instead of doing the sector-by-sector dd of the whole source to target, this solution 

- wipes the old partitions from the target disk
- Creates the target partitions with the setting from the sources build time
- Creates the filesystems
- installs Syslinux in the mbr
- installs the kernel tarball from the source's image partition to the target boot partition
- copies the image partition files from source image partition to target
- Modifies the UUIDs of the 3 partitions in the syslinux.cfg and grub.cfg

Time to complete depends a little on the speed of the source disk and the size of the target.
Measurements on a number of configs show 40 to 50 secs. 