### PR TITLE
x86: installtodisk, prevent Volumio mount actions during process

### DIFF
--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -22,7 +22,6 @@ function ControllerSystem (context) {
   self.context = context;
   self.commandRouter = self.context.coreCommand;
   self.configManager = self.context.configManager;
-
   self.logger = self.context.logger;
   self.callbacks = [];
 }
@@ -856,6 +855,7 @@ ControllerSystem.prototype.installToDisk = function (data) {
     }
   } else {
 
+    self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'disableDeviceActions', '');
 
     var sep = '';
     if ((target.indexOf('mmcblk') >= 0) || (target.indexOf('nvme') >= 0)) {
@@ -897,6 +897,7 @@ ControllerSystem.prototype.installToDisk = function (data) {
       } else {
         self.notifyInstallToDiskStatus({'progress': 0, 'status': 'error'});
       }
+      self.commandRouter.executeOnPlugin('system_controller', 'networkfs', 'enableDeviceActions', '');
     });
   }
 };


### PR DESCRIPTION
This commit will prevent the Volumio mount handler breaking the installtodisk process for x86 as soon as a partptobe is done in a situation where the target device did not previously hold a Volumio partition scheme.

The new  `disableDeviceActions` and `enableDeviceActions` in the networkfs plugin can also be used in other situations where mounting external partitions is to be temporarily suspended.