### PR TITLE
cards.json: support for older x86 ATI cards

### DIFF
--- a/app/plugins/audio_interface/alsa_controller/cards.json
+++ b/app/plugins/audio_interface/alsa_controller/cards.json
@@ -34,6 +34,8 @@
     {"name": "H3 Audio Codec", "multidevice": false, "prettyname": "Onboard Audio", "defaultmixer": "DAC","type":"integrated"},
     {"name": "HDA Intel PCH", "multidevice": true, "devices":[{"number":0, "prettyname": "Analog Out", "defaultmixer": ""},{"number":1, "prettyname": "SPDIF", "defaultmixer": ""},{"number":3, "prettyname": "HDMI", "defaultmixer": ""}]},
     {"name": "HDA Intel", "multidevice": true, "devices":[{"number":0, "prettyname": "Analog Out", "defaultmixer": ""},{"number":1, "prettyname": "SPDIF", "defaultmixer": ""},{"number":3, "prettyname": "HDMI", "defaultmixer": ""}]},
+    {"name": "HDA-Audio Generic", "multidevice": true, "devices":[{"number":3, "prettyname": "HDMI", "defaultmixer": ""}]},
+    {"name": "HDA ATI SB", "multidevice": true, "devices":[{"number":0, "prettyname": "Analog Out", "defaultmixer": ""},{"number":1, "prettyname": "SPDIF", "defaultmixer": ""}]},
     {"name": "Intel ICH6", "multidevice": true, "devices":[{"number":0, "prettyname": "HDMI", "defaultmixer": ""},{"number":4, "prettyname": "SPDIF", "defaultmixer": ""}]},
     {"name": "bytcr-rt5640", "multidevice": false, "prettyname": "Headphone Jack", "defaultmixer": "DAC1","type":"integrated"},
     {"name": "bytcr-rt5651", "multidevice": false, "prettyname": "Headphone Jack", "defaultmixer": "HP","type":"integrated"},


### PR DESCRIPTION
Support for some old hardware, one with an ATI Graphics and an SB soundcard (both commonly used, therefore relevant).
User knows he needs to test this.