### PR TITLE
Fix issue where moving first item of the queue is not possible

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1554,8 +1554,7 @@ CoreCommandRouter.prototype.volumioSaveQueueToPlaylist = function (name) {
 CoreCommandRouter.prototype.volumioMoveQueue = function (from, to) {
   var defer = libQ.defer();
   this.pushConsoleMessage('CoreCommandRouter::volumioMoveQueue');
-
-  if (from !== undefined && to !== undefined) {
+  if (from !== undefined && to !== undefined && from >= 0 && to >= 0) {
     return this.stateMachine.moveQueueItem(from, to);
   } else {
     this.logger.error('Cannot move item in queue, from or to parameter missing');

--- a/app/index.js
+++ b/app/index.js
@@ -1555,7 +1555,7 @@ CoreCommandRouter.prototype.volumioMoveQueue = function (from, to) {
   var defer = libQ.defer();
   this.pushConsoleMessage('CoreCommandRouter::volumioMoveQueue');
 
-  if (from && to) {
+  if (from !== undefined && to !== undefined) {
     return this.stateMachine.moveQueueItem(from, to);
   } else {
     this.logger.error('Cannot move item in queue, from or to parameter missing');

--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -1373,11 +1373,10 @@ CoreStateMachine.prototype.setRepeat = function (value, repeatSingle) {
     }
   } else {
     this.currentRepeat = value;
-	if(this.currentRepeat && repeatSingle != undefined) {
-		this.currentRepeatSingleSong = repeatSingle;	
-	} else {
-		this.currentRepeatSingleSong = false;
-	}
+
+    if (repeatSingle != undefined) {
+      this.currentRepeatSingleSong = repeatSingle;
+    }
 
     this.pushState().fail(this.pushError.bind(this));
   }

--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -1373,10 +1373,11 @@ CoreStateMachine.prototype.setRepeat = function (value, repeatSingle) {
     }
   } else {
     this.currentRepeat = value;
-
-    if (repeatSingle != undefined) {
-      this.currentRepeatSingleSong = repeatSingle;
-    }
+	if(this.currentRepeat && repeatSingle != undefined) {
+		this.currentRepeatSingleSong = repeatSingle;	
+	} else {
+		this.currentRepeatSingleSong = false;
+	}
 
     this.pushState().fail(this.pushError.bind(this));
   }


### PR DESCRIPTION
We should not check if value is greater than 0, since then we cant move first item in the queue.