### PR TITLE
Disable repeatSingle when repeat is disabled

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1555,7 +1555,7 @@ CoreCommandRouter.prototype.volumioMoveQueue = function (from, to) {
   var defer = libQ.defer();
   this.pushConsoleMessage('CoreCommandRouter::volumioMoveQueue');
 
-  if (from !== undefined && to !== undefined) {
+  if (from && to) {
     return this.stateMachine.moveQueueItem(from, to);
   } else {
     this.logger.error('Cannot move item in queue, from or to parameter missing');


### PR DESCRIPTION
repeat single does not work alone, since its nested inside repeat checks and coupled with it in other checks, so it should be set false when repeat is disabled. Currently "pushState" can emit "repeatSingle == true", but if repeat is false, we are not repeating single track, so the state is wrong.

I believe this is more of correcting the state sent to listeners, real fix would be to allow repeatSingle actual repeat the single song when its set, i can look into that if its more preferred way?