### PR TITLE
Upnp choose stream format

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -123,9 +123,11 @@ CoreCommandRouter.prototype.volumiosetvolume = function (VolumeInteger) {
   this.callCallback('volumiosetvolume', VolumeInteger);
 
   var volSet = this.volumeControl.alsavolume(VolumeInteger);
-  volSet.then(function (result) {
-		 return self.volumioupdatevolume(result);
-  });
+  if (volSet) {
+    volSet.then(function (result) {
+      return self.volumioupdatevolume(result);
+   });
+  }
 };
 
 // Volumio Update Volume

--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -96,6 +96,7 @@ CoreStateMachine.prototype.getState = function () {
       enableSkip: this.volatileState.enableSkip,
       consume: false,
       volume: this.currentVolume,
+      deviceVolume: this.currentDeviceVolume,
       mute: this.currentMute,
       disableVolumeControl: this.currentDisableVolumeControl,
       stream: this.volatileState.stream,
@@ -137,6 +138,7 @@ CoreStateMachine.prototype.getState = function () {
         repeatSingle: this.currentRepeatSingleSong,
         consume: true,
         volume: this.currentVolume,
+        deviceVolume: this.currentDeviceVolume,
         mute: this.currentMute,
         disableVolumeControl: this.currentDisableVolumeControl,
         stream: this.consumeState.stream,
@@ -177,6 +179,7 @@ CoreStateMachine.prototype.getState = function () {
         repeatSingle: this.currentRepeatSingleSong,
         consume: this.currentConsume,
         volume: this.currentVolume,
+        deviceVolume: this.currentDeviceVolume,
         disableVolumeControl: this.currentDisableVolumeControl,
         mute: this.currentMute,
         stream: trackBlock.trackType,
@@ -209,6 +212,7 @@ CoreStateMachine.prototype.getEmptyState = function () {
     Streaming: false,
     service: 'mpd',
     volume: this.currentVolume,
+    deviceVolume: this.currentDeviceVolume,
     mute: this.currentMute,
     disableVolumeControl: this.currentDisableVolumeControl,
     random: this.currentRandom,
@@ -330,6 +334,7 @@ CoreStateMachine.prototype.resetVolumioState = function () {
       self.currentRandom = null;
       self.currentRepeat = null;
       self.currentVolume = null;
+      self.currentDeviceVolume = null;
       self.currentMute = null;
       self.currentUpdate = false;
       self.getcurrentVolume();
@@ -454,6 +459,8 @@ CoreStateMachine.prototype.increasePlaybackTimer = function () {
 // Update Volume Value
 CoreStateMachine.prototype.updateVolume = function (Volume) {
   this.currentVolume = Volume.vol;
+  if (undefined != Volume.deviceVol)
+		this.currentDeviceVolume = Volume.deviceVol;
   this.currentMute = Volume.mute;
   this.currentDisableVolumeControl = Volume.disableVolumeControl;
   this.pushState().fail(this.pushError.bind(this));
@@ -465,6 +472,8 @@ CoreStateMachine.prototype.getcurrentVolume = function () {
   this.commandRouter.pushConsoleMessage('CoreStateMachine::getcurrentVolume');
   this.commandRouter.volumioretrievevolume().then((volumeData) => {
     	self.currentVolume = volumeData.vol;
+      if (undefined != volumeData.deviceVol)
+				self.currentDeviceVolume = volumeData.deviceVol;
     	self.currentMute = volumeData.mute;
     	self.currentDisableVolumeControl = volumeData.disableVolumeControl;
     	this.updateTrackBlock();


### PR DESCRIPTION
Choose the suitable stream from UPnP instead of always choosing the first one. This relies on UPnP Server to provide downsampled 352.8 or 384 kHz stream, instead of relying on Volumio to do it. The song will not be displayed if there is no suitable stream found. For example, MediaMonkey (free version) does not provide alternate audo-format streams. 

The purpose of this change is to make it consistent with Roon. And moreover, I think this is how UPnP Control Point "Choose Matching Protocol and Format" task as described in UPnP AV-Architecture document.