### PR TITLE
Add support for ChipDip DAC

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -14,6 +14,7 @@
     {"id":"bassfly","name":"BassFly-uHAT","overlay":"hifiberry-dac","alsanum":"2","mixer":"","modules":"","script":"bassfly-init.sh","needsreboot":"yes"},
     {"id":"bassfly-mic","name":"BassFly-uHAT with I2S Mic","overlay":"googlevoicehat-soundcard","alsanum":"2","mixer":"","modules":"","script":"bassfly-init.sh","needsreboot":"yes"},
     {"id":"bassowl","name":"BassOwl-HAT","overlay":"bassowl","alsanum":"2","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
+    {"id":"chipdip-master-dac","name":"ChipDip DAC","overlay":"chipdip-dac","alsanum":"2","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"fe-pi-audio","name":"Fe-Pi Audio","overlay":"fe-pi-audio","alsanum":"2","mixer":"PCM","modules":"","script":"","needsreboot":"yes"},
     {"id":"generic-dac","name":"Generic I2S DAC","overlay":"hifiberry-dac","alsanum":"2","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"hifiberry-amp","name":"HiFiBerry Amp","overlay":"hifiberry-amp","alsanum":"2","mixer":"Master","modules":"","script":"","needsreboot":"yes"},


### PR DESCRIPTION
Please, add support for sound card ChipDip DAC. Overlay and dirver for "ChipDip DAC" were added in 5.10 kernel
overlay   https://github.com/raspberrypi/linux/blob/rpi-5.10.y/arch/arm/boot/dts/overlays/chipdip-dac-overlay.dts
driver     https://github.com/raspberrypi/linux/blob/rpi-5.10.y/sound/soc/bcm/chipdip-dac.c

For Volumio we have built driver for 4.19 kernel, driver source is in attachement. The driver has been tested along with overlay and they work fine.
Could you please include in Volumio release overlay and driver for "ChipDip DAC"?

[chipdip-dac-driver-4.19.188-v7-Volumio.zip](https://github.com/volumio/Volumio2/files/7273367/chipdip-dac-driver-4.19.188-v7-Volumio.zip)
