### PR TITLE
MPD plugin: Fix handling of URIs containing 'bbc'

### DIFF
--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -385,7 +385,7 @@ ControllerMpd.prototype.parseTrackInfo = function (objTrackInfo) {
       resp.trackType = 'tidal';
     } else if (resp.uri.indexOf('http://') >= 0) {
       resp.service = 'dirble';
-      if (objTrackInfo.file.indexOf('bbc') >= 0) {
+      if (objTrackInfo.file.indexOf('bbc') >= 0 && objTrackInfo.Name) {
         objTrackInfo.Name = objTrackInfo.Name.replace(/_/g, ' ').replace('bbc', 'BBC');
         objTrackInfo.file = objTrackInfo.Name;
       }


### PR DESCRIPTION
When parsing MPD's track info, the MPD plugin checks whether the stream URI contains the letters 'bbc'. If it does, it assumes the URI has got to be a BBC web radio stream. The plugin then proceeds to replace 'bbc' with 'BBC' in the `Name` property of the track info object. Now, while web radio streams will often have a `Name` tag, this is not always the case with other types of streams. With those streams that do not have a `Name` tag, parsing will fail resulting in Volumio not updating playback status nor proceeding to the next song after the current one finishes playing.

This PR fixes the issue by checking for the existence of the `Name` property in the track info object.